### PR TITLE
FEAT/UserService 회원 생성 시 데이터 반환 및 토큰 재발급, 로그아웃 시 회원 검증

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.palja:common-module:0.3.6'
+    implementation 'com.palja:common-module:0.4.6'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/CreateUserRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/CreateUserRes.java
@@ -1,0 +1,23 @@
+package com.palja.user_service.application.dto.response;
+
+import com.palja.user_service.domain.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class CreateUserRes {
+
+	private String loginId;
+	private String name;
+
+	public static CreateUserRes from(User user) {
+		return CreateUserRes.builder()
+			.loginId(user.getLoginId())
+			.name(user.getName())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
@@ -2,7 +2,7 @@ package com.palja.user_service.application.service;
 
 public interface AuthService {
 
-	String refreshAccessToken(String loginId, String userRole, String accessToken, String refreshToken);
+	String refreshAccessToken(String accessToken, String refreshToken);
 
 	void logout(String loginId, String accessToken);
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -4,10 +4,11 @@ import java.util.UUID;
 
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
+import com.palja.user_service.application.dto.response.CreateUserRes;
 
 public interface CompanyUserService {
 
-	void createCompanyUser(CreateCompanyUserCommand command);
+	CreateUserRes createCompanyUser(CreateCompanyUserCommand command);
 
 	void updateCompanyUserStatus(UUID companyUserId, UpdateCompanyUserStatusCommand command);
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
@@ -1,9 +1,10 @@
 package com.palja.user_service.application.service;
 
 import com.palja.user_service.application.command.CreateCustomerCommand;
+import com.palja.user_service.application.dto.response.CreateUserRes;
 
 public interface CustomerService {
 
-	void createCustomer(CreateCustomerCommand command);
+	CreateUserRes createCustomer(CreateCustomerCommand command);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
@@ -1,9 +1,10 @@
 package com.palja.user_service.application.service;
 
 import com.palja.user_service.application.command.CreateManagerCommand;
+import com.palja.user_service.application.dto.response.CreateUserRes;
 
 public interface ManagerService {
 
-	void createManager(CreateManagerCommand command);
+	CreateUserRes createManager(CreateManagerCommand command);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
@@ -7,8 +7,11 @@ import java.nio.charset.StandardCharsets;
 
 import org.springframework.stereotype.Service;
 
+import com.palja.common.exception.BusinessException;
+import com.palja.common.exception.CommonErrorCode;
 import com.palja.user_service.application.service.AuthService;
 import com.palja.user_service.application.util.JwtUtil;
+import com.palja.user_service.domain.entity.User;
 import com.palja.user_service.domain.repository.TokenRepository;
 import com.palja.user_service.domain.repository.UserRepository;
 
@@ -24,9 +27,13 @@ public class AuthServiceImpl implements AuthService {
 	private final JwtUtil jwtUtil;
 
 	@Override
-	public String refreshAccessToken(String loginId, String userRole, String accessToken, String refreshToken) {
+	public String refreshAccessToken(String accessToken, String refreshToken) {
 		String substringRefreshToken = jwtUtil.substringToken(URLDecoder.decode(refreshToken, StandardCharsets.UTF_8));
 		validateRefreshToken(substringRefreshToken);
+		String loginId = jwtUtil.parseRefreshToken(substringRefreshToken).getSubject();
+
+		validateRefreshTokenWithRedis(loginId, substringRefreshToken);
+		String userRole = getUserByLoginId(loginId).getRole().name();
 
 		if (accessToken != null) {
 			addAccessTokenToBlackList(loginId, accessToken);
@@ -37,12 +44,28 @@ public class AuthServiceImpl implements AuthService {
 
 	@Override
 	public void logout(String loginId, String accessToken) {
+		getUserByLoginId(loginId);
+
 		addAccessTokenToBlackList(loginId, accessToken);
 		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + loginId);
 	}
 
+	private User getUserByLoginId(String loginId) {
+		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
+			() -> new BusinessException(CommonErrorCode.NOT_FOUND)
+		);
+	}
+
 	private void validateRefreshToken(String refreshToken) {
 		if (refreshToken == null || !jwtUtil.validateRefreshToken(refreshToken)) {
+			throw new IllegalArgumentException("다시 로그인 해주세요.");
+		}
+	}
+
+	private void validateRefreshTokenWithRedis(String loginId, String refreshToken) {
+		String redisRefreshToken = tokenRepository.get(REFRESH_TOKEN_WHITELIST_PREFIX + loginId);
+
+		if (!redisRefreshToken.equals(refreshToken)) {
 			throw new IllegalArgumentException("다시 로그인 해주세요.");
 		}
 	}

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -37,6 +37,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		User user = User.builder()
 			.loginId(command.loginId())
 			.password(passwordEncoder.encode(command.password()))
+			.name(command.name())
 			.role(UserRole.COMPANY_USER)
 			.build();
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -66,8 +66,10 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		}
 	}
 
-	// TODO: 중복 검사 전략 결정 후 작성
 	private void validateDuplicateName(String name) {
+		if (userRepository.existsByNameAndDeletedAtIsNull(name)) {
+			throw new BusinessException(CommonErrorCode.DOMAIN_ERROR);
+		}
 	}
 
 	private void validateDuplicateEmail(String email) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -10,6 +10,7 @@ import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
+import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.service.CompanyUserService;
 import com.palja.user_service.domain.entity.CompanyUser;
 import com.palja.user_service.domain.entity.User;
@@ -29,7 +30,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 
 	@Override
 	@Transactional
-	public void createCompanyUser(CreateCompanyUserCommand command) {
+	public CreateUserRes createCompanyUser(CreateCompanyUserCommand command) {
 		validateDuplicateLoginId(command.loginId());
 		validateDuplicateName(command.name());
 		validateDuplicateEmail(command.email());
@@ -50,6 +51,8 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 			.build();
 
 		companyUserRepository.save(companyUser);
+
+		return CreateUserRes.from(user);
 	}
 
 	@Override

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
 import com.palja.user_service.application.command.CreateCustomerCommand;
+import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.service.CustomerService;
 import com.palja.user_service.domain.entity.Customer;
 import com.palja.user_service.domain.entity.User;
@@ -26,7 +27,7 @@ public class CustomerServiceImpl implements CustomerService {
 
 	@Override
 	@Transactional
-	public void createCustomer(CreateCustomerCommand command) {
+	public CreateUserRes createCustomer(CreateCustomerCommand command) {
 		validateDuplicateLoginId(command.loginId());
 		validateDuplicateName(command.name());
 		validateDuplicateEmail(command.email());
@@ -46,6 +47,8 @@ public class CustomerServiceImpl implements CustomerService {
 			.build();
 
 		customerRepository.save(customer);
+
+		return CreateUserRes.from(user);
 	}
 
 	// TODO: 예외코드 생성

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -34,6 +34,7 @@ public class CustomerServiceImpl implements CustomerService {
 		User user = User.builder()
 			.loginId(command.loginId())
 			.password(passwordEncoder.encode(command.password()))
+			.name(command.name())
 			.role(UserRole.CUSTOMER)
 			.build();
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -55,8 +55,10 @@ public class CustomerServiceImpl implements CustomerService {
 		}
 	}
 
-	// TODO: 중복 검사 전략 결정 후 작성
 	private void validateDuplicateName(String name) {
+		if (userRepository.existsByNameAndDeletedAtIsNull(name)) {
+			throw new BusinessException(CommonErrorCode.DOMAIN_ERROR);
+		}
 	}
 
 	private void validateDuplicateEmail(String email) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -34,6 +34,7 @@ public class ManagerServiceImpl implements ManagerService {
 		User user = User.builder()
 			.loginId(command.loginId())
 			.password(passwordEncoder.encode(command.password()))
+			.name(command.name())
 			.role(UserRole.MANAGER)
 			.build();
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -54,8 +54,10 @@ public class ManagerServiceImpl implements ManagerService {
 		}
 	}
 
-	// TODO: 중복 검사 전략 결정 후 작성
 	private void validateDuplicateName(String name) {
+		if (userRepository.existsByNameAndDeletedAtIsNull(name)) {
+			throw new BusinessException(CommonErrorCode.DOMAIN_ERROR);
+		}
 	}
 
 	private void validateDuplicateEmail(String email) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
 import com.palja.user_service.application.command.CreateManagerCommand;
+import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.service.ManagerService;
 import com.palja.user_service.domain.entity.Manager;
 import com.palja.user_service.domain.entity.User;
@@ -26,7 +27,7 @@ public class ManagerServiceImpl implements ManagerService {
 
 	@Override
 	@Transactional
-	public void createManager(CreateManagerCommand command) {
+	public CreateUserRes createManager(CreateManagerCommand command) {
 		validateDuplicateLoginId(command.loginId());
 		validateDuplicateName(command.name());
 		validateDuplicateEmail(command.email());
@@ -45,6 +46,8 @@ public class ManagerServiceImpl implements ManagerService {
 			.build();
 
 		managerRepository.save(manager);
+
+		return CreateUserRes.from(user);
 	}
 
 	// TODO: 예외코드 생성

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/CompanyUser.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/CompanyUser.java
@@ -46,6 +46,12 @@ public class CompanyUser extends BaseEntity {
 	@Column(name = "address", nullable = false)
 	private String address;
 
+	@Override
+	public void softDelete() {
+		super.softDelete();
+		user.softDelete();
+	}
+
 	@Builder
 	private CompanyUser(User user, String name, String companyNumber, String email, String address) {
 		this.user = user;

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/Customer.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/Customer.java
@@ -43,6 +43,12 @@ public class Customer extends BaseEntity {
 	@Column(name = "address", nullable = false)
 	private String address;
 
+	@Override
+	public void softDelete() {
+		super.softDelete();
+		user.softDelete();
+	}
+
 	@Builder
 	private Customer(User user, String name, String email, String address) {
 		this.user = user;

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/Manager.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/Manager.java
@@ -40,6 +40,12 @@ public class Manager extends BaseEntity {
 	@Column(name = "email", nullable = false, unique = true)
 	private String email;
 
+	@Override
+	public void softDelete() {
+		super.softDelete();
+		user.softDelete();
+	}
+
 	@Builder
 	private Manager(User user, String name, String email) {
 		this.user = user;

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
@@ -2,6 +2,7 @@ package com.palja.user_service.domain.entity;
 
 import java.time.Instant;
 
+import com.palja.common.auditor.AuditorContext;
 import com.palja.user_service.domain.vo.UserRole;
 import com.palja.user_service.domain.vo.UserStatus;
 
@@ -51,8 +52,13 @@ public class User {
 	@Column(name = "deletedAt")
 	private Instant deletedAt;
 
-	@Column(name = "deletedBy")
-	private Long deletedBy;
+	@Column(name = "deletedBy", length = 10)
+	private String deletedBy;
+
+	public void softDelete() {
+		this.deletedAt = Instant.now();
+		this.deletedBy = AuditorContext.get().getLoginId();
+	}
 
 	@Builder
 	private User(String loginId, String password, String name, UserRole role) {

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
@@ -35,6 +35,9 @@ public class User {
 	@Column(name = "password", nullable = false)
 	private String password;
 
+	@Column(name = "name", length = 10, nullable = false, unique = true)
+	private String name;
+
 	@Column(name = "role", nullable = false)
 	@Enumerated(EnumType.STRING)
 	// @JdbcTypeCode(SqlTypes.NAMED_ENUM)
@@ -52,9 +55,10 @@ public class User {
 	private Long deletedBy;
 
 	@Builder
-	private User(String loginId, String password, UserRole role) {
+	private User(String loginId, String password, String name, UserRole role) {
 		this.loginId = loginId;
 		this.password = password;
+		this.name = name;
 		this.role = role;
 		this.status = this.role == UserRole.COMPANY_USER ? UserStatus.PENDING : UserStatus.ACTIVE;
 	}

--- a/user-service/src/main/java/com/palja/user_service/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/repository/UserRepository.java
@@ -8,6 +8,8 @@ public interface UserRepository {
 
 	boolean existsByLoginIdAndDeletedAtIsNull(String loginId);
 
+	boolean existsByNameAndDeletedAtIsNull(String name);
+
 	Optional<User> findByLoginIdAndDeletedAtIsNull(String loginId);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/repository/UserRepository.java
@@ -6,6 +6,8 @@ import com.palja.user_service.domain.entity.User;
 
 public interface UserRepository {
 
+	User save(User user);
+
 	boolean existsByLoginIdAndDeletedAtIsNull(String loginId);
 
 	boolean existsByNameAndDeletedAtIsNull(String name);

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/init/MasterInitializer.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/init/MasterInitializer.java
@@ -1,0 +1,34 @@
+package com.palja.user_service.infrastructure.init;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.palja.user_service.domain.entity.User;
+import com.palja.user_service.domain.repository.UserRepository;
+import com.palja.user_service.domain.vo.UserRole;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MasterInitializer implements CommandLineRunner {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public void run(String... args) {
+		if (!userRepository.existsByLoginIdAndDeletedAtIsNull("master")) {
+			User master = User.builder()
+				.loginId("master")
+				.password(passwordEncoder.encode("master"))
+				.name("master")
+				.role(UserRole.MASTER)
+				.build();
+
+			userRepository.save(master);
+		}
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/JpaUserRepository.java
@@ -10,6 +10,8 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByLoginIdAndDeletedAtIsNull(String loginId);
 
+	boolean existsByNameAndDeletedAtIsNull(String name);
+
 	Optional<User> findByLoginIdAndDeletedAtIsNull(String loginId);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/adapter/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/adapter/UserRepositoryAdapter.java
@@ -22,6 +22,11 @@ public class UserRepositoryAdapter implements UserRepository {
 	}
 
 	@Override
+	public boolean existsByNameAndDeletedAtIsNull(String name) {
+		return jpaUserRepository.existsByNameAndDeletedAtIsNull(name);
+	}
+
+	@Override
 	public Optional<User> findByLoginIdAndDeletedAtIsNull(String loginId) {
 		return jpaUserRepository.findByLoginIdAndDeletedAtIsNull(loginId);
 	}

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/adapter/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/adapter/UserRepositoryAdapter.java
@@ -17,6 +17,11 @@ public class UserRepositoryAdapter implements UserRepository {
 	private final JpaUserRepository jpaUserRepository;
 
 	@Override
+	public User save(User user) {
+		return jpaUserRepository.save(user);
+	}
+
+	@Override
 	public boolean existsByLoginIdAndDeletedAtIsNull(String loginId) {
 		return jpaUserRepository.existsByLoginIdAndDeletedAtIsNull(loginId);
 	}

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/security/filter/AuthenticationFilter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/security/filter/AuthenticationFilter.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
 	public AuthenticationFilter() {
-		setFilterProcessesUrl("/api/v1/login");
+		setFilterProcessesUrl("/api/v1/auth/login");
 	}
 
 	@Override

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/security/util/JwtUtilImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/security/util/JwtUtilImpl.java
@@ -119,20 +119,6 @@ public class JwtUtilImpl implements JwtUtil {
 		}
 	}
 
-	private String generateToken(Long userId, String role, Key key, long expirationTime) {
-		Date now = new Date();
-
-		return BEARER_PREFIX +
-			Jwts.builder()
-				.setSubject(String.valueOf(userId))
-				.claim("role", role)
-				.setIssuedAt(now)
-				.setExpiration(new Date(now.getTime() + expirationTime))
-				.signWith(key, SignatureAlgorithm.HS256)
-				.compact()
-			;
-	}
-
 	private boolean validateToken(String token, Key key) {
 		try {
 			Jwts.parserBuilder()

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.palja.common.auditor.AuditorContext;
 import com.palja.common.response.ApiResponse;
 import com.palja.user_service.application.service.AuthService;
 
@@ -25,12 +26,11 @@ public class AuthController {
 
 	@PostMapping("/refresh")
 	public ResponseEntity<ApiResponse<Void>> refresh(
-		@RequestHeader("X-USER-LOGIN-ID") String loginId, @RequestHeader("X-USER-ROLE") String userRole,
 		@RequestHeader(value = "Authorization", required = false) String accessToken,
 		@CookieValue(value = "refresh_token", required = false) String refreshToken,
 		HttpServletResponse response
 	) {
-		String newAccessToken = authService.refreshAccessToken(loginId, userRole, accessToken, refreshToken);
+		String newAccessToken = authService.refreshAccessToken(accessToken, refreshToken);
 		addAccessTokenToHeader(response, newAccessToken);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("토큰이 재발급 되었습니다."));
@@ -38,9 +38,10 @@ public class AuthController {
 
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<Void>> logout(
-		@RequestHeader("X-USER-LOGIN-ID") String loginId,
 		@RequestHeader("Authorization") String accessToken, HttpServletResponse response
 	) {
+		String loginId = AuditorContext.get().getLoginId();
+
 		authService.logout(loginId, accessToken);
 		expireRefreshTokenToCookie(response);
 

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.palja.common.response.ApiResponse;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
+import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.service.CompanyUserService;
 import com.palja.user_service.presentation.dto.request.CreateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserStatusReq;
@@ -29,11 +30,11 @@ public class CompanyUserController {
 	private final CompanyUserService companyUserService;
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<Void>> create(@Valid @RequestBody CreateCompanyUserReq requestDto) {
+	public ResponseEntity<ApiResponse<CreateUserRes>> create(@Valid @RequestBody CreateCompanyUserReq requestDto) {
 		CreateCompanyUserCommand command = CreateCompanyUserReq.of(requestDto);
-		companyUserService.createCompanyUser(command);
+		CreateUserRes responseDto = companyUserService.createCompanyUser(command);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("업체 판매자가 생성되었습니다."));
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(responseDto, "업체 판매자가 생성되었습니다."));
 	}
 
 	@PutMapping("/{companyUserId}/status")

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.palja.common.response.ApiResponse;
 import com.palja.user_service.application.command.CreateCustomerCommand;
+import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.service.CustomerService;
 import com.palja.user_service.presentation.dto.request.CreateCustomerReq;
 
@@ -23,11 +24,11 @@ public class CustomerController {
 	private final CustomerService customerService;
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<Void>> create(@Valid @RequestBody CreateCustomerReq requestDto) {
+	public ResponseEntity<ApiResponse<CreateUserRes>> create(@Valid @RequestBody CreateCustomerReq requestDto) {
 		CreateCustomerCommand command = CreateCustomerReq.of(requestDto);
-		customerService.createCustomer(command);
+		CreateUserRes responseDto = customerService.createCustomer(command);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("일반 사용자가 생성되었습니다."));
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(responseDto, "일반 사용자가 생성되었습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.palja.common.response.ApiResponse;
 import com.palja.user_service.application.command.CreateManagerCommand;
+import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.service.ManagerService;
 import com.palja.user_service.presentation.dto.request.CreateManagerReq;
 
@@ -23,11 +24,11 @@ public class ManagerController {
 	private final ManagerService managerService;
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<Void>> create(@Valid @RequestBody CreateManagerReq requestDto) {
+	public ResponseEntity<ApiResponse<CreateUserRes>> create(@Valid @RequestBody CreateManagerReq requestDto) {
 		CreateManagerCommand command = CreateManagerReq.of(requestDto);
-		managerService.createManager(command);
+		CreateUserRes responseDto = managerService.createManager(command);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("관리자가 생성되었습니다."));
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(responseDto, "관리자가 생성되었습니다."));
 	}
 
 }

--- a/user-service/src/main/resources/application-datasource.yml
+++ b/user-service/src/main/resources/application-datasource.yml
@@ -14,8 +14,3 @@ spring:
         format_sql: true
         show_sql: true
         default_schema: palja_user
-    defer-datasource-initialization: true
-  sql:
-    init:
-      mode: always
-      data-locations: classpath:data.sql

--- a/user-service/src/main/resources/data.sql
+++ b/user-service/src/main/resources/data.sql
@@ -1,3 +1,0 @@
-INSERT INTO palja_user.p_user (login_id, password, role, status)
-VALUES ('master', 'master', 'MASTER', 'ACTIVE')
-ON CONFLICT (login_id) DO NOTHING;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #47 

<br>

## 📌 개요
- 회원 생성 시 데이터 반환 및 토큰 재발급, 로그아웃 시 회원 검증

<br>

## 🔁 변경 사항
- Comoon 모듈 의존성 0.4.6 버전 적용하고 코드 수정
- 액세스토큰을 재발급할 때 리프레시 토큰을 검증하고 레디스에 저장된 토큰이 맞는지 확인
- 토큰 재발급과 로그아웃할 때 게이트웨이에서 받은 loginId로 user를 조회해서 검증
- master 계정을 init.sql -> MasterInitializer에서 생성하도록 변경
- 관리자, 일반 사용자, 업체 판매자가 삭제될 때 User 데이터도 삭제되도록 softDelete() 메서드 추가
- 회원 생성 시 name 중복 검사 적용
- JwtUtilImpl에서 불필요한 메서드 삭제 -> generateToken()

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
