### PR TITLE
CHORE/fix-zookeeper-tick-time

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "2181:2181"
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000tproej
+      ZOOKEEPER_TICK_TIME: 2000
     networks:
       - msa-network
 


### PR DESCRIPTION
## 📝 개요
Zookeeper 환경 변수 **`ZOOKEEPER_TICK_TIME`** 오타를 제거하고 , 정상 값인 **2000ms**로 수정했습니다.

## 🔗 관련 이슈
Close #3 