### PR TITLE
Feat/ProductService 재고 수정 기능 구현 & 주문의 요청에 따른 상품 정보 제공 구현

### DIFF
--- a/product-service/src/main/java/com/palja/product_service/application/command/UpdateProductInfoCommand.java
+++ b/product-service/src/main/java/com/palja/product_service/application/command/UpdateProductInfoCommand.java
@@ -1,6 +1,6 @@
 package com.palja.product_service.application.command;
 
-public record UpdateProductCommand(
+public record UpdateProductInfoCommand(
         String name,
         String description,
         Long price,

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/ProductInfoForOrderRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/ProductInfoForOrderRes.java
@@ -1,0 +1,17 @@
+package com.palja.product_service.application.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class ProductInfoForOrderRes {
+
+    private UUID productId;
+    private String productName;
+    private BigDecimal price;
+    private int stockQuantity;
+}

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/UpdateProductInfoRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/UpdateProductInfoRes.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.util.UUID;
 
 @Getter
-public class UpdateProductRes {
+public class UpdateProductInfoRes {
 
     private UUID productId;
     private String name;
@@ -14,8 +14,8 @@ public class UpdateProductRes {
     private String price;
     private String category;
 
-    public static UpdateProductRes fromEntity(Product product) {
-        UpdateProductRes res = new UpdateProductRes();
+    public static UpdateProductInfoRes fromEntity(Product product) {
+        UpdateProductInfoRes res = new UpdateProductInfoRes();
 
         res.productId =  product.getId();
         res.name = product.getName();

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/UpdateStockRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/UpdateStockRes.java
@@ -1,0 +1,22 @@
+package com.palja.product_service.application.dto.res;
+
+import com.palja.product_service.domain.entity.Product;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class UpdateStockRes {
+
+    private UUID productId;
+    private Integer stock;
+
+    public static UpdateStockRes fromEntity(Product product) {
+        UpdateStockRes res = new UpdateStockRes();
+
+        res.productId = product.getId();
+        res.stock = product.getProductStock().getQuantity();
+
+        return res;
+    }
+}

--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -19,6 +19,8 @@ public interface ProductService {
 
     ProductInfoForTimeDealRes findProductForTimeDeal(UUID productId);
 
+    ProductInfoForOrderRes findProductForOrder(UUID productId);
+
     UpdateProductInfoRes updateProductInfo(UUID productId, UpdateProductInfoCommand updateCommand);
 
     UpdateStockRes updateStock(UUID productId, Integer stock);

--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -20,4 +20,6 @@ public interface ProductService {
     ProductInfoForTimeDealRes findProductForTimeDeal(UUID productId);
 
     UpdateProductRes updateProduct(UUID productId, UpdateProductCommand updateCommand);
+
+    UpdateStockRes updateStock(UUID productId, Integer stock);
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -2,7 +2,7 @@ package com.palja.product_service.application.service;
 
 import com.palja.product_service.application.command.CreateProductCommand;
 import com.palja.product_service.application.command.FindProductListByConditionCommand;
-import com.palja.product_service.application.command.UpdateProductCommand;
+import com.palja.product_service.application.command.UpdateProductInfoCommand;
 import com.palja.product_service.application.dto.res.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,7 +19,7 @@ public interface ProductService {
 
     ProductInfoForTimeDealRes findProductForTimeDeal(UUID productId);
 
-    UpdateProductRes updateProduct(UUID productId, UpdateProductCommand updateCommand);
+    UpdateProductInfoRes updateProductInfo(UUID productId, UpdateProductInfoCommand updateCommand);
 
     UpdateStockRes updateStock(UUID productId, Integer stock);
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -98,6 +98,15 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
+    public ProductInfoForOrderRes findProductForOrder(UUID productId) {
+        return Optional.ofNullable(
+                        dslProductRepository.findProductForOrder(productId))
+                .orElseThrow(
+                        () -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND)
+                );
+    }
+
+    @Override
     @Transactional
     public UpdateProductInfoRes updateProductInfo(UUID productId, UpdateProductInfoCommand updateCommand) {
 

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -1,10 +1,9 @@
 package com.palja.product_service.application.service.impl;
 
-import com.palja.common.auditor.CurrentUser;
 import com.palja.common.exception.BusinessException;
 import com.palja.product_service.application.command.CreateProductCommand;
 import com.palja.product_service.application.command.FindProductListByConditionCommand;
-import com.palja.product_service.application.command.UpdateProductCommand;
+import com.palja.product_service.application.command.UpdateProductInfoCommand;
 import com.palja.product_service.application.dto.res.*;
 import com.palja.product_service.application.service.ProductService;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
@@ -100,7 +99,7 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     @Transactional
-    public UpdateProductRes updateProduct(UUID productId, UpdateProductCommand updateCommand) {
+    public UpdateProductInfoRes updateProductInfo(UUID productId, UpdateProductInfoCommand updateCommand) {
 
         Product product = repository.findProduct(productId);
 
@@ -116,12 +115,12 @@ public class ProductServiceImpl implements ProductService {
                 updateCommand.name()))
             throw new BusinessException(ProductErrorCode.DUPLICATE_PRODUCT);
 
-        Product updateProduct = product.updateProduct(updateCommand.name(),
+        Product updateProduct = product.updateInfo(updateCommand.name(),
                 updateCommand.description(),
                 updateCommand.price(),
                 updateCommand.category());
 
-        return UpdateProductRes.fromEntity(updateProduct);
+        return UpdateProductInfoRes.fromEntity(updateProduct);
     }
 
     @Override

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -123,4 +123,21 @@ public class ProductServiceImpl implements ProductService {
 
         return UpdateProductRes.fromEntity(updateProduct);
     }
+
+    @Override
+    @Transactional
+    public UpdateStockRes updateStock(UUID productId, Integer stock) {
+
+        Product product = repository.findProduct(productId);
+        /*
+            String loginId = CurrentUser.getLoginId();
+            이 정보로, 해당 로그인 아이디를 사용하는 유저의 UUID를 가져와서 상품의 UUID와 비교해야함.
+            UUID companyUserId = userClient.요청(loginId);
+            if(product.getCompanyUserId().equals(companyUserID)) 가 True여야만 다음 로직 진행.
+         */
+
+        Product updateProduct = product.updateStock(stock);
+
+        return UpdateStockRes.fromEntity(updateProduct);
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/entity/Product.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/entity/Product.java
@@ -64,7 +64,7 @@ public class Product extends BaseEntity {
         return product;
     }
 
-    public Product updateProduct(String name, String description, Long price, String category) {
+    public Product updateInfo(String name, String description, Long price, String category) {
 
         if (Objects.nonNull(name)) {
             if(name.length() <= 30) this.name = name;

--- a/product-service/src/main/java/com/palja/product_service/domain/entity/Product.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/entity/Product.java
@@ -80,6 +80,14 @@ public class Product extends BaseEntity {
         return this;
     }
 
+    public Product updateStock(Integer stock) {
+        if(Objects.isNull(stock) || stock < 0)
+            throw new BusinessException(ProductErrorCode.INVALID_STOCK);
+
+        this.productStock.updateQuantity(stock);
+        return this;
+    }
+
     public ProductStock increaseStock(Integer quantity) {
         this.productStock = productStock.increase(quantity);
         return this.productStock;

--- a/product-service/src/main/java/com/palja/product_service/domain/entity/ProductStock.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/entity/ProductStock.java
@@ -43,4 +43,9 @@ public class ProductStock extends BaseEntity {
             throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STOCK);
         return this;
     }
+
+    protected ProductStock updateQuantity(Integer quantity) {
+        this.quantity = quantity;
+        return this;
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/exception/ProductErrorCode.java
+++ b/product-service/src/main/java/com/palja/product_service/exception/ProductErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ProductErrorCode implements ErrorCode {
     INVALID_PRODUCT_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "가격은 양수여야 합니다."),
+    INVALID_STOCK(HttpStatus.BAD_REQUEST, "재고는 양수여야 합니다"),
     NOT_SUPPORT_CATEGORY(HttpStatus.BAD_REQUEST, "지원되지 않는 카테고리입니다."),
     NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "상품의 이름은 최대 30자까지 입니다"),
 

--- a/product-service/src/main/java/com/palja/product_service/exception/ProductErrorCode.java
+++ b/product-service/src/main/java/com/palja/product_service/exception/ProductErrorCode.java
@@ -10,12 +10,12 @@ import org.springframework.http.HttpStatus;
 public enum ProductErrorCode implements ErrorCode {
     INVALID_PRODUCT_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "가격은 양수여야 합니다."),
-    INVALID_STOCK(HttpStatus.BAD_REQUEST, "재고는 양수여야 합니다"),
+    INVALID_STOCK(HttpStatus.BAD_REQUEST, "재고는 음수일 수 없습니다."),
     NOT_SUPPORT_CATEGORY(HttpStatus.BAD_REQUEST, "지원되지 않는 카테고리입니다."),
-    NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "상품의 이름은 최대 30자까지 입니다"),
+    NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "상품의 이름은 최대 30자까지 입니다."),
 
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
-    DUPLICATE_PRODUCT(HttpStatus.BAD_REQUEST, "중복된 상품을 등록할 수 없습니다");
+    DUPLICATE_PRODUCT(HttpStatus.BAD_REQUEST, "중복된 상품을 등록할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.infrastructure.repository;
 
+import com.palja.product_service.application.dto.res.ProductInfoForOrderRes;
 import com.palja.product_service.application.dto.res.ProductInfoForTimeDealRes;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
 import com.palja.product_service.domain.entity.Product;
@@ -31,6 +32,19 @@ public class DslProductRepository {
                         product.companyUserId,
                         product.price.amount.longValue(),
                         product.productStock.quantity.longValue()))
+                .from(product)
+                .where(product.id.eq(productId).and(product.deletedAt.isNull()))
+                .fetchOne();
+    }
+
+    public ProductInfoForOrderRes findProductForOrder(UUID productId) {
+
+        return queryFactory.select(Projections.constructor(
+                        ProductInfoForOrderRes.class,
+                        product.id,
+                        product.name,
+                        product.price.amount,
+                        product.productStock.quantity))
                 .from(product)
                 .where(product.id.eq(productId).and(product.deletedAt.isNull()))
                 .fetchOne();

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.palja.product_service.infrastructure.repository;
+package com.palja.product_service.infrastructure.repository.impl;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
@@ -6,6 +6,8 @@ import com.palja.product_service.domain.entity.Product;
 import com.palja.product_service.domain.repository.ProductRepository;
 import com.palja.product_service.domain.vo.Category;
 import com.palja.product_service.exception.ProductErrorCode;
+import com.palja.product_service.infrastructure.repository.DslProductRepository;
+import com.palja.product_service.infrastructure.repository.JpaProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -15,7 +17,7 @@ import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
-public class ProductRepositoryAdapter implements ProductRepository {
+public class ProductRepositoryImpl implements ProductRepository {
 
     private final JpaProductRepository jpaProductRepository;
     private final DslProductRepository dslProductRepository;

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
@@ -61,6 +61,14 @@ public class ProductController {
         return new ResponseEntity<>(ApiResponse.success(res, "상품 정보 조회 성공"), HttpStatus.OK);
     }
 
+    @GetMapping("/order/{productId}")
+    public ResponseEntity<ApiResponse<ProductInfoForOrderRes>> provideProductInfoToOrder(@PathVariable UUID productId) {
+
+        ProductInfoForOrderRes res = service.findProductForOrder(productId);
+
+        return new ResponseEntity<>(ApiResponse.success(res, "상품 정보 조회 성공"), HttpStatus.OK);
+    }
+
     @PutMapping("/manager/{productId}")
     public ResponseEntity<ApiResponse<UpdateProductInfoRes>> updateProductInfo(@RequestBody @Valid UpdateProductInfoReq req,
                                                                                @PathVariable UUID productId) {

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
@@ -70,4 +70,13 @@ public class ProductController {
 
         return new ResponseEntity<>(ApiResponse.success(res, "상품 정보 수정 성공"), HttpStatus.OK);
     }
+
+    @PutMapping("/manager/modifyStock/{productId}")
+    public ResponseEntity<ApiResponse<UpdateStockRes>> updateProductStock(@PathVariable UUID productId,
+                                                                          @RequestParam Integer stock) {
+
+        UpdateStockRes res = service.updateStock(productId, stock);
+
+        return new ResponseEntity<>(ApiResponse.success(res, "상품 재고 수정 성공"), HttpStatus.OK);
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
@@ -4,12 +4,12 @@ import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
 import com.palja.product_service.application.command.CreateProductCommand;
 import com.palja.product_service.application.command.FindProductListByConditionCommand;
-import com.palja.product_service.application.command.UpdateProductCommand;
+import com.palja.product_service.application.command.UpdateProductInfoCommand;
 import com.palja.product_service.application.dto.res.*;
 import com.palja.product_service.application.service.ProductService;
 import com.palja.product_service.presentation.dto.req.CreateProductReq;
 import com.palja.product_service.presentation.dto.req.FindProductListByConditionReq;
-import com.palja.product_service.presentation.dto.req.UpdateProductReq;
+import com.palja.product_service.presentation.dto.req.UpdateProductInfoReq;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -62,11 +62,11 @@ public class ProductController {
     }
 
     @PutMapping("/manager/{productId}")
-    public ResponseEntity<ApiResponse<UpdateProductRes>> updateProduct(@RequestBody @Valid UpdateProductReq req,
-                                                                       @PathVariable UUID productId) {
+    public ResponseEntity<ApiResponse<UpdateProductInfoRes>> updateProductInfo(@RequestBody @Valid UpdateProductInfoReq req,
+                                                                               @PathVariable UUID productId) {
 
-        UpdateProductCommand command = req.toCommand();
-        UpdateProductRes res = service.updateProduct(productId, command);
+        UpdateProductInfoCommand command = req.toCommand();
+        UpdateProductInfoRes res = service.updateProductInfo(productId, command);
 
         return new ResponseEntity<>(ApiResponse.success(res, "상품 정보 수정 성공"), HttpStatus.OK);
     }

--- a/product-service/src/main/java/com/palja/product_service/presentation/dto/req/UpdateProductInfoReq.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/dto/req/UpdateProductInfoReq.java
@@ -1,12 +1,12 @@
 package com.palja.product_service.presentation.dto.req;
 
-import com.palja.product_service.application.command.UpdateProductCommand;
+import com.palja.product_service.application.command.UpdateProductInfoCommand;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
-public class UpdateProductReq {
+public class UpdateProductInfoReq {
 
     @Size(min = 2, max = 30)
     private String name;
@@ -18,7 +18,7 @@ public class UpdateProductReq {
 
     private String category;
 
-    public UpdateProductCommand toCommand() {
-        return new UpdateProductCommand(name, description, price, category);
+    public UpdateProductInfoCommand toCommand() {
+        return new UpdateProductInfoCommand(name, description, price, category);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #88 

<br>

## 📌 개요
- 상품의 재고를 수정하는 기능입니다.
- 판매나 환불 등에 따른 재고 수정이 아닌, 판매자가 직접 상품의 재고를 조정하는 상황에만 해당합니다.
- 주문 서비스에서 상품의 정보를 요청할때 사용할 API 구현

<br>

## 🔁 변경 사항

1. 정보의 변경과 재고의 변경의 책임을 맡은 클래스나 메서드를 보기 확실히 구분하기 위해 정보 관련 이름에 Info를 붙였습니다.
2. infra 계층의 레포지토리 패키지 구조 변경과 이름을 어댑터에서 Impl로 변경했습니다.
3. API 명세서에 주문에서 상품쪽에 요청을 보낼 때 사용할 API에 변경점들이 있으니 확인 부탁드립니다. 

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
테스트 코드는 몰아서 작성해 보도록 하겠습니다.
<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
