### PR TITLE
FEAT/ UserService 커스텀 예외 코드 생성 및 컨트롤러 메서드 권한 별 접근 제어

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.palja:common-module:0.5.4'
+    implementation 'com.palja:common-module:0.5.5'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.palja:common-module:0.5.5'
+    implementation 'com.palja:common-module:0.5.6'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/user-service/src/main/java/com/palja/user_service/application/exception/AuthErrorCode.java
+++ b/user-service/src/main/java/com/palja/user_service/application/exception/AuthErrorCode.java
@@ -1,0 +1,22 @@
+package com.palja.user_service.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.palja.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+	INVALID_USER_INFO(HttpStatus.UNAUTHORIZED, "로그인 정보가 잘못되었습니다."),
+	USER_STATUS_PENDING(HttpStatus.UNAUTHORIZED, "가입 승인 대기 중인 계정입니다."),
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "다시 로그인해주세요.")
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/palja/user_service/application/exception/UserErrorCode.java
@@ -1,0 +1,22 @@
+package com.palja.user_service.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.palja.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+	DUPLICATED_LOGIN_ID(HttpStatus.CONFLICT, "이미 존재하는 로그인 아이디입니다."),
+	DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/AuthService.java
@@ -9,6 +9,6 @@ public interface AuthService {
 
 	String refreshAccessToken(String accessToken, String refreshToken);
 
-	void logout(String loginId, String accessToken);
+	void logout(String currentUserLoginId, String accessToken);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -1,7 +1,5 @@
 package com.palja.user_service.application.service;
 
-import java.util.UUID;
-
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
@@ -10,6 +8,6 @@ public interface CompanyUserService {
 
 	CreateUserRes createCompanyUser(CreateCompanyUserCommand command);
 
-	void updateCompanyUserStatus(UUID companyUserId, UpdateCompanyUserStatusCommand command);
+	void updateCompanyUserStatus(String currentUserLoginId, String loginId, UpdateCompanyUserStatusCommand command);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
@@ -5,6 +5,6 @@ import com.palja.user_service.application.dto.response.CreateUserRes;
 
 public interface ManagerService {
 
-	CreateUserRes createManager(CreateManagerCommand command);
+	CreateUserRes createManager(String currentUserLoginId, CreateManagerCommand command);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
@@ -73,11 +73,11 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public void logout(String loginId, String accessToken) {
-		getUserByLoginId(loginId);
+	public void logout(String currentUserLoginId, String accessToken) {
+		getUserByLoginId(currentUserLoginId);
 
-		addAccessTokenToBlackList(loginId, accessToken);
-		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + loginId);
+		addAccessTokenToBlackList(currentUserLoginId, accessToken);
+		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + currentUserLoginId);
 	}
 
 	private User getUserByLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/AuthServiceImpl.java
@@ -9,9 +9,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.palja.common.exception.BusinessException;
-import com.palja.common.exception.CommonErrorCode;
 import com.palja.user_service.application.command.LoginUserCommand;
 import com.palja.user_service.application.dto.response.TokenRes;
+import com.palja.user_service.application.exception.AuthErrorCode;
 import com.palja.user_service.application.service.AuthService;
 import com.palja.user_service.application.util.JwtUtil;
 import com.palja.user_service.domain.entity.User;
@@ -82,25 +82,25 @@ public class AuthServiceImpl implements AuthService {
 
 	private User getUserByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
-			() -> new BusinessException(CommonErrorCode.NOT_FOUND)
+			() -> new BusinessException(AuthErrorCode.INVALID_USER_INFO)
 		);
 	}
 
 	private void validateUserPassword(String password, String userPassword) {
 		if (!passwordEncoder.matches(password, userPassword)) {
-			throw new IllegalArgumentException("로그인 정보가 잘못되었습니다.");
+			throw new BusinessException(AuthErrorCode.INVALID_USER_INFO);
 		}
 	}
 
 	private void validateUserStatus(User user) {
 		if (user.getStatus().equals(UserStatus.PENDING)) {
-			throw new IllegalArgumentException("가입 승인 대기 상태인 계정입니다.");
+			throw new BusinessException(AuthErrorCode.USER_STATUS_PENDING);
 		}
 	}
 
 	private void validateRefreshToken(String refreshToken) {
 		if (refreshToken == null || !jwtUtil.validateRefreshToken(refreshToken)) {
-			throw new IllegalArgumentException("다시 로그인 해주세요.");
+			throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
 		}
 	}
 
@@ -108,7 +108,7 @@ public class AuthServiceImpl implements AuthService {
 		String redisRefreshToken = tokenRepository.get(REFRESH_TOKEN_WHITELIST_PREFIX + loginId);
 
 		if (!redisRefreshToken.equals(refreshToken)) {
-			throw new IllegalArgumentException("다시 로그인 해주세요.");
+			throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -8,11 +8,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.palja.common.auditor.AuditorContext;
 import com.palja.common.exception.BusinessException;
-import com.palja.common.exception.CommonErrorCode;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CompanyUserService;
 import com.palja.user_service.domain.entity.CompanyUser;
 import com.palja.user_service.domain.entity.User;
@@ -65,20 +65,19 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 
 	private CompanyUser getCompanyUserById(UUID companyUserId) {
 		return companyUserRepository.findByIdAndDeletedAtIsNull(companyUserId).orElseThrow(
-			() -> new BusinessException(CommonErrorCode.DOMAIN_ERROR)
+			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
 		);
 	}
 
-	// TODO: 예외코드 생성
 	private void validateDuplicateLoginId(String loginId) {
 		if (userRepository.existsByLoginIdAndDeletedAtIsNull(loginId)) {
-			throw new BusinessException(CommonErrorCode.DOMAIN_ERROR);
+			throw new BusinessException(UserErrorCode.DUPLICATED_LOGIN_ID);
 		}
 	}
 
 	private void validateDuplicateEmail(String email) {
 		if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
-			throw new BusinessException(CommonErrorCode.DOMAIN_ERROR);
+			throw new BusinessException(UserErrorCode.DUPLICATED_EMAIL);
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -58,9 +58,17 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 
 	@Override
 	@Transactional
-	public void updateCompanyUserStatus(UUID companyUserId, UpdateCompanyUserStatusCommand command) {
-		CompanyUser companyUser = getCompanyUserById(companyUserId);
+	public void updateCompanyUserStatus(String currentUserLoginId, String loginId, UpdateCompanyUserStatusCommand command) {
+		getUserByLoginId(currentUserLoginId);
+
+		User companyUser = getUserByLoginId(loginId);
 		companyUser.updateStatus(command.status());
+	}
+
+	private User getUserByLoginId(String loginId) {
+		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
+			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
+		);
 	}
 
 	private CompanyUser getCompanyUserById(UUID companyUserId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -6,10 +6,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.palja.common.auditor.AuditorContext;
 import com.palja.common.exception.BusinessException;
-import com.palja.common.exception.CommonErrorCode;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CustomerService;
 import com.palja.user_service.domain.entity.User;
 import com.palja.user_service.domain.repository.UserRepository;
@@ -44,16 +44,15 @@ public class CustomerServiceImpl implements CustomerService {
 		return CreateUserRes.from(user);
 	}
 
-	// TODO: 예외코드 생성
 	private void validateDuplicateLoginId(String loginId) {
 		if (userRepository.existsByLoginIdAndDeletedAtIsNull(loginId)) {
-			throw new BusinessException(CommonErrorCode.DOMAIN_ERROR);
+			throw new BusinessException(UserErrorCode.DUPLICATED_LOGIN_ID);
 		}
 	}
 
 	private void validateDuplicateEmail(String email) {
 		if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
-			throw new BusinessException(CommonErrorCode.DOMAIN_ERROR);
+			throw new BusinessException(UserErrorCode.DUPLICATED_EMAIL);
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -25,7 +25,8 @@ public class ManagerServiceImpl implements ManagerService {
 
 	@Override
 	@Transactional
-	public CreateUserRes createManager(CreateManagerCommand command) {
+	public CreateUserRes createManager(String currentUserLoginId, CreateManagerCommand command) {
+		getUserByLoginId(currentUserLoginId);
 		validateDuplicateLoginId(command.loginId());
 		validateDuplicateEmail(command.email());
 
@@ -42,6 +43,12 @@ public class ManagerServiceImpl implements ManagerService {
 		userRepository.save(user);
 
 		return CreateUserRes.from(user);
+	}
+
+	private User getUserByLoginId(String loginId) {
+		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
+			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
+		);
 	}
 
 	private void validateDuplicateLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -6,10 +6,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.palja.common.auditor.AuditorContext;
 import com.palja.common.exception.BusinessException;
-import com.palja.common.exception.CommonErrorCode;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateManagerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.ManagerService;
 import com.palja.user_service.domain.entity.User;
 import com.palja.user_service.domain.repository.UserRepository;
@@ -44,16 +44,15 @@ public class ManagerServiceImpl implements ManagerService {
 		return CreateUserRes.from(user);
 	}
 
-	// TODO: 예외코드 생성
 	private void validateDuplicateLoginId(String loginId) {
 		if (userRepository.existsByLoginIdAndDeletedAtIsNull(loginId)) {
-			throw new BusinessException(CommonErrorCode.DOMAIN_ERROR);
+			throw new BusinessException(UserErrorCode.DUPLICATED_LOGIN_ID);
 		}
 	}
 
 	private void validateDuplicateEmail(String email) {
 		if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
-			throw new BusinessException(CommonErrorCode.DOMAIN_ERROR);
+			throw new BusinessException(UserErrorCode.DUPLICATED_EMAIL);
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -1,7 +1,5 @@
 package com.palja.user_service.presentation.controller;
 
-import java.util.UUID;
-
 import org.springframework.http.ResponseEntity;
 
 import com.palja.common.response.ApiResponse;
@@ -13,6 +11,6 @@ public interface CompanyUserController {
 
 	ResponseEntity<ApiResponse<CreateUserRes>> create(CreateCompanyUserReq requestDto);
 
-	ResponseEntity<ApiResponse<Void>> updateStatus(UUID companyUserId, UpdateCompanyUserStatusReq requestDto);
+	ResponseEntity<ApiResponse<Void>> updateStatus(String loginId, UpdateCompanyUserStatusReq requestDto);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/AuthControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/AuthControllerImpl.java
@@ -14,8 +14,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.palja.common.auditor.AuditorContext;
+import com.palja.common.annotation.RequiredAnonymous;
+import com.palja.common.annotation.RequiredRole;
+import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
+import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.LoginUserCommand;
 import com.palja.user_service.application.dto.response.TokenRes;
 import com.palja.user_service.application.service.AuthService;
@@ -34,6 +37,7 @@ public class AuthControllerImpl implements AuthController {
 	private final AuthService authService;
 
 	@Override
+	@RequiredAnonymous
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LoginUserReq requestDto, HttpServletResponse response) {
 		LoginUserCommand command = LoginUserReq.of(requestDto);
@@ -64,13 +68,14 @@ public class AuthControllerImpl implements AuthController {
 	}
 
 	@Override
+	@RequiredRole({UserRole.MASTER, UserRole.MANAGER, UserRole.CUSTOMER, UserRole.COMPANY_USER})
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<Void>> logout(
 		@RequestHeader("Authorization") String accessToken, HttpServletResponse response
 	) {
-		String loginId = AuditorContext.get().getLoginId();
+		String currentUserLoginId = CurrentUser.getLoginId();
 
-		authService.logout(loginId, accessToken);
+		authService.logout(currentUserLoginId, accessToken);
 		addRefreshTokenToCookie(response, "", 0);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("로그아웃 되었습니다."));

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -1,7 +1,5 @@
 package com.palja.user_service.presentation.controller.impl;
 
-import java.util.UUID;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,7 +9,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.palja.common.annotation.RequiredAnonymous;
+import com.palja.common.annotation.RequiredRole;
+import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
+import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
@@ -31,6 +33,7 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 	private final CompanyUserService companyUserService;
 
 	@Override
+	@RequiredAnonymous
 	@PostMapping
 	public ResponseEntity<ApiResponse<CreateUserRes>> create(@Valid @RequestBody CreateCompanyUserReq requestDto) {
 		CreateCompanyUserCommand command = CreateCompanyUserReq.of(requestDto);
@@ -40,12 +43,15 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 	}
 
 	@Override
-	@PutMapping("/{companyUserId}/status")
+	@RequiredRole({UserRole.MASTER, UserRole.MANAGER})
+	@PutMapping("/{loginId}/status")
 	public ResponseEntity<ApiResponse<Void>> updateStatus(
-		@PathVariable("companyUserId") UUID companyUserId, @Valid @RequestBody UpdateCompanyUserStatusReq requestDto
+		@PathVariable("loginId") String loginId, @Valid @RequestBody UpdateCompanyUserStatusReq requestDto
 	) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
 		UpdateCompanyUserStatusCommand command = UpdateCompanyUserStatusReq.of(requestDto);
-		companyUserService.updateCompanyUserStatus(companyUserId, command);
+		companyUserService.updateCompanyUserStatus(currentUserLoginId, loginId, command);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("업체 판매자의 상태가 수정되었습니다."));
 	}

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.palja.common.annotation.RequiredAnonymous;
 import com.palja.common.response.ApiResponse;
 import com.palja.user_service.application.command.CreateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
@@ -25,6 +26,7 @@ public class CustomerControllerImpl implements CustomerController {
 	private final CustomerService customerService;
 
 	@Override
+	@RequiredAnonymous
 	@PostMapping
 	public ResponseEntity<ApiResponse<CreateUserRes>> create(@Valid @RequestBody CreateCustomerReq requestDto) {
 		CreateCustomerCommand command = CreateCustomerReq.of(requestDto);

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
@@ -7,7 +7,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.palja.common.annotation.RequiredRole;
+import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
+import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateManagerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.service.ManagerService;
@@ -25,10 +28,13 @@ public class ManagerControllerImpl implements ManagerController {
 	private final ManagerService managerService;
 
 	@Override
+	@RequiredRole({UserRole.MASTER})
 	@PostMapping
 	public ResponseEntity<ApiResponse<CreateUserRes>> create(@Valid @RequestBody CreateManagerReq requestDto) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
 		CreateManagerCommand command = CreateManagerReq.of(requestDto);
-		CreateUserRes responseDto = managerService.createManager(command);
+		CreateUserRes responseDto = managerService.createManager(currentUserLoginId, command);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(responseDto, "관리자가 생성되었습니다."));
 	}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #68 

<br>

## 📌 개요
- 커스텀 예외 코드 생성 및 컨트롤러 메서드 권한 별 접근 제어

<br>

## 🔁 변경 사항
- 커스텀 예외 코드를 생성해서 예외가 발생했을때 BusinessException을 던지도록 수정
- @RequiredAnonymous와 @RequiredRole를 사용해서 접근 권한 제어

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
지금 @RequiredAnonymous를 사용하면 로그인한 사용자도 접근이 가능한 상태인데 게이트웨이와 common 모듈을 수정해야 하는 문제라 현재 PR에 작성된 코드에는 문제가 없습니다!

마찬가지로 관리자 생성할 때 @RequiredRole({UserRole.MASTER})를 적용했는데 예외가 발생하는데 이것도 게이트웨이에서 해당 경로를 그냥 통과시키도록 설정해놔서 발생하는 문제여서 게이트웨이와 common 모듈 수정해놓도록 하겠습니다.

그리고 블랙리스트에 등록된 액세스 토큰도 계속 사용할 수 있는 상태인데 게이트웨이에 필터에 토큰 블랙리스트를 확인하는 로직이 빠져있어서 이 부분도 다음 PR에서 추가해놓겠습니다. 


<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
