### PR TITLE
FEAT/ PaymentService 결제 취소 API 구현

### DIFF
--- a/payment-service/src/main/java/com/palja/payment_service/application/command/CancelPaymentCommand.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/command/CancelPaymentCommand.java
@@ -1,0 +1,15 @@
+package com.palja.payment_service.application.command;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Builder
+public record CancelPaymentCommand(
+        UUID paymentId,
+        Long userId,
+        BigDecimal cancelAmount,
+        String cancelReason
+) {
+}

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/PGPaymentService.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/PGPaymentService.java
@@ -3,7 +3,11 @@ package com.palja.payment_service.application.service;
 import com.palja.payment_service.application.dto.response.PGPaymentRes;
 import com.palja.payment_service.domain.entity.Payment;
 
+import java.math.BigDecimal;
+
 public interface PGPaymentService {
 
     PGPaymentRes requestPayment(Payment payment);
+
+    PGPaymentRes cancelPayment(Payment payment, BigDecimal cancelAmount, String cancelReason);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/PaymentService.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/PaymentService.java
@@ -1,9 +1,12 @@
 package com.palja.payment_service.application.service;
 
+import com.palja.payment_service.application.command.CancelPaymentCommand;
 import com.palja.payment_service.application.command.CreatePaymentCommand;
 import com.palja.payment_service.application.dto.response.PaymentDetailRes;
 
 public interface PaymentService {
 
     PaymentDetailRes createPayment(CreatePaymentCommand command);
+
+    PaymentDetailRes cancelPayment(CancelPaymentCommand command);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
@@ -2,6 +2,7 @@ package com.palja.payment_service.application.service.impl;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
+import com.palja.payment_service.application.command.CancelPaymentCommand;
 import com.palja.payment_service.application.command.CreatePaymentCommand;
 import com.palja.payment_service.application.dto.response.PGPaymentRes;
 import com.palja.payment_service.application.dto.response.PaymentDetailRes;
@@ -11,6 +12,7 @@ import com.palja.payment_service.domain.entity.Payment;
 import com.palja.payment_service.domain.entity.PaymentLog;
 import com.palja.payment_service.domain.repository.PaymentLogRepository;
 import com.palja.payment_service.domain.repository.PaymentRepository;
+import com.palja.payment_service.domain.vo.PaymentStatus;
 import com.palja.payment_service.exception.PaymentErrorCode;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
@@ -69,6 +71,49 @@ public class PaymentServiceImpl implements PaymentService {
 
         if (!pgRes.isSuccess()) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_FAILED);
+        }
+
+        return PaymentDetailRes.from(payment);
+    }
+
+    @Override
+    @Transactional(noRollbackFor = BusinessException.class)
+    public PaymentDetailRes cancelPayment(CancelPaymentCommand command) {
+
+        Payment payment = paymentRepository.findById(command.paymentId())
+                .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
+
+        if (payment.getStatus() != PaymentStatus.APPROVED) {
+            throw new BusinessException(CommonErrorCode.BAD_REQUEST);
+        }
+
+        PaymentLog requestLog = createRequestLog(payment);
+        paymentLogRepository.save(requestLog);
+
+        PGPaymentRes pgRes;
+        try {
+            pgRes = pgPaymentService.cancelPayment(
+                    payment,
+                    command.cancelAmount(),
+                    command.cancelReason()
+            );
+        } catch (Exception e) {
+            throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
+        }
+
+        if (pgRes.isSuccess()) {
+            payment.cancel(command.cancelReason());
+        } else {
+            payment.fail(pgRes.getPgResponseMessage());
+        }
+
+        paymentRepository.save(payment);
+
+        PaymentLog resultLog = createResultLog(payment, pgRes);
+        paymentLogRepository.save(resultLog);
+
+        if (!pgRes.isSuccess()) {
+            throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
         }
 
         return PaymentDetailRes.from(payment);

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
@@ -29,21 +29,6 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     @Transactional(noRollbackFor = BusinessException.class)
-    /*TODO: order-service에서 orderId로 주문을 조회하고
-            주문금액과 결제 금액이 동일한지, userId, status(CREATED) 검증하기
-            만약, 다르다면 PG 호출하지 말고 Payment 상태값을 FAILED로 저장하고 로그 남기기
-
-      TODO: PaymentLog에 retryCount, success 추가하고
-            5~10분 이내 같은 orderId와 userId로 결제 5번 이상 실패하면
-            더 이상 PG 호출이 안되도록 막기, order-service에 이벤트 전달 (상태 CREATED->CANCLED)
-
-      TODO: 결제 성공 & 실패 이벤트 발생
-            1. PaymentApprovedEvent(orderId, paymentId, userId, amount, paymentKey 등)
-             Kafka에 order-service, coupon-service 등이 이 이벤트를 구독해서
-             주문 상태 변경, 쿠폰 사용 처리 등을 비동기로 처리
-            2. PaymentFailedEvent(orderId, paymentId, userId, 사유, 에러코드 등)
-                Kafka에 order-service가 주문 상태를 그래도 CREATED로 유지, coupon-service 도 미사용으로 유지
-     */
     public PaymentDetailRes createPayment(CreatePaymentCommand command) {
         Payment payment = Payment.create(command.orderId(), command.userId(), command.amount(), command.currency(), command.paymentMethod(), command.paymentKey());
         paymentRepository.save(payment);
@@ -81,10 +66,10 @@ public class PaymentServiceImpl implements PaymentService {
     public PaymentDetailRes cancelPayment(CancelPaymentCommand command) {
 
         Payment payment = paymentRepository.findById(command.paymentId())
-                .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         if (payment.getStatus() != PaymentStatus.APPROVED) {
-            throw new BusinessException(CommonErrorCode.BAD_REQUEST);
+            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_APPROVED);
         }
 
         PaymentLog requestLog = createRequestLog(payment);
@@ -97,6 +82,8 @@ public class PaymentServiceImpl implements PaymentService {
                     command.cancelAmount(),
                     command.cancelReason()
             );
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
         }
@@ -113,7 +100,7 @@ public class PaymentServiceImpl implements PaymentService {
         paymentLogRepository.save(resultLog);
 
         if (!pgRes.isSuccess()) {
-            throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
+            throw new BusinessException(PaymentErrorCode.PAYMENT_FAILED);
         }
 
         return PaymentDetailRes.from(payment);

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
@@ -29,6 +29,19 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     @Transactional(noRollbackFor = BusinessException.class)
+    /*TODO: order-service에서 orderId로 주문을 조회하고
+            주문금액과 결제 금액이 동일한지, userId, status(CREATED) 검증하기
+            만약, 다르다면 PG 호출하지 말고 Payment 상태값을 FAILED로 저장하고 로그 남기기
+      TODO: PaymentLog에 retryCount, success 추가하고
+            5~10분 이내 같은 orderId와 userId로 결제 5번 이상 실패하면
+            더 이상 PG 호출이 안되도록 막기, order-service에 이벤트 전달 (상태 CREATED->CANCLED)
+      TODO: 결제 성공 & 실패 이벤트 발생
+            1. PaymentApprovedEvent(orderId, paymentId, userId, amount, paymentKey 등)
+             Kafka에 order-service, coupon-service 등이 이 이벤트를 구독해서
+             주문 상태 변경, 쿠폰 사용 처리 등을 비동기로 처리
+            2. PaymentFailedEvent(orderId, paymentId, userId, 사유, 에러코드 등)
+                Kafka에 order-service가 주문 상태를 그래도 CREATED로 유지, coupon-service 도 미사용으로 유지
+     */
     public PaymentDetailRes createPayment(CreatePaymentCommand command) {
         Payment payment = Payment.create(command.orderId(), command.userId(), command.amount(), command.currency(), command.paymentMethod(), command.paymentKey());
         paymentRepository.save(payment);

--- a/payment-service/src/main/java/com/palja/payment_service/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/entity/Payment.java
@@ -1,8 +1,10 @@
 package com.palja.payment_service.domain.entity;
 
 import com.palja.common.entity.BaseEntity;
+import com.palja.common.exception.BusinessException;
 import com.palja.payment_service.domain.vo.PaymentMethod;
 import com.palja.payment_service.domain.vo.PaymentStatus;
+import com.palja.payment_service.exception.PaymentErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -79,5 +81,15 @@ public class Payment extends BaseEntity {
     public void fail(String pgMessage) {
         this.status = PaymentStatus.FAILED;
         this.cancelReason = pgMessage;
+    }
+
+    public void cancel(String reason) {
+        if (this.status != PaymentStatus.APPROVED) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_APPROVED);
+        }
+
+        this.status = PaymentStatus.CANCELED;
+        this.cancelReason = reason;
+        this.completedAt = LocalDateTime.now();
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/exception/PaymentErrorCode.java
+++ b/payment-service/src/main/java/com/palja/payment_service/exception/PaymentErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PaymentErrorCode implements ErrorCode {
 
+    PAYMENT_EXCEED_AMOUNT(HttpStatus.BAD_REQUEST, "취소 금액이 결제 금액을 초과할 수 없습니다."),
+    PAYMENT_NOT_PARTIAL_REFUND(HttpStatus.BAD_REQUEST, "부분 환불이 불가합니다,"),
+    PAYMENT_NOT_APPROVED(HttpStatus.BAD_REQUEST,"승인된 결제만 취소할 수 있습니다."),
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "결제에 실패했습니다."),
     INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 방법입니다."),
     INSUFFICIENT_FUNDS(HttpStatus.BAD_REQUEST, "결제에 필요한 금액이 부족합니다."),

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/dto/request/TossPaymentCancelReq.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/dto/request/TossPaymentCancelReq.java
@@ -1,0 +1,13 @@
+package com.palja.payment_service.infrastructure.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class TossPaymentCancelReq {
+    private String cancelReason;
+    private BigDecimal cancelAmount;
+}

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/TossPaymentService.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/TossPaymentService.java
@@ -1,8 +1,11 @@
 package com.palja.payment_service.infrastructure.external;
 
+import com.palja.common.exception.BusinessException;
 import com.palja.payment_service.application.dto.response.PGPaymentRes;
 import com.palja.payment_service.application.service.PGPaymentService;
 import com.palja.payment_service.domain.entity.Payment;
+import com.palja.payment_service.exception.PaymentErrorCode;
+import com.palja.payment_service.infrastructure.dto.request.TossPaymentCancelReq;
 import com.palja.payment_service.infrastructure.dto.response.TossPaymentRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,6 +69,62 @@ public class TossPaymentService implements PGPaymentService {
             return PGPaymentRes.builder()
                     .paymentKey(paymentKey)
                     .pgResponseCode(String.valueOf(e.getStatusCode()))
+                    .pgResponseMessage(e.getResponseBodyAsString())
+                    .success(false)
+                    .approvedAmount(null)
+                    .build();
+        }
+    }
+
+    @Override
+    public PGPaymentRes cancelPayment(Payment payment, BigDecimal cancelAmount, String cancelReason) {
+        String paymentKey = payment.getPaymentKey();
+        log.info("Toss cancel request. paymentKey={}, orderId={}, cancelAmount={}, reason={}",
+                paymentKey, payment.getOrderId(), cancelAmount, cancelReason);
+
+        if (cancelAmount.compareTo(payment.getAmount()) > 0) {
+            log.error("취소 금액이 결제 금액을 초과합니다. cancelAmount={}, paymentAmount={}", cancelAmount, payment.getAmount());
+            throw new BusinessException(PaymentErrorCode.PAYMENT_EXCEED_AMOUNT);
+        }
+
+        if (cancelAmount.compareTo(payment.getAmount()) < 0) {
+            log.error("부분 환불은 지원되지 않습니다. cancelAmount={}, paymentAmount={}", cancelAmount, payment.getAmount());
+            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_PARTIAL_REFUND);
+        }
+
+        try {
+            TossPaymentCancelReq req = TossPaymentCancelReq.builder()
+                    .cancelAmount(cancelAmount)
+                    .cancelReason(cancelReason)
+                    .build();
+
+            TossPaymentRes res = tossWebClient.post()
+                    .uri("/v1/payments/{paymentKey}/cancel", paymentKey)
+                    .bodyValue(req)
+                    .retrieve()
+                    .bodyToMono(TossPaymentRes.class)
+                    .block();
+
+            boolean success = "CANCELED".equalsIgnoreCase(res.getStatus());
+            String message = success
+                    ? "토스 결제 취소 성공"
+                    : "토스 결제 취소 실패. status=" + res.getStatus();
+
+            return PGPaymentRes.builder()
+                    .paymentKey(res.getPaymentKey())
+                    .pgResponseCode(success ? "SUCCESS" : res.getStatus())
+                    .pgResponseMessage(message)
+                    .success(success)
+                    .approvedAmount(null)
+                    .build();
+
+        } catch (WebClientResponseException e) {
+            log.error("토스 결제 취소 API 실패. 상태 코드: {} 응답: {}",
+                    e.getStatusCode(), e.getResponseBodyAsString(), e);
+
+            return PGPaymentRes.builder()
+                    .paymentKey(paymentKey)
+                    .pgResponseCode(String.valueOf(e.getStatusCode().value()))
                     .pgResponseMessage(e.getResponseBodyAsString())
                     .success(false)
                     .approvedAmount(null)

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/TossPaymentService.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/TossPaymentService.java
@@ -79,16 +79,18 @@ public class TossPaymentService implements PGPaymentService {
     @Override
     public PGPaymentRes cancelPayment(Payment payment, BigDecimal cancelAmount, String cancelReason) {
         String paymentKey = payment.getPaymentKey();
-        log.info("Toss cancel request. paymentKey={}, orderId={}, cancelAmount={}, reason={}",
-                paymentKey, payment.getOrderId(), cancelAmount, cancelReason);
+        log.info("Toss cancel request. paymentKey={}, orderId={}, cancelAmount={}, paymentAmount={}, reason={}",
+                paymentKey, payment.getOrderId(), cancelAmount, payment.getAmount(), cancelReason);
 
-        if (cancelAmount.compareTo(payment.getAmount()) > 0) {
-            log.error("취소 금액이 결제 금액을 초과합니다. cancelAmount={}, paymentAmount={}", cancelAmount, payment.getAmount());
+        BigDecimal paymentAmount = payment.getAmount();
+
+        if (cancelAmount.compareTo(paymentAmount) > 0) {
+            log.error("취소 금액이 결제 금액을 초과합니다. cancelAmount={}, paymentAmount={}", cancelAmount, paymentAmount);
             throw new BusinessException(PaymentErrorCode.PAYMENT_EXCEED_AMOUNT);
         }
 
-        if (cancelAmount.compareTo(payment.getAmount()) < 0) {
-            log.error("부분 환불은 지원되지 않습니다. cancelAmount={}, paymentAmount={}", cancelAmount, payment.getAmount());
+        if (cancelAmount.compareTo(paymentAmount) < 0) {
+            log.error("부분 환불은 지원되지 않습니다. cancelAmount={}, paymentAmount={}", cancelAmount, paymentAmount);
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_PARTIAL_REFUND);
         }
 

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentController.java
@@ -3,6 +3,7 @@ package com.palja.payment_service.presentation.controller;
 import com.palja.common.response.ApiResponse;
 import com.palja.payment_service.application.dto.response.PaymentDetailRes;
 import com.palja.payment_service.application.service.PaymentService;
+import com.palja.payment_service.presentation.dto.request.CancelPaymentReq;
 import com.palja.payment_service.presentation.dto.request.CreatePaymentReq;
 import com.palja.payment_service.presentation.dto.response.PaymentRes;
 import jakarta.validation.Valid;
@@ -11,14 +12,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
 public class PaymentController {
 
     private final PaymentService paymentService;
 
-    @PostMapping("/payments")
+    @PostMapping
     public ResponseEntity<ApiResponse<PaymentRes>> createPayment(
             @Valid @RequestBody CreatePaymentReq req
     ) {
@@ -28,5 +31,17 @@ public class PaymentController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(res, "결제가 생성되었습니다."));
+    }
+
+    @PostMapping("/{paymentId}/cancel")
+    public ResponseEntity<ApiResponse<PaymentRes>> cancelPayment(
+            @PathVariable UUID paymentId,
+            @RequestBody CancelPaymentReq req
+    ){
+        PaymentDetailRes result = paymentService.cancelPayment(req.toCommand(paymentId));
+        PaymentRes res = PaymentRes.from(result);
+
+        return ResponseEntity
+                .ok(ApiResponse.success(res,"결제가 취소되었습니다."));
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/dto/request/CancelPaymentReq.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/dto/request/CancelPaymentReq.java
@@ -1,0 +1,26 @@
+package com.palja.payment_service.presentation.dto.request;
+
+import com.palja.payment_service.application.command.CancelPaymentCommand;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class CancelPaymentReq {
+
+    private Long userId;
+    private BigDecimal cancelAmount;
+    private String cancelReason;
+
+    public CancelPaymentCommand toCommand(UUID paymentId) {
+        return CancelPaymentCommand.builder()
+                .paymentId(paymentId)
+                .userId(userId)
+                .cancelAmount(cancelAmount)
+                .cancelReason(cancelReason)
+                .build();
+    }
+}

--- a/payment-service/src/test/java/com/palja/payment_service/application/service/impl/PaymentServiceImplTest.java
+++ b/payment-service/src/test/java/com/palja/payment_service/application/service/impl/PaymentServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.palja.payment_service.application.service.impl;
 
 import com.palja.common.exception.BusinessException;
+import com.palja.payment_service.application.command.CancelPaymentCommand;
 import com.palja.payment_service.application.command.CreatePaymentCommand;
 import com.palja.payment_service.application.dto.response.PGPaymentRes;
 import com.palja.payment_service.application.dto.response.PaymentDetailRes;
@@ -23,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,7 +121,7 @@ class PaymentServiceImplTest {
         
         assertThatThrownBy(() -> paymentService.createPayment(command))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", PaymentErrorCode.PAYMENT_FAILED); // 수정
+                .hasFieldOrPropertyWithValue("errorCode", PaymentErrorCode.PAYMENT_FAILED);
 
         ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
         then(paymentRepository).should(times(2)).save(paymentCaptor.capture());
@@ -141,4 +143,109 @@ class PaymentServiceImplTest {
     /*
     TODO:  orderService에서 주문 시 주문금액과 결제 금액이 다를 때 결제 실패 Test Code(orderService Mock 설정 필요)
      */
+
+    @Test
+    @DisplayName("결제 상태가 APPROVED인 결제건 전체 금액 취소 성공")
+    void cancelPayment_success() {
+        Payment payment = Payment.create(
+                UUID.randomUUID(),
+                1L,
+                new BigDecimal("10000"),
+                "KRW",
+                PaymentMethod.CARD,
+                "paymentKey123"
+        );
+        payment.approve("paymentKey123");
+
+        given(paymentRepository.findById(payment.getId()))
+                .willReturn(Optional.of(payment));
+
+        PGPaymentRes pgRes = PGPaymentRes.builder()
+                .paymentKey("paymentKey123")
+                .pgResponseCode("SUCCESS")
+                .pgResponseMessage("취소 성공")
+                .success(true)
+                .approvedAmount(new BigDecimal("10000"))
+                .build();
+
+        given(pgPaymentService.cancelPayment(payment, new BigDecimal("10000"), "전체 환불"))
+                .willReturn(pgRes);
+
+        PaymentDetailRes result = paymentService.cancelPayment(
+                CancelPaymentCommand.builder()
+                        .paymentId(payment.getId())
+                        .userId(1L)
+                        .cancelAmount(new BigDecimal("10000"))
+                        .cancelReason("전체 환불")
+                        .build()
+        );
+
+        assertThat(result).isNotNull();
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.CANCELED.name());
+
+        then(pgPaymentService).should()
+                .cancelPayment(payment, new BigDecimal("10000"), "전체 환불");
+    }
+
+    @Test
+    @DisplayName("부분 환불 시 결제 취소 실패")
+    void cancelPayment_partialRefundNotAllowed() {
+        Payment payment = Payment.create(
+                UUID.randomUUID(),
+                1L,
+                new BigDecimal("10000"),
+                "KRW",
+                PaymentMethod.CARD,
+                "paymentKey123"
+        );
+        payment.approve("paymentKey123");
+
+        given(paymentRepository.findById(payment.getId()))
+                .willReturn(Optional.of(payment));
+
+        given(pgPaymentService.cancelPayment(any(Payment.class), any(), any()))
+                .willThrow(new BusinessException(PaymentErrorCode.PAYMENT_NOT_PARTIAL_REFUND));
+
+        assertThatThrownBy(() -> paymentService.cancelPayment(
+                CancelPaymentCommand.builder()
+                        .paymentId(payment.getId())
+                        .userId(1L)
+                        .cancelAmount(new BigDecimal("2000"))
+                        .cancelReason("부분 환불 요청")
+                        .build()
+        ))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", PaymentErrorCode.PAYMENT_NOT_PARTIAL_REFUND);
+    }
+
+    @Test
+    @DisplayName("취소 금액이 결제 금액을 초과하면 결제 취소 실패")
+    void cancelPayment_exceedAmount() {
+        Payment payment = Payment.create(
+                UUID.randomUUID(),
+                1L,
+                new BigDecimal("10000"),
+                "KRW",
+                PaymentMethod.CARD,
+                "paymentKey123"
+        );
+        payment.approve("paymentKey123");
+
+        given(paymentRepository.findById(payment.getId()))
+                .willReturn(Optional.of(payment));
+
+        given(pgPaymentService.cancelPayment(any(Payment.class), any(), any()))
+                .willThrow(new BusinessException(PaymentErrorCode.PAYMENT_EXCEED_AMOUNT));
+
+        assertThatThrownBy(() -> paymentService.cancelPayment(
+                CancelPaymentCommand.builder()
+                        .paymentId(payment.getId())
+                        .userId(1L)
+                        .cancelAmount(new BigDecimal("12000"))
+                        .cancelReason("환불 요청")
+                        .build()
+        ))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", PaymentErrorCode.PAYMENT_EXCEED_AMOUNT);
+    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #35 

<br>

## 📌 개요
### 1. 도메인 계층
- Payment 엔티티의 결제 취소 로직 (cancel)
- PG 응답에서 결제 취소 상태를 확인하고, 이를 기반으로 결제 상태를 CANCELED로 변경

### 2. 애플리케이션 계층
- CancelPaymentCommand 객체 추가
- 결제 취소를 위한 cancelPayment 메서드를 PaymentServiceImpl에 구현 (결제 정보 조회하고 결제 취소 요청을 외부 PG 시스템에 전달하도록)
- PGPaymentService 인터페이스에 cancelPayment 추가해 결제 취소 기능을 구현했고, TossPaymentService에서 외부 PG 시스템의 취소 API 호출

### 3. 인프라 계층
- TossPaymentService 클래스에서 WebClient를 사용해 Toss에 결제 취소 요청을 보냄
- 취소 금액이 결제 금액을 초과하거나, 부분 환불을 하려는 경우 예외 처리
- Toss API로 부터 받은 응답을 PGPaymentRes로 매핑 후 결제 취소 결과 처리

### 4. 프레젠테이션 계층
- 결제 취소 API (POST /api/v1/payments/{paymentId}/cancel) 구현
- CancelPaymentReq로 취소 요청을 받고 CancelPaymentComman로 변환해서 서비스 계층에 전달
- 결제 취소 처리 후, 결과를 PaymentRes로 변환해서 반환

### 5. 테스트
- 결제 취소 성공 시 결제 상태가 CANCELED로 변경되는지 검증
- 결제 취소 금액이 결제 금액을 초과하는 경우 PAYMENT_EXCEED_AMOUNT 예외 발생
- 부분환불이 불가능하므로 PAYMENT_NOT_PARTIAL_REFUND 예외 발생

<br>

## 🔁 변경 사항

<br>

## 📸 스크린샷

<details>
  <summary>결제 취소 성공</summary>
  <img width="855" height="1057" alt="image" src="https://github.com/user-attachments/assets/1ae53b0e-6a76-49e7-a5d5-e581172ef484" />
</details>

<details>
  <summary>결제 부분 환불 불가로 예외 처리</summary>
  <img width="1154" height="1030" alt="image" src="https://github.com/user-attachments/assets/82e03be4-0ee2-4f1a-be84-fbe2da4c7ec6" />
</details>

<details>
  <summary>결제 취소 금액이 결제 금액을 초과할 경우 예외 처리</summary>
  <img width="1106" height="983" alt="image" src="https://github.com/user-attachments/assets/ee1ce820-7b29-4f8e-828e-3d867f5b5b60" />
</details>

<br>

## 👀 기타 더 이야기해볼 점
고도화 기간에 시간이 남는다면 부분환불을 구현할 예정입니다:)
<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
