### PR TITLE
Feat/ReviewService 리뷰 생성 기능 구현

### DIFF
--- a/review-service/build.gradle
+++ b/review-service/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.kafka:spring-kafka'
-    implementation 'com.palja:common-module:0.3.6'
+    implementation 'com.palja:common-module:0.5.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/review-service/src/main/java/com/palja/review_service/application/command/CreateReviewCommand.java
+++ b/review-service/src/main/java/com/palja/review_service/application/command/CreateReviewCommand.java
@@ -1,0 +1,15 @@
+package com.palja.review_service.application.command;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record CreateReviewCommand(
+        String title,
+        String content,
+        BigDecimal rating,
+        Boolean isLike,
+        Boolean disLike,
+        UUID orderId,
+        String loginId
+) {
+}

--- a/review-service/src/main/java/com/palja/review_service/application/dto/res/CreateReviewRes.java
+++ b/review-service/src/main/java/com/palja/review_service/application/dto/res/CreateReviewRes.java
@@ -1,0 +1,31 @@
+package com.palja.review_service.application.dto.res;
+
+import com.palja.review_service.domain.entity.Review;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+public class CreateReviewRes {
+
+    private UUID reviewId;
+    private String title;
+    private String content;
+    private BigDecimal rating;
+    private Boolean like;
+    private Boolean disLike;
+
+    public static CreateReviewRes fromEntity(Review review) {
+        CreateReviewRes res = new CreateReviewRes();
+
+        res.reviewId = review.getId();
+        res.title = review.getTitle();
+        res.content = review.getContent();
+        res.rating = review.getRating();
+        res.like = review.getLike();
+        res.disLike = review.getDislike();
+
+        return res;
+    }
+}

--- a/review-service/src/main/java/com/palja/review_service/application/service/ReviewService.java
+++ b/review-service/src/main/java/com/palja/review_service/application/service/ReviewService.java
@@ -1,0 +1,9 @@
+package com.palja.review_service.application.service;
+
+import com.palja.review_service.application.command.CreateReviewCommand;
+import com.palja.review_service.application.dto.res.CreateReviewRes;
+
+public interface ReviewService {
+
+    CreateReviewRes create(CreateReviewCommand createCommand);
+}

--- a/review-service/src/main/java/com/palja/review_service/application/service/impl/ReviewServiceImpl.java
+++ b/review-service/src/main/java/com/palja/review_service/application/service/impl/ReviewServiceImpl.java
@@ -1,0 +1,44 @@
+package com.palja.review_service.application.service.impl;
+
+import com.palja.review_service.application.command.CreateReviewCommand;
+import com.palja.review_service.application.dto.res.CreateReviewRes;
+import com.palja.review_service.application.service.ReviewService;
+import com.palja.review_service.domain.entity.Review;
+import com.palja.review_service.domain.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+
+    private final ReviewRepository repository;
+
+    @Override
+    public CreateReviewRes create(CreateReviewCommand createCommand) {
+
+        /**
+         * TODO : 로그인 아이디로 리뷰를 작성한 회원의 ID(Long)를 찾아와야함.
+         * TODO : 주문 아이디로 주문서비스에서 상품의 ID를 찾아와야함
+         */
+        //Long userId = UserClient.getId(createCommand.loginId());
+        //UUID orderProductId = OrderClient.getProductId(createCommand.orderId());
+        Long userId = 1L;
+        UUID orderProductId = UUID.randomUUID();
+        Review review = Review.create(createCommand.title(),
+                createCommand.content(),
+                createCommand.rating(),
+                createCommand.isLike(),
+                createCommand.disLike(),
+                userId,
+                createCommand.orderId(),
+                orderProductId);
+
+        Review saved = repository.save(review);
+        return  CreateReviewRes.fromEntity(saved);
+    }
+}

--- a/review-service/src/main/java/com/palja/review_service/domain/entity/Review.java
+++ b/review-service/src/main/java/com/palja/review_service/domain/entity/Review.java
@@ -42,14 +42,14 @@ public class Review {
 
     protected Review() {}
 
-    public static Review create(String title, String content, Long userId, UUID orderId, UUID productId) {
+    public static Review create(String title, String content, BigDecimal rating, Boolean isLike, Boolean dislike, Long userId, UUID orderId, UUID productId) {
         Review review = new Review();
 
         review.title = title;
         review.content = content;
-        review.rating = BigDecimal.ZERO;
-        review.like = false;
-        review.dislike = false;
+        review.rating = rating;
+        review.like = isLike;
+        review.dislike = dislike;
         review.userId = userId;
         review.orderId = orderId;
         review.productId = productId;

--- a/review-service/src/main/java/com/palja/review_service/domain/repository/ReviewRepository.java
+++ b/review-service/src/main/java/com/palja/review_service/domain/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.palja.review_service.domain.repository;
+
+import com.palja.review_service.domain.entity.Review;
+
+public interface ReviewRepository {
+
+    Review save(Review review);
+}

--- a/review-service/src/main/java/com/palja/review_service/infrastructure/repository/JpaReviewRepository.java
+++ b/review-service/src/main/java/com/palja/review_service/infrastructure/repository/JpaReviewRepository.java
@@ -1,0 +1,9 @@
+package com.palja.review_service.infrastructure.repository;
+
+import com.palja.review_service.domain.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface JpaReviewRepository extends JpaRepository<Review, UUID> {
+}

--- a/review-service/src/main/java/com/palja/review_service/infrastructure/repository/ReviewRepositoryAdapter.java
+++ b/review-service/src/main/java/com/palja/review_service/infrastructure/repository/ReviewRepositoryAdapter.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ReviewRepositoryAdaptor implements ReviewRepository {
+public class ReviewRepositoryAdapter implements ReviewRepository {
 
     private final JpaReviewRepository jpaReviewRepository;
 

--- a/review-service/src/main/java/com/palja/review_service/infrastructure/repository/ReviewRepositoryAdaptor.java
+++ b/review-service/src/main/java/com/palja/review_service/infrastructure/repository/ReviewRepositoryAdaptor.java
@@ -1,0 +1,18 @@
+package com.palja.review_service.infrastructure.repository;
+
+import com.palja.review_service.domain.entity.Review;
+import com.palja.review_service.domain.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewRepositoryAdaptor implements ReviewRepository {
+
+    private final JpaReviewRepository jpaReviewRepository;
+
+    @Override
+    public Review save(Review review) {
+        return jpaReviewRepository.save(review);
+    }
+}

--- a/review-service/src/main/java/com/palja/review_service/presentation/controller/ReviewController.java
+++ b/review-service/src/main/java/com/palja/review_service/presentation/controller/ReviewController.java
@@ -1,0 +1,38 @@
+package com.palja.review_service.presentation.controller;
+
+import com.palja.common.auditor.AuditorContext;
+import com.palja.common.response.ApiResponse;
+import com.palja.review_service.application.command.CreateReviewCommand;
+import com.palja.review_service.application.dto.res.CreateReviewRes;
+import com.palja.review_service.application.service.ReviewService;
+import com.palja.review_service.presentation.dto.req.CreateReviewReq;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService service;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateReviewRes>> createReview(@RequestBody @Valid CreateReviewReq createReq) {
+
+        String loginId = AuditorContext.get().getLoginId();
+        if(createReq.getIsLike().equals(Boolean.TRUE) && createReq.getIsLike().equals(createReq.getDisLike()))
+            throw new IllegalArgumentException();
+
+        CreateReviewCommand createCommand = createReq.toCommand(loginId);
+
+        CreateReviewRes res = service.create(createCommand);
+
+        return new ResponseEntity<>(ApiResponse.success(res, "리뷰 생성 성공"), HttpStatus.OK);
+    }
+}

--- a/review-service/src/main/java/com/palja/review_service/presentation/dto/req/CreateReviewReq.java
+++ b/review-service/src/main/java/com/palja/review_service/presentation/dto/req/CreateReviewReq.java
@@ -1,0 +1,41 @@
+package com.palja.review_service.presentation.dto.req;
+
+import com.palja.review_service.application.command.CreateReviewCommand;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateReviewReq {
+
+    @NotEmpty(message = "리뷰의 제목은 필수항목 입니다.")
+    private String title;
+
+    @NotEmpty(message = "리뷰의 내용은 필수항목 입니다.")
+    private String content;
+
+    @NotNull(message = "리뷰의 별점은 필수항목 입니다")
+    @DecimalMin(value = "0.0")
+    @DecimalMax(value = "5.0")
+    private BigDecimal rating;
+
+    private Boolean isLike;
+
+    private Boolean disLike;
+
+    @NotNull
+    private UUID orderId;
+
+    public CreateReviewCommand toCommand(String loginId) {
+        return new CreateReviewCommand(title, content, rating, isLike, disLike, orderId, loginId);
+    }
+}

--- a/review-service/src/test/java/com/palja/review_service/application/service/impl/ReviewServiceImplTest.java
+++ b/review-service/src/test/java/com/palja/review_service/application/service/impl/ReviewServiceImplTest.java
@@ -1,0 +1,65 @@
+package com.palja.review_service.application.service.impl;
+
+import com.palja.review_service.application.command.CreateReviewCommand;
+import com.palja.review_service.application.dto.res.CreateReviewRes;
+import com.palja.review_service.domain.entity.Review;
+import com.palja.review_service.domain.repository.ReviewRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceImplTest {
+
+    @InjectMocks
+    private ReviewServiceImpl reviewService;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Test
+    @DisplayName("리뷰 생성에 성공한다")
+    void create() {
+        //given
+        UUID orderId = UUID.randomUUID();
+        Long userId = 1L;
+        UUID orderProductIdId = UUID.randomUUID();
+        CreateReviewCommand createCommand = new CreateReviewCommand(
+                "리뷰", "내용", BigDecimal.ONE, Boolean.TRUE, Boolean.FALSE, orderId, "loginId"
+        );
+        Review review = Review.create(createCommand.title(),
+                createCommand.content(),
+                createCommand.rating(),
+                createCommand.isLike(),
+                createCommand.disLike(),
+                userId,
+                createCommand.orderId(),
+                orderProductIdId);
+
+        CreateReviewRes expected = CreateReviewRes.fromEntity(review);
+
+        given(reviewRepository.save(any(Review.class))).willReturn(review);
+
+        //when
+        CreateReviewRes result = reviewService.create(createCommand);
+
+        //then
+        assertThat(result.getTitle()).isEqualTo(expected.getTitle());
+        assertThat(result.getContent()).isEqualTo(expected.getContent());
+        assertThat(result.getRating()).isEqualTo(expected.getRating());
+        assertThat(result.getLike()).isEqualTo(expected.getLike());
+        assertThat(result.getDisLike()).isEqualTo(expected.getDisLike());
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #58 

<br>

## 📌 개요
- 리뷰를 생성해 DB에 저장합니다

<br>

## 🔁 변경 사항
1. Common 모듈 최신버전으로 적용했습니다.
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
1. 리뷰의 좋아요와 싫어요는 둘 다 False일 수는 있어도 둘 다 True일 수는 없다고 생각해 컨트롤러에 해당 부분 검증하는 코드 작성했습니다.
2. 로그인 아이디를 알고있으니 이 정보로 유저서비스에서 작성한 회원의 ID를 가져오려 생각중이지만, 아직 반영하지는 않았습니다.
3. 어떤 주문에 대한 리뷰일것이기 때문에 주문ID를 가져오기 편하다고 생각해 주문서비스에서 주문한 상품의 ID를 가져오려 생각중이지만, 아직 반영하지는 않았습니다.

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
