### PR TITLE
REFACTOR/ProductService - 상품 조회시 재고에 대해 페치조인 적용

### DIFF
--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
@@ -25,6 +25,7 @@ public class DslProductRepository {
         return queryFactory
                 .select(product)
                 .from(product)
+                .join(product.productStock).fetchJoin()
                 .where(nameLike(condition.getName()),
                         priceBetween(condition.getMinPrice(), condition.getMaxPrice()),
                         categoryEq(condition.getCategory()),

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
@@ -3,10 +3,16 @@ package com.palja.product_service.infrastructure.repository;
 import com.palja.product_service.domain.entity.Product;
 import com.palja.product_service.domain.vo.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaProductRepository extends JpaRepository<Product, UUID> {
+
+    @Query(value = "SELECT p FROM Product p INNER JOIN FETCH p.productStock WHERE p.id = :productId")
+    Optional<Product> findByIdFetchStock(@Param("productId") UUID productId);
 
     Boolean existsByCompanyNameAndCategoryAndName(String companyName, Category category, String name);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/ProductRepositoryAdapter.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/ProductRepositoryAdapter.java
@@ -29,7 +29,7 @@ public class ProductRepositoryAdapter implements ProductRepository {
 
     @Override
     public Product findProduct(UUID productId) {
-        return jpaProductRepository.findById(productId).orElseThrow();
+        return jpaProductRepository.findByIdFetchStock(productId).orElseThrow();
     }
 
     @Override


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #59 

<br>

## 📌 개요
- 상품을 조회하는데에 전부 페치조인 적용

<br>

## 🔁 변경 사항
- Jpa 레포지토리에 메서드를 하나 만들어 @Query 에너테이션으로 조회시 페치조인 설정
- Dsl 레포지토리에 .join(...)으로 페치조인 설정
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
나중에 시간이 남는다면 DTO조회로 변경하겠습니다
<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
