### PR TITLE
FEAT/UserService 로그아웃 및 액세스 토큰 재발급 API 구현

### DIFF
--- a/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
@@ -1,4 +1,7 @@
 package com.palja.user_service.application.service;
 
 public interface AuthService {
+
+	void logout(String authHeader);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
@@ -2,6 +2,6 @@ package com.palja.user_service.application.service;
 
 public interface AuthService {
 
-	void logout(String authHeader);
+	void logout(Long userId, String authHeader);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
@@ -2,6 +2,8 @@ package com.palja.user_service.application.service;
 
 public interface AuthService {
 
-	void logout(Long userId, String authHeader);
+	String refreshAccessToken(Long userId, String userRole, String accessToken, String refreshToken);
+
+	void logout(Long userId, String accessToken);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
@@ -21,9 +21,8 @@ public class AuthServiceImpl implements AuthService {
 	private final JwtUtil jwtUtil;
 
 	@Override
-	public void logout(String token) {
+	public void logout(Long userId, String token) {
 		String accessToken = jwtUtil.substringToken(token);
-		String userId = jwtUtil.parseAccessToken(accessToken).getSubject();
 		String hashKey = jwtUtil.hashingTokenToSHA256(accessToken);
 
 		redisRepository.save(

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
@@ -2,6 +2,9 @@ package com.palja.user_service.application.service.impl;
 
 import static com.palja.user_service.application.util.RedisKeyConstants.*;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 import org.springframework.stereotype.Service;
 
 import com.palja.user_service.application.service.AuthService;
@@ -21,14 +24,36 @@ public class AuthServiceImpl implements AuthService {
 	private final JwtUtil jwtUtil;
 
 	@Override
-	public void logout(Long userId, String token) {
-		String accessToken = jwtUtil.substringToken(token);
-		String hashKey = jwtUtil.hashingTokenToSHA256(accessToken);
+	public String refreshAccessToken(Long userId, String userRole, String accessToken, String refreshToken) {
+		String substringRefreshToken = jwtUtil.substringToken(URLDecoder.decode(refreshToken, StandardCharsets.UTF_8));
+		validateRefreshToken(substringRefreshToken);
+
+		if (accessToken != null) {
+			addAccessTokenToBlackList(userId, accessToken);
+		}
+
+		return jwtUtil.generateAccessToken(userId, userRole);
+	}
+
+	@Override
+	public void logout(Long userId, String accessToken) {
+		addAccessTokenToBlackList(userId, accessToken);
+		redisRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + userId);
+	}
+
+	private void validateRefreshToken(String refreshToken) {
+		if (refreshToken == null || !jwtUtil.validateRefreshToken(refreshToken)) {
+			throw new IllegalArgumentException("다시 로그인 해주세요.");
+		}
+	}
+
+	private void addAccessTokenToBlackList(Long userId, String accessToken) {
+		String substringAccessToken = jwtUtil.substringToken(accessToken);
+		String hashKey = jwtUtil.hashingTokenToSHA256(substringAccessToken);
 
 		redisRepository.save(
-			ACCESS_TOKEN_BLACKLIST_PREFIX + userId + ":" + hashKey, accessToken, jwtUtil.getAccessKeyExpirationTime()
+			ACCESS_TOKEN_BLACKLIST_PREFIX + userId + ":" + hashKey, substringAccessToken, jwtUtil.getAccessKeyExpirationTime()
 		);
-		redisRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + userId);
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
@@ -1,8 +1,12 @@
 package com.palja.user_service.application.service.impl;
 
+import static com.palja.user_service.application.util.RedisKeyConstants.*;
+
 import org.springframework.stereotype.Service;
 
 import com.palja.user_service.application.service.AuthService;
+import com.palja.user_service.application.util.JwtUtil;
+import com.palja.user_service.domain.external.redis.RedisRepository;
 import com.palja.user_service.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -12,5 +16,20 @@ import lombok.RequiredArgsConstructor;
 public class AuthServiceImpl implements AuthService {
 
 	private final UserRepository userRepository;
+	private final RedisRepository redisRepository;
+
+	private final JwtUtil jwtUtil;
+
+	@Override
+	public void logout(String token) {
+		String accessToken = jwtUtil.substringToken(token);
+		String userId = jwtUtil.parseAccessToken(accessToken).getSubject();
+		String hashKey = jwtUtil.hashingTokenToSHA256(accessToken);
+
+		redisRepository.save(
+			ACCESS_TOKEN_BLACKLIST_PREFIX + userId + ":" + hashKey, accessToken, jwtUtil.getAccessKeyExpirationTime()
+		);
+		redisRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + userId);
+	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/util/JwtUtil.java
+++ b/user-service/src/main/java/com/palja/user_service/application/util/JwtUtil.java
@@ -1,0 +1,27 @@
+package com.palja.user_service.application.util;
+
+import io.jsonwebtoken.Claims;
+
+public interface JwtUtil {
+
+	long getAccessKeyExpirationTime();
+
+	long getRefreshKeyExpirationTime();
+
+	String generateAccessToken(Long userId, String role);
+
+	String generateRefreshToken(Long userId, String role);
+
+	boolean validateAccessToken(String accessToken);
+
+	boolean validateRefreshToken(String refreshToken);
+
+	String substringToken(String token);
+
+	Claims parseAccessToken(String accessToken);
+
+	Claims parseRefreshToken(String refreshToken);
+
+	String hashingTokenToSHA256(String token);
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/util/RedisKeyConstants.java
+++ b/user-service/src/main/java/com/palja/user_service/application/util/RedisKeyConstants.java
@@ -1,0 +1,12 @@
+package com.palja.user_service.application.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RedisKeyConstants {
+
+	public static final String ACCESS_TOKEN_BLACKLIST_PREFIX = "AUTH:BL:AT:";
+	public static final String REFRESH_TOKEN_WHITELIST_PREFIX = "AUTH:WL:RT:";
+
+}

--- a/user-service/src/main/java/com/palja/user_service/domain/external/redis/RedisRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/external/redis/RedisRepository.java
@@ -1,0 +1,11 @@
+package com.palja.user_service.domain.external.redis;
+
+public interface RedisRepository {
+
+	void save(String key, String value, long ttl);
+
+	String get(String key);
+
+	void remove(String key);
+
+}

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/redis/RedisRepositoryImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/redis/RedisRepositoryImpl.java
@@ -5,11 +5,13 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import com.palja.user_service.domain.external.redis.RedisRepository;
+
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class RedisRepository {
+public class RedisRepositoryImpl implements RedisRepository {
 
 	private final RedisTemplate<String, String> redisTemplate;
 

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/security/impl/AuthenticationSuccessHandlerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/security/impl/AuthenticationSuccessHandlerImpl.java
@@ -43,8 +43,8 @@ public class AuthenticationSuccessHandlerImpl implements AuthenticationSuccessHa
 
 		String refreshToken = jwtUtil.generateRefreshToken(userId, userRole);
 		addRefreshTokenToCookie(response, refreshToken);
-		refreshToken = jwtUtil.substringToken(refreshToken);
-		redisRepository.save(REFRESH_TOKEN_WHITELIST_PREFIX + userId, refreshToken, jwtUtil.getRefreshKeyExpirationTime());
+		String substringRefreshToken = jwtUtil.substringToken(refreshToken);
+		redisRepository.save(REFRESH_TOKEN_WHITELIST_PREFIX + userId, substringRefreshToken, jwtUtil.getRefreshKeyExpirationTime());
 
 		setResponse(response);
 
@@ -58,7 +58,7 @@ public class AuthenticationSuccessHandlerImpl implements AuthenticationSuccessHa
 	private void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
 		refreshToken = URLEncoder.encode(refreshToken, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
 		ResponseCookie cookie = ResponseCookie
-			.from("refreshToken", refreshToken)
+			.from("refresh_token", refreshToken)
 			.path("/")
 			.httpOnly(true)
 			.secure(false) // HTTPS

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/security/impl/AuthenticationSuccessHandlerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/security/impl/AuthenticationSuccessHandlerImpl.java
@@ -1,5 +1,7 @@
 package com.palja.user_service.infrastructure.security.impl;
 
+import static com.palja.user_service.application.util.RedisKeyConstants.*;
+
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -12,8 +14,8 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.palja.user_service.infrastructure.external.redis.RedisRepository;
-import com.palja.user_service.infrastructure.security.util.JwtUtil;
+import com.palja.user_service.application.util.JwtUtil;
+import com.palja.user_service.domain.external.redis.RedisRepository;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,7 +30,6 @@ public class AuthenticationSuccessHandlerImpl implements AuthenticationSuccessHa
 	private final JwtUtil jwtUtil;
 	private final RedisRepository redisRepository;
 
-	private static final String REFRESH_TOKEN_PREFIX = "AUTH:WL:RT:";
 
 	@Override
 	public void onAuthenticationSuccess(
@@ -42,7 +43,8 @@ public class AuthenticationSuccessHandlerImpl implements AuthenticationSuccessHa
 
 		String refreshToken = jwtUtil.generateRefreshToken(userId, userRole);
 		addRefreshTokenToCookie(response, refreshToken);
-		redisRepository.save(REFRESH_TOKEN_PREFIX + userId, refreshToken, jwtUtil.getRefreshKeyExpirationTime());
+		refreshToken = jwtUtil.substringToken(refreshToken);
+		redisRepository.save(REFRESH_TOKEN_WHITELIST_PREFIX + userId, refreshToken, jwtUtil.getRefreshKeyExpirationTime());
 
 		setResponse(response);
 

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/security/util/JwtUtilImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/security/util/JwtUtilImpl.java
@@ -1,6 +1,9 @@
 package com.palja.user_service.infrastructure.security.util;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
@@ -8,6 +11,8 @@ import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+
+import com.palja.user_service.application.util.JwtUtil;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -22,16 +27,16 @@ import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
-public class JwtUtil {
+public class JwtUtilImpl implements JwtUtil {
 
 	private final Key accessKey;
-	private final long accessKeyExpirationTime;
+	@Getter private final long accessKeyExpirationTime;
 	private final Key refreshKey;
 	@Getter private final long refreshKeyExpirationTime;
 
 	private final String BEARER_PREFIX = "Bearer ";
 
-	public JwtUtil(
+	public JwtUtilImpl(
 		@Value("${jwt.access.secret}") String accessSecret, @Value("${jwt.access.expiration}") Duration accessExpiration,
 		@Value("${jwt.refresh.secret}") String refreshSecret, @Value("${jwt.refresh.expiration}") Duration refreshExpiration
 	) {
@@ -41,22 +46,27 @@ public class JwtUtil {
 		this.refreshKeyExpirationTime = refreshExpiration.toMillis();
 	}
 
+	@Override
 	public String generateAccessToken(Long userId, String role) {
 		return generateToken(userId, role, accessKey, accessKeyExpirationTime);
 	}
 
+	@Override
 	public String generateRefreshToken(Long userId, String role) {
 		return generateToken(userId, role, refreshKey, refreshKeyExpirationTime);
 	}
 
+	@Override
 	public boolean validateAccessToken(String accessToken) {
 		return validateToken(accessToken, accessKey);
 	}
 
+	@Override
 	public boolean validateRefreshToken(String refreshToken) {
 		return validateToken(refreshToken, refreshKey);
 	}
 
+	@Override
 	public String substringToken(String token) {
 		if (StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX)) {
 			return token.substring(BEARER_PREFIX.length());
@@ -65,12 +75,29 @@ public class JwtUtil {
 		}
 	}
 
+	@Override
 	public Claims parseAccessToken(String accessToken) {
 		return parseToken(accessToken, accessKey);
 	}
 
+	@Override
 	public Claims parseRefreshToken(String refreshToken) {
 		return parseToken(refreshToken, refreshKey);
+	}
+
+	@Override
+	public String hashingTokenToSHA256(String token) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			md.update(token.getBytes(StandardCharsets.UTF_8));
+			StringBuilder sb = new StringBuilder();
+			for (byte b : md.digest()) {
+				sb.append(String.format("%02x", b));
+			}
+			return sb.toString();
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("SHA-256 알고리즘을 찾을 수 없습니다.");
+		}
 	}
 
 	private String generateToken(Long userId, String role, Key key, long expirationTime) {

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
@@ -1,12 +1,10 @@
 package com.palja.user_service.presentation.controller;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,15 +23,32 @@ public class AuthController {
 
 	private final AuthService authService;
 
+	@PostMapping("/refresh")
+	public ResponseEntity<ApiResponse<Void>> refresh(
+		@RequestHeader("X-USER-ID") Long userId, @RequestHeader("X-USER-ROLE") String userRole,
+		@RequestHeader(value = "Authorization", required = false) String accessToken,
+		@CookieValue(value = "refresh_token", required = false) String refreshToken,
+		HttpServletResponse response
+	) {
+		String newAccessToken = authService.refreshAccessToken(userId, userRole, accessToken, refreshToken);
+		addAccessTokenToHeader(response, newAccessToken);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("토큰이 재발급 되었습니다."));
+	}
+
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<Void>> logout(
 		@RequestHeader("X-USER-ID") Long userId,
-		HttpServletResponse response, @RequestHeader("Authorization") String token
+		@RequestHeader("Authorization") String accessToken, HttpServletResponse response
 	) {
-		authService.logout(userId, token);
+		authService.logout(userId, accessToken);
 		expireRefreshTokenToCookie(response);
-		System.out.println(userId);
+
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("로그아웃 되었습니다."));
+	}
+
+	private void addAccessTokenToHeader(HttpServletResponse response, String accessToken) {
+		response.setHeader("Authorization", accessToken);
 	}
 
 	private void expireRefreshTokenToCookie(HttpServletResponse response) {

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
@@ -53,7 +53,7 @@ public class AuthController {
 
 	private void expireRefreshTokenToCookie(HttpServletResponse response) {
 		ResponseCookie cookie = ResponseCookie
-			.from("refreshToken")
+			.from("refresh_token")
 			.maxAge(0)
 			.build();
 		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
@@ -1,10 +1,21 @@
 package com.palja.user_service.presentation.controller;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.palja.common.response.ApiResponse;
 import com.palja.user_service.application.service.AuthService;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -13,5 +24,23 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
 	private final AuthService authService;
+
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<Void>> logout(
+		HttpServletResponse response, @RequestHeader("Authorization") String token
+	) {
+		authService.logout(token);
+		expireRefreshTokenToCookie(response);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("로그아웃 되었습니다."));
+	}
+
+	private void expireRefreshTokenToCookie(HttpServletResponse response) {
+		ResponseCookie cookie = ResponseCookie
+			.from("refreshToken")
+			.maxAge(0)
+			.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
@@ -27,11 +27,12 @@ public class AuthController {
 
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<Void>> logout(
+		@RequestHeader("X-USER-ID") Long userId,
 		HttpServletResponse response, @RequestHeader("Authorization") String token
 	) {
-		authService.logout(token);
+		authService.logout(userId, token);
 		expireRefreshTokenToCookie(response);
-
+		System.out.println(userId);
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("로그아웃 되었습니다."));
 	}
 

--- a/user-service/src/test/java/com/palja/user_service/secret/JwtUtilTest.java
+++ b/user-service/src/test/java/com/palja/user_service/secret/JwtUtilTest.java
@@ -13,9 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.palja.user_service.application.util.JwtUtil;
 import com.palja.user_service.domain.entity.User;
 import com.palja.user_service.domain.vo.UserRole;
-import com.palja.user_service.infrastructure.security.util.JwtUtil;
 
 import io.jsonwebtoken.Claims;
 
@@ -88,6 +88,15 @@ public class JwtUtilTest {
 			assertThat(claims.get("role", String.class)).isEqualTo(manager.getRole().name());
 		}
 
+		@Test
+		@DisplayName("해싱")
+		@Order(5)
+		void hashing() {
+			String hash1 = jwtUtil.hashingTokenToSHA256(accessToken);
+			String hash2 = jwtUtil.hashingTokenToSHA256(accessToken);
+			assertThat(hash1).isEqualTo(hash2);
+		}
+
 	}
 
 	@Nested
@@ -130,6 +139,15 @@ public class JwtUtilTest {
 			Claims claims = jwtUtil.parseRefreshToken(refreshToken);
 			assertThat(claims.getSubject()).isEqualTo(manager.getId().toString());
 			assertThat(claims.get("role", String.class)).isEqualTo(manager.getRole().name());
+		}
+
+		@Test
+		@DisplayName("해싱")
+		@Order(5)
+		void hashing() {
+			String hash1 = jwtUtil.hashingTokenToSHA256(refreshToken);
+			String hash2 = jwtUtil.hashingTokenToSHA256(refreshToken);
+			assertThat(hash1).isEqualTo(hash2);
 		}
 
 	}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #29 

<br>

## 📌 개요
- 로그아웃 및 액세스 토큰 재발급 API를 구현했습니다.

<br>

## 🔁 변경 사항
- 리프레시 토큰 쿠키 이름을 refresh_token으로 변경
- 로그아웃 시 액세스 토큰을 해싱키로 변환하고 key에 포함해서 블랙리스트 처리 (같은 사용자가 짧은 시간에 다시 로그인, 로그아웃 해도 기존에 블랙리스트 처리됐던 액세스 토큰이 남아있도록)
- 로그인 시 리프레시 토큰을 레디스에 저장 (화이트리스트)
- 로그아웃 시  레디스에 저장된 리프레시 토큰을 삭제

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
