### PR TITLE
FEAT/쿠폰 조회 기능 구현 (목록 조회, 상세 조회)

### DIFF
--- a/coupon-service/build.gradle
+++ b/coupon-service/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'com.palja:common-module:0.3.6'
+    implementation 'com.palja:common-module:0.5.1'
 }
 
 dependencyManagement {

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponDetailRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponDetailRes.java
@@ -6,37 +6,48 @@ import com.palja.coupon_service.domain.vo.DiscountType;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
 @Builder
-public class CouponDTO {
+public class CouponDetailRes {
     private UUID couponId;
     private String couponName;
     private String description;
     private DiscountType discountType;
     private Integer discountValue;
     private Integer totalQuantity;
+    private Integer issuedQuantity;
     private Integer maxDiscountAmount;
     private Integer minOrderAmount;
     private LocalDateTime issueStartAt;
     private LocalDateTime issueEndAt;
     private CouponStatus status;
+    private Instant createdAt;
+    private String createdBy;
+    private Instant updatedAt;
+    private String updatedBy;
 
-    public static CouponDTO from(Coupon coupon) {
-        return CouponDTO.builder()
+    public static CouponDetailRes from(Coupon coupon) {
+        return CouponDetailRes.builder()
                 .couponId(coupon.getId())
                 .couponName(coupon.getName())
                 .description(coupon.getDescription())
                 .discountType(coupon.getDiscountPolicy().getDiscountType())
                 .discountValue(coupon.getDiscountPolicy().getDiscountValue())
                 .totalQuantity(coupon.getTotalQuantity())
+                .issuedQuantity(coupon.getIssuedQuantity())
                 .maxDiscountAmount(coupon.getAmountPolicy().getMaxDiscountAmount())
                 .minOrderAmount(coupon.getAmountPolicy().getMinOrderAmount())
                 .issueStartAt(coupon.getIssuePeriod().getIssueStartAt())
                 .issueEndAt(coupon.getIssuePeriod().getIssueEndAt())
                 .status(coupon.getStatus())
+                .createdAt(coupon.getCreatedAt())
+                .createdBy(coupon.getCreatedBy())
+                .updatedAt(coupon.getUpdatedAt())
+                .updatedBy(coupon.getUpdatedBy())
                 .build();
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponRes.java
@@ -1,0 +1,43 @@
+package com.palja.coupon_service.application.dto;
+
+import com.palja.coupon_service.domain.entity.Coupon;
+import com.palja.coupon_service.domain.vo.CouponStatus;
+import com.palja.coupon_service.domain.vo.DiscountType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CouponRes {
+    private UUID couponId;
+    private String couponName;
+    private String description;
+    private DiscountType discountType;
+    private Integer discountValue;
+    private Integer totalQuantity;
+    private Integer maxDiscountAmount;
+    private Integer minOrderAmount;
+    private LocalDateTime issueStartAt;
+    private LocalDateTime issueEndAt;
+    private CouponStatus status;
+
+    public static CouponRes from(Coupon coupon) {
+        return CouponRes.builder()
+                .couponId(coupon.getId())
+                .couponName(coupon.getName())
+                .description(coupon.getDescription())
+                .discountType(coupon.getDiscountPolicy().getDiscountType())
+                .discountValue(coupon.getDiscountPolicy().getDiscountValue())
+                .totalQuantity(coupon.getTotalQuantity())
+                .maxDiscountAmount(coupon.getAmountPolicy().getMaxDiscountAmount())
+                .minOrderAmount(coupon.getAmountPolicy().getMinOrderAmount())
+                .issueStartAt(coupon.getIssuePeriod().getIssueStartAt())
+                .issueEndAt(coupon.getIssuePeriod().getIssueEndAt())
+                .status(coupon.getStatus())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponManagerService.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponManagerService.java
@@ -1,9 +1,18 @@
 package com.palja.coupon_service.application.service;
 
 import com.palja.coupon_service.application.command.CreateCouponCommand;
-import com.palja.coupon_service.application.dto.CouponDTO;
+import com.palja.coupon_service.application.dto.CouponRes;
+import com.palja.coupon_service.application.dto.CouponDetailRes;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
 
 public interface CouponManagerService {
 
-    CouponDTO createCoupon(CreateCouponCommand command);
+    CouponRes createCoupon(CreateCouponCommand command);
+
+    Page<CouponRes> getCouponList(Pageable pageable);
+
+    CouponDetailRes getCouponDetail(UUID couponId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
@@ -1,17 +1,24 @@
 package com.palja.coupon_service.application.service.impl;
 
+import com.palja.common.exception.BusinessException;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
-import com.palja.coupon_service.application.dto.CouponDTO;
+import com.palja.coupon_service.application.dto.CouponRes;
+import com.palja.coupon_service.application.dto.CouponDetailRes;
 import com.palja.coupon_service.application.service.CouponManagerService;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.repository.CouponRepository;
 import com.palja.coupon_service.domain.vo.AmountPolicy;
 import com.palja.coupon_service.domain.vo.DiscountPolicy;
 import com.palja.coupon_service.domain.vo.IssuePeriod;
+import com.palja.coupon_service.exception.CouponErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -22,7 +29,7 @@ public class CouponManagerServiceImpl implements CouponManagerService {
 
     @Override
     @Transactional
-    public CouponDTO createCoupon(CreateCouponCommand command) {
+    public CouponRes createCoupon(CreateCouponCommand command) {
         log.info("쿠폰 생성 시작");
 
         Coupon coupon = Coupon.create(
@@ -36,6 +43,23 @@ public class CouponManagerServiceImpl implements CouponManagerService {
 
         Coupon savedCoupon = couponRepository.save(coupon);
 
-        return CouponDTO.from(savedCoupon);
+        return CouponRes.from(savedCoupon);
+    }
+
+    @Override
+    public Page<CouponRes> getCouponList(Pageable pageable) {
+        log.info("쿠폰 목록 조회 시작");
+        return couponRepository.findAllByDeletedAtIsNull(pageable)
+                .map(CouponRes::from);
+    }
+
+    @Override
+    public CouponDetailRes getCouponDetail(UUID couponId) {
+        log.info("쿠폰 조회 시작 - couponId={}", couponId);
+
+        Coupon coupon = couponRepository.findByIdAndDeletedAtIsNull(couponId)
+                .orElseThrow(() -> new BusinessException(CouponErrorCode.COUPON_NOT_FOUND));
+
+        return CouponDetailRes.from(coupon);
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponRepository.java
@@ -1,6 +1,8 @@
 package com.palja.coupon_service.domain.repository;
 
 import com.palja.coupon_service.domain.entity.Coupon;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -9,7 +11,9 @@ public interface CouponRepository {
 
     Coupon save(Coupon coupon);
 
-    Optional<Coupon> findById(UUID id);
+    Page<Coupon> findAllByDeletedAtIsNull(Pageable pageable);
+
+    Optional<Coupon> findByIdAndDeletedAtIsNull(UUID id);
 
     void delete(Coupon coupon);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponRepositoryAdaptor.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponRepositoryAdaptor.java
@@ -3,6 +3,8 @@ package com.palja.coupon_service.infrastructure.repository;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -20,8 +22,13 @@ public class CouponRepositoryAdaptor implements CouponRepository {
     }
 
     @Override
-    public Optional<Coupon> findById(UUID id) {
-        return jpaCouponRepository.findById(id);
+    public Page<Coupon> findAllByDeletedAtIsNull(Pageable pageable) {
+        return jpaCouponRepository.findAllByDeletedAtIsNull(pageable);
+    }
+
+    @Override
+    public Optional<Coupon> findByIdAndDeletedAtIsNull(UUID id) {
+        return jpaCouponRepository.findByIdAndDeletedAtIsNull(id);
     }
 
     @Override

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponRepository.java
@@ -1,11 +1,17 @@
 package com.palja.coupon_service.infrastructure.repository;
 
 import com.palja.coupon_service.domain.entity.Coupon;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface JpaCouponRepository extends JpaRepository<Coupon, UUID> {
+    Page<Coupon> findAllByDeletedAtIsNull(Pageable pageable);
+
+    Optional<Coupon> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
@@ -1,20 +1,25 @@
 package com.palja.coupon_service.presentation.controller;
 
 import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
-import com.palja.coupon_service.application.dto.CouponDTO;
+import com.palja.coupon_service.application.dto.CouponRes;
 import com.palja.coupon_service.application.service.CouponManagerService;
 import com.palja.coupon_service.presentation.dto.request.CreateCouponReq;
 import com.palja.coupon_service.presentation.dto.response.CreateCouponRes;
+import com.palja.coupon_service.presentation.dto.response.FindCouponDetailRes;
+import com.palja.coupon_service.presentation.dto.response.PagedCouponListRes;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -30,10 +35,30 @@ public class CouponManagerController {
         log.info("POST /api/v1/manager/coupons - 쿠폰 생성 요청");
         CreateCouponCommand command = CreateCouponReq.of(request);
 
-        CouponDTO couponDTO = couponManagerService.createCoupon(command);
+        CouponRes couponDTO = couponManagerService.createCoupon(command);
 
         CreateCouponRes couponRes = CreateCouponRes.from(couponDTO);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(couponRes, "쿠폰이 생성되었습니다."));
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<PagedCouponListRes>> getCouponList(Pageable pageable) {
+        log.info("GET /api/v1/manager/coupons - 쿠폰 목록 조회 요청");
+
+        Page<CouponRes> couponResPage = couponManagerService.getCouponList(pageable);
+
+        PageResponse<PagedCouponListRes> response = PageResponse.from(couponResPage.map(PagedCouponListRes::from));
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{couponId}")
+    public ResponseEntity<ApiResponse<FindCouponDetailRes>> getCouponDetail(@PathVariable UUID couponId) {
+        log.info("GET /api/v1/manager/coupons/{} - 쿠폰 상세 조회 요청", couponId);
+
+        FindCouponDetailRes response = FindCouponDetailRes.from(couponManagerService.getCouponDetail(couponId));
+
+        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 상세 조회"));
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
@@ -26,7 +26,7 @@ public class CreateCouponReq {
     private String description;
 
     @NotNull(message = "쿠폰 타입은 필수입니다.")
-    private DiscountType discountType;
+    private String discountType;
 
     @NotNull(message = "할인율은 필수입니다.")
     @Min(value = 1)
@@ -43,11 +43,11 @@ public class CreateCouponReq {
     @Future(message = "발급 종료일은 현재 시간 이후여야 합니다")
     private LocalDateTime issueEndAt;
 
-    public static CreateCouponCommand of (CreateCouponReq request) {
+    public static CreateCouponCommand of(CreateCouponReq request) {
         return CreateCouponCommand.builder()
                 .couponName(request.getCouponName())
                 .description(request.getDescription())
-                .discountType(request.getDiscountType())
+                .discountType(DiscountType.valueOf(request.getDiscountType().toUpperCase()))
                 .discountValue(request.getDiscountValue())
                 .totalQuantity(request.getTotalQuantity())
                 .maxDiscountAmount(request.getMaxDiscountAmount())

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/response/FindCouponDetailRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/response/FindCouponDetailRes.java
@@ -1,0 +1,57 @@
+package com.palja.coupon_service.presentation.dto.response;
+
+import com.palja.coupon_service.application.dto.CouponDetailRes;
+import com.palja.coupon_service.domain.vo.CouponStatus;
+import com.palja.coupon_service.domain.vo.DiscountType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindCouponDetailRes {
+    private UUID couponId;
+    private String couponName;
+    private String description;
+    private DiscountType discountType;
+    private Integer discountValue;
+    private Integer totalQuantity;
+    private Integer issuedQuantity;
+    private Integer maxDiscountAmount;
+    private Integer minOrderAmount;
+    private LocalDateTime issueStartAt;
+    private LocalDateTime issueEndAt;
+    private CouponStatus status;
+    private Instant createdAt;
+    private String createdBy;
+    private Instant updatedAt;
+    private String updatedBy;
+
+    public static FindCouponDetailRes from(CouponDetailRes couponDetailRes) {
+        return FindCouponDetailRes.builder()
+                .couponId(couponDetailRes.getCouponId())
+                .couponName(couponDetailRes.getCouponName())
+                .description(couponDetailRes.getDescription())
+                .discountType(couponDetailRes.getDiscountType())
+                .discountValue(couponDetailRes.getDiscountValue())
+                .totalQuantity(couponDetailRes.getTotalQuantity())
+                .issuedQuantity(couponDetailRes.getIssuedQuantity())
+                .maxDiscountAmount(couponDetailRes.getMaxDiscountAmount())
+                .minOrderAmount(couponDetailRes.getMinOrderAmount())
+                .issueStartAt(couponDetailRes.getIssueStartAt())
+                .issueEndAt(couponDetailRes.getIssueEndAt())
+                .status(couponDetailRes.getStatus())
+                .createdAt(couponDetailRes.getCreatedAt())
+                .createdBy(couponDetailRes.getCreatedBy())
+                .updatedAt(couponDetailRes.getUpdatedAt())
+                .updatedBy(couponDetailRes.getUpdatedBy())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/response/PagedCouponListRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/response/PagedCouponListRes.java
@@ -3,7 +3,10 @@ package com.palja.coupon_service.presentation.dto.response;
 import com.palja.coupon_service.application.dto.CouponRes;
 import com.palja.coupon_service.domain.vo.CouponStatus;
 import com.palja.coupon_service.domain.vo.DiscountType;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -12,7 +15,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateCouponRes {
+public class PagedCouponListRes {
     private UUID couponId;
     private String couponName;
     private DiscountType discountType;
@@ -21,8 +24,8 @@ public class CreateCouponRes {
     private LocalDateTime issueEndAt;
     private CouponStatus status;
 
-    public static CreateCouponRes from(CouponRes couponRes) {
-        return CreateCouponRes.builder()
+    public static PagedCouponListRes from(CouponRes couponRes) {
+        return PagedCouponListRes.builder()
                 .couponId(couponRes.getCouponId())
                 .couponName(couponRes.getCouponName())
                 .discountType(couponRes.getDiscountType())

--- a/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
+++ b/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.palja.coupon_service.application.service.impl;
 
 import com.palja.coupon_service.application.command.CreateCouponCommand;
-import com.palja.coupon_service.application.dto.CouponDTO;
+import com.palja.coupon_service.application.dto.CouponRes;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.repository.CouponRepository;
 import com.palja.coupon_service.domain.vo.*;
@@ -58,7 +58,7 @@ class CouponManagerServiceImplTest {
         given(couponRepository.save(any(Coupon.class))).willReturn(savedCoupon);
 
         // when
-        CouponDTO result = couponManagerService.createCoupon(command);
+        CouponRes result = couponManagerService.createCoupon(command);
 
         // then
         assertThat(result).isNotNull();


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토리링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #57 

<br>

## 📌 개요
관리자가 등록된 쿠폰을 조회할 수 있는 기능을 구현했습니다. 

<br>

## 🔁 변경 사항

### 1. 도메인 계층
- **CouponRepository**: 페이징 목록 조회 및 단건 조회 추가

### 2. 애플리케이션 계층
- **CouponDTO → CouponRes 리네이밍**: 응답 목적에 맞게 네이밍 변경
- **CouponDetailRes 추가**: 상세 조회용 DTO
- **CouponManagerService**: 쿠폰 목록 조회, 상세 조회 메서드 추가

### 3. 인프라 계층
- **JpaCouponRepository**: 페이징 목록 조회 및 단건 조회 추가
- **CouponRepositoryAdapter**: 리포지토리 인터페이스 구현체 업데이트

### 4. 프레젠테이션 계층
- **CouponManagerController**: 
  - `GET /api/v1/manager/coupons` - 쿠폰 목록 조회 (페이징)
  - `GET /api/v1/manager/coupons/{couponId}` - 쿠폰 상세 조회
- **PagedCouponListRes**: 목록 조회용 응답 DTO
- **FindCouponDetailRes**: 상세 조회용 응답 DTO
- **CreateCouponReq**: discountType 필드를 String으로 변경 후 Enum 변환 처리

<br>

## 📸 스크린샷

<details>
  <summary>쿠폰 목록 조회 API</summary>
  
<img width="1077" height="765" alt="image" src="https://github.com/user-attachments/assets/706af412-74bb-4d8a-ae1d-dfe5800a1977" />

</details>

<details>
  <summary>쿠폰 상세 조회 API</summary>
  
<img width="1067" height="725" alt="image" src="https://github.com/user-attachments/assets/0038f003-f32d-4f34-8d8f-975cd21f897c" />

</details>

<br>

## 👀 기타 더 이야기해볼 점
- 현재 쿠폰 생성 시 쿠폰명 중복 검증이 안되어있어서 이는 추후 추가하겠습니다
<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.