### PR TITLE
FEAT/쿠폰 상태 변경 기능 및 권한 검증 구현

### DIFF
--- a/coupon-service/src/main/java/com/palja/coupon_service/application/command/ChangeCouponStatusCommand.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/command/ChangeCouponStatusCommand.java
@@ -1,0 +1,13 @@
+package com.palja.coupon_service.application.command;
+
+import com.palja.coupon_service.domain.vo.CouponStatus;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record ChangeCouponStatusCommand(
+        UUID couponId,
+        CouponStatus status
+) {
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/command/ChangeCouponStatusCommand.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/command/ChangeCouponStatusCommand.java
@@ -1,6 +1,5 @@
 package com.palja.coupon_service.application.command;
 
-import com.palja.coupon_service.domain.vo.CouponStatus;
 import lombok.Builder;
 
 import java.util.UUID;
@@ -8,6 +7,6 @@ import java.util.UUID;
 @Builder
 public record ChangeCouponStatusCommand(
         UUID couponId,
-        CouponStatus status
+        String status
 ) {
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/command/CreateCouponCommand.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/command/CreateCouponCommand.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public record CreateCouponCommand(
         String couponName,
         String description,
-        DiscountType discountType,
+        String discountType,
         Integer discountValue,
         Integer totalQuantity,
         Integer maxDiscountAmount,

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponManagerService.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponManagerService.java
@@ -1,5 +1,6 @@
 package com.palja.coupon_service.application.service;
 
+import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
 import com.palja.coupon_service.application.command.UpdateCouponCommand;
 import com.palja.coupon_service.application.dto.CouponRes;
@@ -15,7 +16,10 @@ public interface CouponManagerService {
 
     CouponRes updateCoupon(UpdateCouponCommand command);
 
+    CouponRes changeCouponStatus(ChangeCouponStatusCommand command);
+
     Page<CouponRes> getCouponList(Pageable pageable);
 
     CouponDetailRes getCouponDetail(UUID couponId);
+
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
@@ -9,10 +9,7 @@ import com.palja.coupon_service.application.dto.CouponDetailRes;
 import com.palja.coupon_service.application.service.CouponManagerService;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.repository.CouponRepository;
-import com.palja.coupon_service.domain.vo.AmountPolicy;
-import com.palja.coupon_service.domain.vo.CouponStatus;
-import com.palja.coupon_service.domain.vo.DiscountPolicy;
-import com.palja.coupon_service.domain.vo.IssuePeriod;
+import com.palja.coupon_service.domain.vo.*;
 import com.palja.coupon_service.exception.CouponErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +37,7 @@ public class CouponManagerServiceImpl implements CouponManagerService {
         Coupon coupon = Coupon.create(
                 command.couponName(),
                 command.description(),
-                DiscountPolicy.of(command.discountType(), command.discountValue()),
+                DiscountPolicy.of(DiscountType.valueOf(command.discountType().toUpperCase()), command.discountValue()),
                 command.totalQuantity(),
                 AmountPolicy.of(command.maxDiscountAmount(), command.minOrderAmount()),
                 IssuePeriod.of(command.issueStartAt(), command.issueEndAt())
@@ -86,7 +83,7 @@ public class CouponManagerServiceImpl implements CouponManagerService {
 
         CouponStatus oldStatus = coupon.getStatus();
 
-        coupon.changeStatus(command.status());
+        coupon.changeStatus(CouponStatus.valueOf(command.status().toUpperCase()));
 
         log.info("쿠폰 상태 변경 완료 - couponId={} status={} -> {}", command.couponId(), oldStatus, command.status());
         return CouponRes.from(coupon);

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
@@ -33,6 +33,8 @@ public class CouponManagerServiceImpl implements CouponManagerService {
     public CouponRes createCoupon(CreateCouponCommand command) {
         log.info("쿠폰 생성 시작");
 
+        validateCouponNameDuplicate(command.couponName());
+
         Coupon coupon = Coupon.create(
                 command.couponName(),
                 command.description(),
@@ -55,6 +57,8 @@ public class CouponManagerServiceImpl implements CouponManagerService {
 
         Coupon coupon = couponRepository.findByIdAndDeletedAtIsNull(command.couponId())
                 .orElseThrow(() -> new BusinessException(CouponErrorCode.COUPON_NOT_FOUND));
+
+        validateCouponNameDuplicate(command.couponName());
 
         coupon.update(
                 command.couponName(),
@@ -85,5 +89,13 @@ public class CouponManagerServiceImpl implements CouponManagerService {
                 .orElseThrow(() -> new BusinessException(CouponErrorCode.COUPON_NOT_FOUND));
 
         return CouponDetailRes.from(coupon);
+    }
+
+    // 쿠폰명 중복 체크
+    private void validateCouponNameDuplicate(String couponName) {
+        if (couponRepository.existsByNameAndDeletedAtIsNull(couponName)) {
+            log.warn("쿠폰명 중복 - couponName: {}", couponName);
+            throw new BusinessException(CouponErrorCode.DUPLICATE_COUPON_NAME);
+        }
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
@@ -1,6 +1,7 @@
 package com.palja.coupon_service.application.service.impl;
 
 import com.palja.common.exception.BusinessException;
+import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
 import com.palja.coupon_service.application.command.UpdateCouponCommand;
 import com.palja.coupon_service.application.dto.CouponRes;
@@ -9,6 +10,7 @@ import com.palja.coupon_service.application.service.CouponManagerService;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.repository.CouponRepository;
 import com.palja.coupon_service.domain.vo.AmountPolicy;
+import com.palja.coupon_service.domain.vo.CouponStatus;
 import com.palja.coupon_service.domain.vo.DiscountPolicy;
 import com.palja.coupon_service.domain.vo.IssuePeriod;
 import com.palja.coupon_service.exception.CouponErrorCode;
@@ -71,6 +73,22 @@ public class CouponManagerServiceImpl implements CouponManagerService {
         );
 
         log.info("쿠폰 수정 완료 - couponId={}", command.couponId());
+        return CouponRes.from(coupon);
+    }
+
+    @Override
+    @Transactional
+    public CouponRes changeCouponStatus(ChangeCouponStatusCommand command) {
+        log.info("쿠폰 상태 변경 시작 - couponId={} status={}", command.couponId(), command.status());
+
+        Coupon coupon = couponRepository.findByIdAndDeletedAtIsNull(command.couponId())
+                .orElseThrow(() -> new BusinessException(CouponErrorCode.COUPON_NOT_FOUND));
+
+        CouponStatus oldStatus = coupon.getStatus();
+
+        coupon.changeStatus(command.status());
+
+        log.info("쿠폰 상태 변경 완료 - couponId={} status={} -> {}", command.couponId(), oldStatus, command.status());
         return CouponRes.from(coupon);
     }
 

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/entity/Coupon.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/entity/Coupon.java
@@ -105,6 +105,15 @@ public class Coupon extends BaseEntity {
         }
     }
 
+    public void changeStatus(CouponStatus newStatus) {
+        validateStatusTransition(newStatus);
+
+        if (newStatus == CouponStatus.DELETED)
+            softDelete();
+
+        this.status = newStatus;
+    }
+
     // 필수 필드 검증
     private static void validateRequiredFields(String name) {
         if (name == null || name.isBlank())
@@ -136,5 +145,12 @@ public class Coupon extends BaseEntity {
     private void validateTotalQuantityUpdate(Integer newTotalQuantity) {
         if (this.issuedQuantity != null && newTotalQuantity < this.issuedQuantity)
             throw new BusinessException(CouponErrorCode.INVALID_QUANTITY);
+    }
+
+    // 쿠폰 상태 변경 검증
+    private void validateStatusTransition(CouponStatus newStatus) {
+        if (!this.status.canTransitionTo(newStatus)) {
+            throw new BusinessException(CouponErrorCode.INVALID_STATUS_TRANSITION);
+        }
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponRepository.java
@@ -16,4 +16,6 @@ public interface CouponRepository {
     Optional<Coupon> findByIdAndDeletedAtIsNull(UUID id);
 
     void delete(Coupon coupon);
+
+    boolean existsByNameAndDeletedAtIsNull(String couponName);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/vo/CouponStatus.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/vo/CouponStatus.java
@@ -1,8 +1,40 @@
 package com.palja.coupon_service.domain.vo;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum CouponStatus {
-    ACTIVE,
-    PAUSED,
-    EXPIRED,
-    DELETED
+    ACTIVE("활성") {
+        @Override
+        public boolean canTransitionTo(CouponStatus newStatus) {
+            return newStatus == PAUSED || newStatus == EXPIRED || newStatus == DELETED;
+        }
+    },
+    PAUSED("일시정지") {
+        @Override
+        public boolean canTransitionTo(CouponStatus newStatus) {
+            return newStatus == ACTIVE || newStatus == EXPIRED || newStatus == DELETED;
+        }
+    },
+    EXPIRED("만료") {
+        @Override
+        public boolean canTransitionTo(CouponStatus newStatus) {
+            return newStatus == DELETED;
+        }
+    },
+    DELETED("삭제") {
+        @Override
+        public boolean canTransitionTo(CouponStatus newStatus) {
+            return false;
+        }
+    },
+
+    ;
+
+    private final String description;
+
+    // 특정 상태로 전환 가능한지 확인
+    public abstract boolean canTransitionTo(CouponStatus newStatus);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/exception/CouponErrorCode.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/exception/CouponErrorCode.java
@@ -39,6 +39,9 @@ public enum CouponErrorCode implements ErrorCode {
     CANNOT_MODIFY_DELETED_OR_EXPIRED_COUPON(HttpStatus.BAD_REQUEST, "삭제되거나 만료된 쿠폰은 수정할 수 없습니다."),
     CANNOT_MODIFY_ISSUED_COUPON(HttpStatus.BAD_REQUEST, "발급 중인 쿠폰은 수정할 수 없습니다."),
     CANNOT_DELETE_ISSUED_COUPON(HttpStatus.BAD_REQUEST, "이미 발급된 쿠폰은 삭제할 수 없습니다."),
+    INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 상태 전환입니다."),
+    CANNOT_ACTIVATE_EXPIRED_COUPON(HttpStatus.BAD_REQUEST, "만료된 쿠폰은 활성화할 수 없습니다."),
+    CANNOT_PAUSE_DELETED_COUPON(HttpStatus.BAD_REQUEST, "삭제된 쿠폰은 일시정지할 수 없습니다."),
 
     // 권한 관련
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "쿠폰 관리 권한이 없습니다.");;

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponRepositoryAdaptor.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponRepositoryAdaptor.java
@@ -35,4 +35,9 @@ public class CouponRepositoryAdaptor implements CouponRepository {
     public void delete(Coupon coupon) {
         jpaCouponRepository.delete(coupon);
     }
+
+    @Override
+    public boolean existsByNameAndDeletedAtIsNull(String couponName) {
+        return jpaCouponRepository.existsByNameAndDeletedAtIsNull(couponName);
+    }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponRepository.java
@@ -14,4 +14,6 @@ public interface JpaCouponRepository extends JpaRepository<Coupon, UUID> {
     Page<Coupon> findAllByDeletedAtIsNull(Pageable pageable);
 
     Optional<Coupon> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByNameAndDeletedAtIsNull(String couponName);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
@@ -5,12 +5,15 @@ import com.palja.common.exception.BusinessException;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
+import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
 import com.palja.coupon_service.application.command.UpdateCouponCommand;
 import com.palja.coupon_service.application.dto.CouponDetailRes;
 import com.palja.coupon_service.application.dto.CouponRes;
 import com.palja.coupon_service.application.service.CouponManagerService;
+import com.palja.coupon_service.domain.vo.CouponStatus;
 import com.palja.coupon_service.exception.CouponErrorCode;
+import com.palja.coupon_service.presentation.dto.request.ChangeCouponStatusReq;
 import com.palja.coupon_service.presentation.dto.request.CreateCouponReq;
 import com.palja.coupon_service.presentation.dto.request.UpdateCouponReq;
 import jakarta.validation.Valid;
@@ -55,7 +58,21 @@ public class CouponManagerController {
 
         CouponRes couponRes = couponManagerService.updateCoupon(command);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(couponRes, "쿠폰이 수정되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success(couponRes, "쿠폰이 수정되었습니다."));
+    }
+
+    @PutMapping("/{couponId}/status")
+    public ResponseEntity<ApiResponse<CouponRes>> changeCouponStatus(@PathVariable UUID couponId,
+                                                                     @Valid @RequestBody ChangeCouponStatusReq request) {
+        log.info("PUT /api/v1/coupons/manager/{}/status - 쿠폰 상태 변경 요청 status: {}", couponId, request.getStatus());
+
+        validateRole();
+
+        ChangeCouponStatusCommand command = ChangeCouponStatusReq.of(couponId, request);
+
+        CouponRes couponRes = couponManagerService.changeCouponStatus(command);
+
+        return ResponseEntity.ok(ApiResponse.success(couponRes, "쿠폰 상태가 변경되었습니다."));
     }
 
 

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
@@ -1,12 +1,16 @@
 package com.palja.coupon_service.presentation.controller;
 
+import com.palja.common.auditor.CurrentUser;
+import com.palja.common.exception.BusinessException;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
+import com.palja.common.vo.UserRole;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
 import com.palja.coupon_service.application.command.UpdateCouponCommand;
 import com.palja.coupon_service.application.dto.CouponDetailRes;
 import com.palja.coupon_service.application.dto.CouponRes;
 import com.palja.coupon_service.application.service.CouponManagerService;
+import com.palja.coupon_service.exception.CouponErrorCode;
 import com.palja.coupon_service.presentation.dto.request.CreateCouponReq;
 import com.palja.coupon_service.presentation.dto.request.UpdateCouponReq;
 import jakarta.validation.Valid;
@@ -31,6 +35,9 @@ public class CouponManagerController {
     @PostMapping
     public ResponseEntity<ApiResponse<CouponRes>> createCoupon(@Valid @RequestBody CreateCouponReq request) {
         log.info("POST /api/v1/coupons/manager - 쿠폰 생성 요청");
+
+        validateRole();
+
         CreateCouponCommand command = CreateCouponReq.of(request);
 
         CouponRes couponRes = couponManagerService.createCoupon(command);
@@ -41,6 +48,8 @@ public class CouponManagerController {
     @PutMapping("/{couponId}")
     public ResponseEntity<ApiResponse<CouponRes>> updateCoupon(@PathVariable UUID couponId, @Valid @RequestBody UpdateCouponReq request) {
         log.info("PUT /api/v1/coupons/manager/{} - 쿠폰 수정 요청", couponId);
+
+        validateRole();
 
         UpdateCouponCommand command = UpdateCouponReq.of(couponId, request);
 
@@ -54,6 +63,8 @@ public class CouponManagerController {
     public ResponseEntity<ApiResponse<PageResponse<CouponRes>>> getCouponList(Pageable pageable) {
         log.info("GET /api/v1/coupons/manager - 쿠폰 목록 조회 요청");
 
+        validateRole();
+
         Page<CouponRes> couponResPage = couponManagerService.getCouponList(pageable);
 
         PageResponse<CouponRes> response = PageResponse.from(couponResPage);
@@ -65,8 +76,19 @@ public class CouponManagerController {
     public ResponseEntity<ApiResponse<CouponDetailRes>> getCouponDetail(@PathVariable UUID couponId) {
         log.info("GET /api/v1/coupons/manager/{} - 쿠폰 상세 조회 요청", couponId);
 
+        validateRole();
+
         CouponDetailRes response = couponManagerService.getCouponDetail(couponId);
 
         return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 상세 조회"));
+    }
+
+    private void validateRole() {
+        UserRole role = CurrentUser.getRole();
+
+        if (!UserRole.MASTER.equals(role) && !UserRole.MANAGER.equals(role)) {
+            log.warn("권한 없는 사용자의 쿠폰 관리 시도 - id: {}  role: {}", CurrentUser.getLoginId(), role);
+            throw new BusinessException(CouponErrorCode.INSUFFICIENT_PERMISSION);
+        }
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/ChangeCouponStatusReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/ChangeCouponStatusReq.java
@@ -1,0 +1,21 @@
+package com.palja.coupon_service.presentation.dto.request;
+
+import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
+import com.palja.coupon_service.domain.vo.CouponStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class ChangeCouponStatusReq {
+    @NotNull(message = "변경할 상태를 입력해주세요.")
+    private String status;
+
+    public static ChangeCouponStatusCommand of(UUID couponId, ChangeCouponStatusReq request) {
+        return ChangeCouponStatusCommand.builder()
+                .couponId(couponId)
+                .status(CouponStatus.valueOf(request.getStatus().toUpperCase()))
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/ChangeCouponStatusReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/ChangeCouponStatusReq.java
@@ -1,7 +1,6 @@
 package com.palja.coupon_service.presentation.dto.request;
 
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
-import com.palja.coupon_service.domain.vo.CouponStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -15,7 +14,7 @@ public class ChangeCouponStatusReq {
     public static ChangeCouponStatusCommand of(UUID couponId, ChangeCouponStatusReq request) {
         return ChangeCouponStatusCommand.builder()
                 .couponId(couponId)
-                .status(CouponStatus.valueOf(request.getStatus().toUpperCase()))
+                .status(request.getStatus())
                 .build();
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
@@ -1,7 +1,6 @@
 package com.palja.coupon_service.presentation.dto.request;
 
 import com.palja.coupon_service.application.command.CreateCouponCommand;
-import com.palja.coupon_service.domain.vo.DiscountType;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 
@@ -41,7 +40,7 @@ public class CreateCouponReq {
         return CreateCouponCommand.builder()
                 .couponName(request.getCouponName())
                 .description(request.getDescription())
-                .discountType(DiscountType.valueOf(request.getDiscountType().toUpperCase()))
+                .discountType(request.getDiscountType())
                 .discountValue(request.getDiscountValue())
                 .totalQuantity(request.getTotalQuantity())
                 .maxDiscountAmount(request.getMaxDiscountAmount())

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
@@ -3,17 +3,11 @@ package com.palja.coupon_service.presentation.dto.request;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
 import com.palja.coupon_service.domain.vo.DiscountType;
 import jakarta.validation.constraints.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class CreateCouponReq {
 
     @NotNull(message = "쿠폰명은 필수입니다.")

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/UpdateCouponReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/UpdateCouponReq.java
@@ -4,18 +4,12 @@ import com.palja.coupon_service.application.command.UpdateCouponCommand;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class UpdateCouponReq {
 
     @Size(max = 50, message = "쿠폰명은 최대 50자까지 입력 가능합니다.")

--- a/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
+++ b/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
@@ -1,23 +1,37 @@
 package com.palja.coupon_service.application.service.impl;
 
+import com.palja.common.exception.BusinessException;
+import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
+import com.palja.coupon_service.application.command.UpdateCouponCommand;
+import com.palja.coupon_service.application.dto.CouponDetailRes;
 import com.palja.coupon_service.application.dto.CouponRes;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.repository.CouponRepository;
 import com.palja.coupon_service.domain.vo.*;
+import com.palja.coupon_service.exception.CouponErrorCode;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,112 +44,346 @@ class CouponManagerServiceImplTest {
     @Mock
     private CouponRepository couponRepository;
 
-    @Test
-    @DisplayName("쿠폰 생성 성공")
-    void createCoupon_Success() {
-        // given
-        CreateCouponCommand command = CreateCouponCommand.builder()
-                .couponName("테스트 쿠폰")
-                .description("테스트 쿠폰 설명")
-                .discountType(DiscountType.PERCENTAGE)
-                .discountValue(10)
-                .totalQuantity(1000)
-                .maxDiscountAmount(5000)
-                .minOrderAmount(10000)
-                .issueStartAt(LocalDateTime.of(2025, 12, 1, 0, 0))
-                .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
-                .build();
+    @Nested
+    @DisplayName("쿠폰 생성")
+    class CreateCouponTest {
 
-        Coupon savedCoupon = Coupon.create(
-                command.couponName(),
-                command.description(),
-                DiscountPolicy.of(command.discountType(), command.discountValue()),
-                command.totalQuantity(),
-                AmountPolicy.of(command.maxDiscountAmount(), command.minOrderAmount()),
-                IssuePeriod.of(command.issueStartAt(), command.issueEndAt())
-        );
+        @Test
+        @DisplayName("성공")
+        void createCoupon_Success() {
+            // given
+            CreateCouponCommand command = CreateCouponCommand.builder()
+                    .couponName("테스트 쿠폰")
+                    .description("테스트 쿠폰 설명")
+                    .discountType(DiscountType.PERCENTAGE)
+                    .discountValue(10)
+                    .totalQuantity(1000)
+                    .maxDiscountAmount(5000)
+                    .minOrderAmount(10000)
+                    .issueStartAt(LocalDateTime.of(2025, 12, 1, 0, 0))
+                    .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .build();
 
-        given(couponRepository.save(any(Coupon.class))).willReturn(savedCoupon);
+            Coupon savedCoupon = Coupon.create(
+                    command.couponName(),
+                    command.description(),
+                    DiscountPolicy.of(command.discountType(), command.discountValue()),
+                    command.totalQuantity(),
+                    AmountPolicy.of(command.maxDiscountAmount(), command.minOrderAmount()),
+                    IssuePeriod.of(command.issueStartAt(), command.issueEndAt())
+            );
 
-        // when
-        CouponRes result = couponManagerService.createCoupon(command);
+            given(couponRepository.save(any(Coupon.class))).willReturn(savedCoupon);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getCouponName()).isEqualTo("테스트 쿠폰");
-        assertThat(result.getDescription()).isEqualTo("테스트 쿠폰 설명");
-        assertThat(result.getDiscountType()).isEqualTo(DiscountType.PERCENTAGE);
-        assertThat(result.getDiscountValue()).isEqualTo(10);
-        assertThat(result.getTotalQuantity()).isEqualTo(1000);
-        assertThat(result.getMaxDiscountAmount()).isEqualTo(5000);
-        assertThat(result.getMinOrderAmount()).isEqualTo(10000);
-        assertThat(result.getIssueStartAt()).isEqualTo(LocalDateTime.of(2025, 12, 1, 0, 0));
-        assertThat(result.getIssueEndAt()).isEqualTo(LocalDateTime.of(2025, 12, 31, 23, 59));
-        assertThat(result.getStatus()).isEqualTo(CouponStatus.ACTIVE);
+            // when
+            CouponRes result = couponManagerService.createCoupon(command);
 
-        verify(couponRepository).save(any(Coupon.class));
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getCouponName()).isEqualTo("테스트 쿠폰");
+            assertThat(result.getDescription()).isEqualTo("테스트 쿠폰 설명");
+            assertThat(result.getDiscountType()).isEqualTo(DiscountType.PERCENTAGE);
+            assertThat(result.getDiscountValue()).isEqualTo(10);
+            assertThat(result.getTotalQuantity()).isEqualTo(1000);
+            assertThat(result.getMaxDiscountAmount()).isEqualTo(5000);
+            assertThat(result.getMinOrderAmount()).isEqualTo(10000);
+            assertThat(result.getIssueStartAt()).isEqualTo(LocalDateTime.of(2025, 12, 1, 0, 0));
+            assertThat(result.getIssueEndAt()).isEqualTo(LocalDateTime.of(2025, 12, 31, 23, 59));
+            assertThat(result.getStatus()).isEqualTo(CouponStatus.ACTIVE);
+
+            verify(couponRepository).save(any(Coupon.class));
+        }
+
+        @Test
+        @DisplayName("할인값 0 예외 발생")
+        void createCoupon_Invalid_DiscountValue_ThrowException() {
+            // given
+            CreateCouponCommand command = CreateCouponCommand.builder()
+                    .couponName("테스트 쿠폰")
+                    .description("테스트 쿠폰 설명")
+                    .discountType(DiscountType.PERCENTAGE)
+                    .discountValue(0)
+                    .totalQuantity(1000)
+                    .maxDiscountAmount(5000)
+                    .minOrderAmount(10000)
+                    .issueStartAt(LocalDateTime.of(2025, 12, 1, 0, 0))
+                    .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .build();
+
+            assertThatThrownBy(() -> couponManagerService.createCoupon(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("할인값이 유효하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("퍼센트 타입 할인값 100 초과 예외 발생")
+        void createCoupon_Percentage_Invalid_DiscountValue_ThrowException() {
+            // given
+            CreateCouponCommand command = CreateCouponCommand.builder()
+                    .couponName("테스트 쿠폰")
+                    .description("테스트 쿠폰 설명")
+                    .discountType(DiscountType.PERCENTAGE)
+                    .discountValue(105)
+                    .totalQuantity(1000)
+                    .maxDiscountAmount(5000)
+                    .minOrderAmount(10000)
+                    .issueStartAt(LocalDateTime.of(2025, 12, 1, 0, 0))
+                    .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .build();
+
+            assertThatThrownBy(() -> couponManagerService.createCoupon(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("할인값이 유효하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("발급 시작일이 종료 예정일보다 늦을 때 예외 발생")
+        void createCoupon_Invalid_IssueStartAt_ThrowException() {
+            // given
+            CreateCouponCommand command = CreateCouponCommand.builder()
+                    .couponName("테스트 쿠폰")
+                    .description("테스트 쿠폰 설명")
+                    .discountType(DiscountType.PERCENTAGE)
+                    .discountValue(10)
+                    .totalQuantity(1000)
+                    .maxDiscountAmount(5000)
+                    .minOrderAmount(10000)
+                    .issueStartAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .issueEndAt(LocalDateTime.of(2025, 12, 1, 0, 0))
+                    .build();
+
+            assertThatThrownBy(() -> couponManagerService.createCoupon(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("발급 시작일이 종료일보다 늦을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("중복 쿠폰명 예외 발생")
+        void createCoupon_Duplicate_Coupon_Name_ThrowException() {
+            // given
+            CreateCouponCommand command = CreateCouponCommand.builder()
+                    .couponName("테스트 쿠폰")
+                    .description("테스트 쿠폰 설명")
+                    .discountType(DiscountType.PERCENTAGE)
+                    .discountValue(10)
+                    .totalQuantity(1000)
+                    .maxDiscountAmount(5000)
+                    .minOrderAmount(10000)
+                    .issueStartAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .issueEndAt(LocalDateTime.of(2025, 12, 1, 0, 0))
+                    .build();
+
+            given(couponRepository.existsByNameAndDeletedAtIsNull(command.couponName())).willReturn(true);
+
+            assertThatThrownBy(() -> couponManagerService.createCoupon(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("이미 존재하는 쿠폰명입니다.");
+        }
     }
 
-    @Test
-    @DisplayName("쿠폰 생성 할인값 0 예외 발생")
-    void createCoupon_Invalid_DiscountValue_ThrowException() {
-        // given
-        CreateCouponCommand command = CreateCouponCommand.builder()
-                .couponName("테스트 쿠폰")
-                .description("테스트 쿠폰 설명")
-                .discountType(DiscountType.PERCENTAGE)
-                .discountValue(0)
-                .totalQuantity(1000)
-                .maxDiscountAmount(5000)
-                .minOrderAmount(10000)
-                .issueStartAt(LocalDateTime.of(2025, 12, 1, 0, 0))
-                .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
-                .build();
+    @Nested
+    @DisplayName("쿠폰 수정")
+    class UpdateCouponTest {
+        @Test
+        @DisplayName("수정 성공")
+        void updateCoupon_Success() {
+            UUID couponId = UUID.randomUUID();
+            UpdateCouponCommand command = UpdateCouponCommand.builder()
+                    .couponId(couponId)
+                    .couponName("수정된 쿠폰명")
+                    .description("수정된 쿠폰 설명")
+                    .totalQuantity(1000)
+                    .maxDiscountAmount(5000)
+                    .minOrderAmount(10000)
+                    .issueStartAt(LocalDateTime.of(2025, 12, 10, 0, 0))
+                    .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .build();
 
-        assertThatThrownBy(() -> couponManagerService.createCoupon(command))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("할인값이 유효하지 않습니다.");
+            Coupon existingCoupon = mock(Coupon.class);
+            given(existingCoupon.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
+            given(existingCoupon.getAmountPolicy()).willReturn(mock(AmountPolicy.class));
+            given(existingCoupon.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
+            given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(existingCoupon));
+
+            // when
+            CouponRes result = couponManagerService.updateCoupon(command);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(couponRepository).findByIdAndDeletedAtIsNull(couponId);
+            verify(existingCoupon).update(
+                    command.couponName(),
+                    command.description(),
+                    command.totalQuantity(),
+                    command.maxDiscountAmount(),
+                    command.minOrderAmount(),
+                    command.issueStartAt(),
+                    command.issueEndAt()
+            );
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 쿠폰 수정 실패")
+        void updateCoupon_NotFound_ThrowException() {
+            UUID couponId = UUID.randomUUID();
+            UpdateCouponCommand command = UpdateCouponCommand.builder()
+                    .couponId(couponId)
+                    .couponName("수정된 쿠폰명")
+                    .description("수정된 쿠폰 설명")
+                    .totalQuantity(1000)
+                    .maxDiscountAmount(5000)
+                    .minOrderAmount(10000)
+                    .issueStartAt(LocalDateTime.of(2025, 12, 10, 0, 0))
+                    .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .build();
+
+            given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> couponManagerService.updateCoupon(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("쿠폰을 찾을 수 없습니다.");
+        }
     }
 
-    @Test
-    @DisplayName("쿠폰 생성 퍼센트 타입 할인값 100 초과 예외 발생")
-    void createCoupon_Percentage_Invalid_DiscountValue_ThrowException() {
-        // given
-        CreateCouponCommand command = CreateCouponCommand.builder()
-                .couponName("테스트 쿠폰")
-                .description("테스트 쿠폰 설명")
-                .discountType(DiscountType.PERCENTAGE)
-                .discountValue(105)
-                .totalQuantity(1000)
-                .maxDiscountAmount(5000)
-                .minOrderAmount(10000)
-                .issueStartAt(LocalDateTime.of(2025, 12, 1, 0, 0))
-                .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
-                .build();
+    @Nested
+    @DisplayName("쿠폰 상태 변경")
+    class ChangeCouponStatusTest {
+        @Test
+        @DisplayName("쿠폰 만료 상태 변경 성공")
+        void changeCouponStatus_ToActive_Success() {
+            // given
+            UUID couponId = UUID.randomUUID();
+            ChangeCouponStatusCommand command = ChangeCouponStatusCommand.builder()
+                    .couponId(couponId)
+                    .status(CouponStatus.EXPIRED)
+                    .build();
 
-        assertThatThrownBy(() -> couponManagerService.createCoupon(command))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("할인값이 유효하지 않습니다.");
+            Coupon existingCoupon = mock(Coupon.class);
+            given(existingCoupon.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
+            given(existingCoupon.getAmountPolicy()).willReturn(mock(AmountPolicy.class));
+            given(existingCoupon.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
+            given(existingCoupon.getStatus()).willReturn(CouponStatus.ACTIVE);
+            given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(existingCoupon));
+
+            // when
+            CouponRes result = couponManagerService.changeCouponStatus(command);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(couponRepository).findByIdAndDeletedAtIsNull(couponId);
+            verify(existingCoupon).changeStatus(CouponStatus.EXPIRED);
+        }
+
+        @Test
+        @DisplayName("쿠폰 상태 변경 변경 실패")
+        void changeCouponStatus_ToActive_ThrowException() {
+            // given
+            UUID couponId = UUID.randomUUID();
+            ChangeCouponStatusCommand command = ChangeCouponStatusCommand.builder()
+                    .couponId(couponId)
+                    .status(CouponStatus.ACTIVE)
+                    .build();
+
+            Coupon existingCoupon = mock(Coupon.class);
+            given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(existingCoupon));
+            given(existingCoupon.getStatus()).willReturn(CouponStatus.EXPIRED);
+            willThrow(new BusinessException(CouponErrorCode.INVALID_STATUS_TRANSITION))
+                    .given(existingCoupon).changeStatus(CouponStatus.ACTIVE);
+
+            assertThatThrownBy(() -> couponManagerService.changeCouponStatus(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("유효하지 않은 상태 전환입니다.");
+        }
     }
 
-    @Test
-    @DisplayName("쿠폰 생성 발급 시작일이 종료 예정일보다 늦을 때 예외 발생")
-    void createCoupon_Invalid_IssueStartAt_ThrowException() {
-        // given
-        CreateCouponCommand command = CreateCouponCommand.builder()
-                .couponName("테스트 쿠폰")
-                .description("테스트 쿠폰 설명")
-                .discountType(DiscountType.PERCENTAGE)
-                .discountValue(10)
-                .totalQuantity(1000)
-                .maxDiscountAmount(5000)
-                .minOrderAmount(10000)
-                .issueStartAt(LocalDateTime.of(2025, 12, 31, 23, 59))
-                .issueEndAt(LocalDateTime.of(2025, 12, 1, 0, 0))
-                .build();
+    @Nested
+    @DisplayName("쿠폰 목록 조회")
+    class GetCouponListTest {
+        @Test
+        @DisplayName("조회 성공")
+        void getCouponList_Success() {
+            // given
+            Coupon coupon1 = mock(Coupon.class);
+            given(coupon1.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
+            given(coupon1.getAmountPolicy()).willReturn(mock(AmountPolicy.class));
+            given(coupon1.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
 
-        assertThatThrownBy(() -> couponManagerService.createCoupon(command))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("발급 시작일이 종료일보다 늦을 수 없습니다.");
+            Coupon coupon2 = mock(Coupon.class);
+            given(coupon2.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
+            given(coupon2.getAmountPolicy()).willReturn(mock(AmountPolicy.class));
+            given(coupon2.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
+
+            Pageable pageable = PageRequest.of(0, 10);
+            List<Coupon> coupons = List.of(coupon1, coupon2);
+
+            Page<Coupon> couponPage = new PageImpl<>(coupons, pageable, coupons.size());
+
+            given(couponRepository.findAllByDeletedAtIsNull(pageable)).willReturn(couponPage);
+
+            // when
+            Page<CouponRes> result = couponManagerService.getCouponList(pageable);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).hasSize(2);
+            verify(couponRepository).findAllByDeletedAtIsNull(pageable);
+        }
+
+        @Test
+        @DisplayName("조회 성공 - 빈 목록")
+        void getCouponList_EmptyList_Success() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Coupon> couponPage = new PageImpl<>(List.of(), pageable, 0);
+
+            given(couponRepository.findAllByDeletedAtIsNull(pageable)).willReturn(couponPage);
+
+            // when
+            Page<CouponRes> result = couponManagerService.getCouponList(pageable);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).isEmpty();
+            verify(couponRepository).findAllByDeletedAtIsNull(pageable);
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 상세 조회")
+    class getCouponDetailTest {
+        @Test
+        @DisplayName("상세 조회 성공")
+        void getCouponDetail_Success() {
+            // given
+            UUID couponId = UUID.randomUUID();
+            Coupon coupon = mock(Coupon.class);
+            given(coupon.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
+            given(coupon.getAmountPolicy()).willReturn(mock(AmountPolicy.class));
+            given(coupon.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
+
+            given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(coupon));
+
+            // when
+            CouponDetailRes result = couponManagerService.getCouponDetail(couponId);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(couponRepository).findByIdAndDeletedAtIsNull(couponId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 쿠폰 상세 조회 실패")
+        void getCouponDetail_NotFound_ThrowException() {
+            // given
+            UUID couponId = UUID.randomUUID();
+
+            given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> couponManagerService.getCouponDetail(couponId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("쿠폰을 찾을 수 없습니다.");
+        }
     }
 }
+

--- a/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
+++ b/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
@@ -55,7 +55,7 @@ class CouponManagerServiceImplTest {
             CreateCouponCommand command = CreateCouponCommand.builder()
                     .couponName("테스트 쿠폰")
                     .description("테스트 쿠폰 설명")
-                    .discountType(DiscountType.PERCENTAGE)
+                    .discountType(DiscountType.PERCENTAGE.toString())
                     .discountValue(10)
                     .totalQuantity(1000)
                     .maxDiscountAmount(5000)
@@ -67,7 +67,7 @@ class CouponManagerServiceImplTest {
             Coupon savedCoupon = Coupon.create(
                     command.couponName(),
                     command.description(),
-                    DiscountPolicy.of(command.discountType(), command.discountValue()),
+                    DiscountPolicy.of(DiscountType.valueOf(command.discountType()), command.discountValue()),
                     command.totalQuantity(),
                     AmountPolicy.of(command.maxDiscountAmount(), command.minOrderAmount()),
                     IssuePeriod.of(command.issueStartAt(), command.issueEndAt())
@@ -101,7 +101,7 @@ class CouponManagerServiceImplTest {
             CreateCouponCommand command = CreateCouponCommand.builder()
                     .couponName("테스트 쿠폰")
                     .description("테스트 쿠폰 설명")
-                    .discountType(DiscountType.PERCENTAGE)
+                    .discountType(DiscountType.PERCENTAGE.toString())
                     .discountValue(0)
                     .totalQuantity(1000)
                     .maxDiscountAmount(5000)
@@ -122,7 +122,7 @@ class CouponManagerServiceImplTest {
             CreateCouponCommand command = CreateCouponCommand.builder()
                     .couponName("테스트 쿠폰")
                     .description("테스트 쿠폰 설명")
-                    .discountType(DiscountType.PERCENTAGE)
+                    .discountType(DiscountType.PERCENTAGE.toString())
                     .discountValue(105)
                     .totalQuantity(1000)
                     .maxDiscountAmount(5000)
@@ -143,7 +143,7 @@ class CouponManagerServiceImplTest {
             CreateCouponCommand command = CreateCouponCommand.builder()
                     .couponName("테스트 쿠폰")
                     .description("테스트 쿠폰 설명")
-                    .discountType(DiscountType.PERCENTAGE)
+                    .discountType(DiscountType.PERCENTAGE.toString())
                     .discountValue(10)
                     .totalQuantity(1000)
                     .maxDiscountAmount(5000)
@@ -164,7 +164,7 @@ class CouponManagerServiceImplTest {
             CreateCouponCommand command = CreateCouponCommand.builder()
                     .couponName("테스트 쿠폰")
                     .description("테스트 쿠폰 설명")
-                    .discountType(DiscountType.PERCENTAGE)
+                    .discountType(DiscountType.PERCENTAGE.toString())
                     .discountValue(10)
                     .totalQuantity(1000)
                     .maxDiscountAmount(5000)
@@ -255,7 +255,7 @@ class CouponManagerServiceImplTest {
             UUID couponId = UUID.randomUUID();
             ChangeCouponStatusCommand command = ChangeCouponStatusCommand.builder()
                     .couponId(couponId)
-                    .status(CouponStatus.EXPIRED)
+                    .status(CouponStatus.EXPIRED.toString())
                     .build();
 
             Coupon existingCoupon = mock(Coupon.class);
@@ -281,7 +281,7 @@ class CouponManagerServiceImplTest {
             UUID couponId = UUID.randomUUID();
             ChangeCouponStatusCommand command = ChangeCouponStatusCommand.builder()
                     .couponId(couponId)
-                    .status(CouponStatus.ACTIVE)
+                    .status(CouponStatus.ACTIVE.toString())
                     .build();
 
             Coupon existingCoupon = mock(Coupon.class);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #83 
<br>

## 📌 개요
쿠폰의 상태를 변경할 수 있는 기능을 구현하고, 관리자 권한 검증 로직을 추가했습니다.

<br>

## 🔁 변경 사항

### 1. 도메인 계층
- **Coupon 엔티티**: 상태 변경 메서드 및 상태 전환 검증 로직 추가 (`changeStatus()`, `validateStatusTransition()`)
- **CouponStatus Enum 개선**: 각 상태별 전환 가능한 상태 정의 및 설명 필드 추가
- **CouponRepository**: 쿠폰명 중복 체크 메서드 추가 (`existsByNameAndDeletedAtIsNull()`)

### 2. 애플리케이션 계층
- **ChangeCouponStatusCommand 추가**: 쿠폰 상태 변경 요청 데이터 전달용 커맨드 객체
- **CouponManagerService**: 쿠폰 상태 변경 메서드 추가 (`changeCouponStatus()`)
- **쿠폰명 중복 검증**: 생성 및 수정 시 쿠폰명 중복 체크 로직 추가

### 3. 프레젠테이션 계층
- **CouponManagerController**: 
  - `PUT /api/v1/coupons/manager/{couponId}/status` 엔드포인트 추가
  - 모든 관리자 API에 권한 검증 로직 적용 (`validateRole()`)
- **ChangeCouponStatusReq 추가**: 쿠폰 상태 변경 요청 DTO
- **Request DTO 정리**: 불필요한 Lombok 어노테이션 제거 (`@Builder`, `@AllArgsConstructor`, `@NoArgsConstructor`)

### 4. 인프라 계층
- **JpaCouponRepository**: 쿠폰명 중복 체크 쿼리 메서드 구현
- **CouponRepositoryAdapter**: 도메인 리포지토리 인터페이스 구현체 업데이트

### 5. 예외 처리
- **CouponErrorCode 추가**: 상태 전환 관련 에러 코드 추가 (`INVALID_STATUS_TRANSITION` 등)

### 6. 테스트
- **CouponManagerServiceImplTest 개선**: 
  - `@Nested` 구조로 테스트 가독성 향상
  - 쿠폰 생성, 수정, 상태 변경, 목록 조회, 상세 조회 테스트 추가
  - 중복 쿠폰명, 존재하지 않는 쿠폰, 잘못된 상태 전환 등 예외 케이스 테스트

<br>

## 📸 스크린샷

<details>
  <summary>쿠폰 상태 변경 API</summary>
 
<img width="1062" height="723" alt="image" src="https://github.com/user-attachments/assets/6fb90f5a-eacf-4b85-9a08-d1731d6b1a1a" />


</details>

<details>
  <summary>테스트 코드 결과</summary>
 
<img width="440" height="489" alt="image" src="https://github.com/user-attachments/assets/2cfedcb6-88e9-4c28-a819-452dc7f81ad3" />


</details>


<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.