### PR TITLE
REFACTOR/UserService 토큰 관련 로직 리팩토링

### DIFF
--- a/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
@@ -2,8 +2,8 @@ package com.palja.user_service.application.service;
 
 public interface AuthService {
 
-	String refreshAccessToken(Long userId, String userRole, String accessToken, String refreshToken);
+	String refreshAccessToken(String loginId, String userRole, String accessToken, String refreshToken);
 
-	void logout(Long userId, String accessToken);
+	void logout(String loginId, String accessToken);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 
 import com.palja.user_service.application.service.AuthService;
 import com.palja.user_service.application.util.JwtUtil;
-import com.palja.user_service.domain.external.redis.RedisRepository;
+import com.palja.user_service.domain.repository.TokenRepository;
 import com.palja.user_service.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthServiceImpl implements AuthService {
 
 	private final UserRepository userRepository;
-	private final RedisRepository redisRepository;
+	private final TokenRepository tokenRepository;
 
 	private final JwtUtil jwtUtil;
 
@@ -38,7 +38,7 @@ public class AuthServiceImpl implements AuthService {
 	@Override
 	public void logout(Long userId, String accessToken) {
 		addAccessTokenToBlackList(userId, accessToken);
-		redisRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + userId);
+		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + userId);
 	}
 
 	private void validateRefreshToken(String refreshToken) {
@@ -51,7 +51,7 @@ public class AuthServiceImpl implements AuthService {
 		String substringAccessToken = jwtUtil.substringToken(accessToken);
 		String hashKey = jwtUtil.hashingTokenToSHA256(substringAccessToken);
 
-		redisRepository.save(
+		tokenRepository.save(
 			ACCESS_TOKEN_BLACKLIST_PREFIX + userId + ":" + hashKey, substringAccessToken, jwtUtil.getAccessKeyExpirationTime()
 		);
 	}

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
@@ -24,21 +24,21 @@ public class AuthServiceImpl implements AuthService {
 	private final JwtUtil jwtUtil;
 
 	@Override
-	public String refreshAccessToken(Long userId, String userRole, String accessToken, String refreshToken) {
+	public String refreshAccessToken(String loginId, String userRole, String accessToken, String refreshToken) {
 		String substringRefreshToken = jwtUtil.substringToken(URLDecoder.decode(refreshToken, StandardCharsets.UTF_8));
 		validateRefreshToken(substringRefreshToken);
 
 		if (accessToken != null) {
-			addAccessTokenToBlackList(userId, accessToken);
+			addAccessTokenToBlackList(loginId, accessToken);
 		}
 
-		return jwtUtil.generateAccessToken(userId, userRole);
+		return jwtUtil.generateAccessToken(loginId, userRole);
 	}
 
 	@Override
-	public void logout(Long userId, String accessToken) {
-		addAccessTokenToBlackList(userId, accessToken);
-		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + userId);
+	public void logout(String loginId, String accessToken) {
+		addAccessTokenToBlackList(loginId, accessToken);
+		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + loginId);
 	}
 
 	private void validateRefreshToken(String refreshToken) {
@@ -47,12 +47,12 @@ public class AuthServiceImpl implements AuthService {
 		}
 	}
 
-	private void addAccessTokenToBlackList(Long userId, String accessToken) {
+	private void addAccessTokenToBlackList(String loginId, String accessToken) {
 		String substringAccessToken = jwtUtil.substringToken(accessToken);
 		String hashKey = jwtUtil.hashingTokenToSHA256(substringAccessToken);
 
 		tokenRepository.save(
-			ACCESS_TOKEN_BLACKLIST_PREFIX + userId + ":" + hashKey, substringAccessToken, jwtUtil.getAccessKeyExpirationTime()
+			ACCESS_TOKEN_BLACKLIST_PREFIX + loginId + ":" + hashKey, substringAccessToken, jwtUtil.getAccessKeyExpirationTime()
 		);
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/util/JwtUtil.java
+++ b/user-service/src/main/java/com/palja/user_service/application/util/JwtUtil.java
@@ -8,9 +8,9 @@ public interface JwtUtil {
 
 	long getRefreshKeyExpirationTime();
 
-	String generateAccessToken(Long userId, String role);
+	String generateAccessToken(String loginId, String role);
 
-	String generateRefreshToken(Long userId, String role);
+	String generateRefreshToken(String loginId);
 
 	boolean validateAccessToken(String accessToken);
 

--- a/user-service/src/main/java/com/palja/user_service/domain/repository/TokenRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/repository/TokenRepository.java
@@ -1,6 +1,6 @@
-package com.palja.user_service.domain.external.redis;
+package com.palja.user_service.domain.repository;
 
-public interface RedisRepository {
+public interface TokenRepository {
 
 	void save(String key, String value, long ttl);
 

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/redis/RedisRepositoryImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/redis/RedisRepositoryImpl.java
@@ -5,13 +5,13 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
-import com.palja.user_service.domain.external.redis.RedisRepository;
+import com.palja.user_service.domain.repository.TokenRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class RedisRepositoryImpl implements RedisRepository {
+public class RedisRepositoryImpl implements TokenRepository {
 
 	private final RedisTemplate<String, String> redisTemplate;
 

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/security/impl/AuthenticationSuccessHandlerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/security/impl/AuthenticationSuccessHandlerImpl.java
@@ -35,16 +35,16 @@ public class AuthenticationSuccessHandlerImpl implements AuthenticationSuccessHa
 	public void onAuthenticationSuccess(
 		HttpServletRequest request, HttpServletResponse response, Authentication authentication
 	) throws IOException {
-		Long userId = ((UserDetailsImpl)authentication.getPrincipal()).getUserId();
+		String loginId = ((UserDetailsImpl)authentication.getPrincipal()).getUsername();
 		String userRole = ((UserDetailsImpl)authentication.getPrincipal()).getUserRole();
 
-		String accessToken = jwtUtil.generateAccessToken(userId, userRole);
+		String accessToken = jwtUtil.generateAccessToken(loginId, userRole);
 		addAccessTokenToHeader(response, accessToken);
 
-		String refreshToken = jwtUtil.generateRefreshToken(userId, userRole);
+		String refreshToken = jwtUtil.generateRefreshToken(loginId);
 		addRefreshTokenToCookie(response, refreshToken);
 		String substringRefreshToken = jwtUtil.substringToken(refreshToken);
-		tokenRepository.save(REFRESH_TOKEN_WHITELIST_PREFIX + userId, substringRefreshToken, jwtUtil.getRefreshKeyExpirationTime());
+		tokenRepository.save(REFRESH_TOKEN_WHITELIST_PREFIX + loginId, substringRefreshToken, jwtUtil.getRefreshKeyExpirationTime());
 
 		setResponse(response);
 

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/security/impl/AuthenticationSuccessHandlerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/security/impl/AuthenticationSuccessHandlerImpl.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palja.user_service.application.util.JwtUtil;
-import com.palja.user_service.domain.external.redis.RedisRepository;
+import com.palja.user_service.domain.repository.TokenRepository;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AuthenticationSuccessHandlerImpl implements AuthenticationSuccessHandler {
 
 	private final JwtUtil jwtUtil;
-	private final RedisRepository redisRepository;
+	private final TokenRepository tokenRepository;
 
 
 	@Override
@@ -44,7 +44,7 @@ public class AuthenticationSuccessHandlerImpl implements AuthenticationSuccessHa
 		String refreshToken = jwtUtil.generateRefreshToken(userId, userRole);
 		addRefreshTokenToCookie(response, refreshToken);
 		String substringRefreshToken = jwtUtil.substringToken(refreshToken);
-		redisRepository.save(REFRESH_TOKEN_WHITELIST_PREFIX + userId, substringRefreshToken, jwtUtil.getRefreshKeyExpirationTime());
+		tokenRepository.save(REFRESH_TOKEN_WHITELIST_PREFIX + userId, substringRefreshToken, jwtUtil.getRefreshKeyExpirationTime());
 
 		setResponse(response);
 

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/security/util/JwtUtilImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/security/util/JwtUtilImpl.java
@@ -47,13 +47,32 @@ public class JwtUtilImpl implements JwtUtil {
 	}
 
 	@Override
-	public String generateAccessToken(Long userId, String role) {
-		return generateToken(userId, role, accessKey, accessKeyExpirationTime);
+	public String generateAccessToken(String loginId, String role) {
+		Date now = new Date();
+
+		return BEARER_PREFIX +
+			Jwts.builder()
+				.setSubject(loginId)
+				.claim("role", role)
+				.setIssuedAt(now)
+				.setExpiration(new Date(now.getTime() + accessKeyExpirationTime))
+				.signWith(accessKey, SignatureAlgorithm.HS256)
+				.compact()
+			;
 	}
 
 	@Override
-	public String generateRefreshToken(Long userId, String role) {
-		return generateToken(userId, role, refreshKey, refreshKeyExpirationTime);
+	public String generateRefreshToken(String loginId) {
+		Date now = new Date();
+
+		return BEARER_PREFIX +
+			Jwts.builder()
+				.setSubject(loginId)
+				.setIssuedAt(now)
+				.setExpiration(new Date(now.getTime() + refreshKeyExpirationTime))
+				.signWith(refreshKey, SignatureAlgorithm.HS256)
+				.compact()
+			;
 	}
 
 	@Override

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
@@ -25,12 +25,12 @@ public class AuthController {
 
 	@PostMapping("/refresh")
 	public ResponseEntity<ApiResponse<Void>> refresh(
-		@RequestHeader("X-USER-ID") Long userId, @RequestHeader("X-USER-ROLE") String userRole,
+		@RequestHeader("X-USER-LOGIN-ID") String loginId, @RequestHeader("X-USER-ROLE") String userRole,
 		@RequestHeader(value = "Authorization", required = false) String accessToken,
 		@CookieValue(value = "refresh_token", required = false) String refreshToken,
 		HttpServletResponse response
 	) {
-		String newAccessToken = authService.refreshAccessToken(userId, userRole, accessToken, refreshToken);
+		String newAccessToken = authService.refreshAccessToken(loginId, userRole, accessToken, refreshToken);
 		addAccessTokenToHeader(response, newAccessToken);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("토큰이 재발급 되었습니다."));
@@ -38,10 +38,10 @@ public class AuthController {
 
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<Void>> logout(
-		@RequestHeader("X-USER-ID") Long userId,
+		@RequestHeader("X-USER-LOGIN-ID") String loginId,
 		@RequestHeader("Authorization") String accessToken, HttpServletResponse response
 	) {
-		authService.logout(userId, accessToken);
+		authService.logout(loginId, accessToken);
 		expireRefreshTokenToCookie(response);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("로그아웃 되었습니다."));

--- a/user-service/src/test/java/com/palja/user_service/secret/JwtUtilTest.java
+++ b/user-service/src/test/java/com/palja/user_service/secret/JwtUtilTest.java
@@ -57,7 +57,7 @@ public class JwtUtilTest {
 		@DisplayName("생성")
 		@Order(1)
 		void generate() {
-			String token = jwtUtil.generateAccessToken(manager.getId(), manager.getRole().name());
+			String token = jwtUtil.generateAccessToken(manager.getLoginId(), manager.getRole().name());
 			assertThat(token).startsWith(BEARER_PREFIX);
 			accessToken = token;
 		}
@@ -84,7 +84,7 @@ public class JwtUtilTest {
 		@Order(4)
 		void parse() {
 			Claims claims = jwtUtil.parseAccessToken(accessToken);
-			assertThat(claims.getSubject()).isEqualTo(manager.getId().toString());
+			assertThat(claims.getSubject()).isEqualTo(manager.getLoginId());
 			assertThat(claims.get("role", String.class)).isEqualTo(manager.getRole().name());
 		}
 
@@ -110,7 +110,7 @@ public class JwtUtilTest {
 		@DisplayName("생성")
 		@Order(1)
 		void generate() {
-			String token = jwtUtil.generateRefreshToken(manager.getId(), manager.getRole().name());
+			String token = jwtUtil.generateRefreshToken(manager.getLoginId());
 			assertThat(token).startsWith(BEARER_PREFIX);
 			refreshToken = token;
 		}
@@ -137,8 +137,7 @@ public class JwtUtilTest {
 		@Order(4)
 		void parse() {
 			Claims claims = jwtUtil.parseRefreshToken(refreshToken);
-			assertThat(claims.getSubject()).isEqualTo(manager.getId().toString());
-			assertThat(claims.get("role", String.class)).isEqualTo(manager.getRole().name());
+			assertThat(claims.getSubject()).isEqualTo(manager.getLoginId());
 		}
 
 		@Test


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #34 

<br>

## 📌 개요
- 토큰 관련 로직 리팩토링했습니다.

<br>

## 🔁 변경 사항
- RedisRepository 이름을 TokenRepository로 변경하고 패키지 경로를 변경했습니다.
- 액세스 토큰의 subject를 userId -> loginId로 변경했습니다.
- 리프레시 토큰의 subject를 userId -> loginId로 변경하고 claim에 데이터를 저장하지 않도록 변경했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
컨트롤러에서 헤더의 loginId와 userRole을 받는 부분은 이후 PR에서 AuditorContext에서 꺼내는 방식으로 변경해서 올릴 예정입니다.

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
