### PR TITLE
FEAT/OrderService 주문 생성 API 구현

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -37,7 +37,7 @@ ext {
 }
 
 dependencies {
-	implementation 'com.palja:common-module:0.4.6'
+	implementation 'com.palja:common-module:0.5.6'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import java.util.UUID;
 
 // 주문 생성 Command
-// Presentation Layer에서 전달받은 요청을 Application Layer로 전달
+// Presentation -> Application 전달
 @Builder
 public record CreateOrderCommand(
         String loginId,
@@ -15,33 +15,4 @@ public record CreateOrderCommand(
         UUID couponId,
         DeliveryCommand delivery
 ) {
-
-    // 유효성 검증
-    public void validate() {
-        if (loginId == null) {
-            throw new IllegalArgumentException("사용자 로그인 ID는 필수입니다.");
-        }
-        if (productId == null) {
-            throw new IllegalArgumentException("상품 ID는 필수입니다.");
-        }
-        if (quantity <= 0) {
-            throw new IllegalArgumentException("주문 수량은 1 이상이어야 합니다.");
-        }
-        if (delivery == null) {
-            throw new IllegalArgumentException("배송 정보는 필수입니다.");
-        }
-
-        // 배송 정보 검증
-        delivery.validate();
-    }
-
-    // 타임딜 주문 여부
-    public boolean isTimeDealOrder() {
-        return timeDealId != null;
-    }
-
-    // 쿠폰 사용 여부
-    public boolean hasCoupon() {
-        return couponId != null;
-    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
@@ -1,4 +1,47 @@
 package com.palja.order_service.application.command;
 
-public record CreateOrderCommand() {
+import lombok.Builder;
+
+import java.util.UUID;
+
+// 주문 생성 Command
+// Presentation Layer에서 전달받은 요청을 Application Layer로 전달
+@Builder
+public record CreateOrderCommand(
+        String loginId,
+        UUID productId,
+        int quantity,
+        UUID timeDealId,
+        UUID couponId,
+        DeliveryCommand delivery
+) {
+
+    // 유효성 검증
+    public void validate() {
+        if (loginId == null) {
+            throw new IllegalArgumentException("사용자 로그인 ID는 필수입니다.");
+        }
+        if (productId == null) {
+            throw new IllegalArgumentException("상품 ID는 필수입니다.");
+        }
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("주문 수량은 1 이상이어야 합니다.");
+        }
+        if (delivery == null) {
+            throw new IllegalArgumentException("배송 정보는 필수입니다.");
+        }
+
+        // 배송 정보 검증
+        delivery.validate();
+    }
+
+    // 타임딜 주문 여부
+    public boolean isTimeDealOrder() {
+        return timeDealId != null;
+    }
+
+    // 쿠폰 사용 여부
+    public boolean hasCoupon() {
+        return couponId != null;
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/command/DeliveryCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/DeliveryCommand.java
@@ -1,0 +1,39 @@
+package com.palja.order_service.application.command;
+
+
+import lombok.Builder;
+
+// 배송 정보 Command
+// 주문 생성 시 배송 정보 전달
+@Builder
+public record DeliveryCommand(
+        String recipientName,
+        String recipientEmail,
+        String recipientAddress,
+        String deliveryMessage
+) {
+
+    // 유효성 검증
+    public void validate() {
+        if (recipientName == null || recipientName.isBlank()) {
+            throw new IllegalArgumentException("수령인 이름은 필수입니다.");
+        }
+        if (recipientAddress == null || recipientAddress.isBlank()) {
+            throw new IllegalArgumentException("수령인 주소는 필수입니다.");
+        }
+
+        // 길이 검증
+        if (recipientName.length() > 50) {
+            throw new IllegalArgumentException("수령인 이름은 50자를 초과할 수 없습니다.");
+        }
+        if (recipientEmail != null && recipientEmail.length() > 255) {
+            throw new IllegalArgumentException("이메일은 255자를 초과할 수 없습니다.");
+        }
+        if (recipientAddress.length() > 200) {
+            throw new IllegalArgumentException("수령인 주소는 200자를 초과할 수 없습니다.");
+        }
+        if (deliveryMessage != null && deliveryMessage.length() > 255) {
+            throw new IllegalArgumentException("배송 메시지는 255자를 초과할 수 없습니다.");
+        }
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/command/DeliveryCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/DeliveryCommand.java
@@ -12,28 +12,4 @@ public record DeliveryCommand(
         String recipientAddress,
         String deliveryMessage
 ) {
-
-    // 유효성 검증
-    public void validate() {
-        if (recipientName == null || recipientName.isBlank()) {
-            throw new IllegalArgumentException("수령인 이름은 필수입니다.");
-        }
-        if (recipientAddress == null || recipientAddress.isBlank()) {
-            throw new IllegalArgumentException("수령인 주소는 필수입니다.");
-        }
-
-        // 길이 검증
-        if (recipientName.length() > 50) {
-            throw new IllegalArgumentException("수령인 이름은 50자를 초과할 수 없습니다.");
-        }
-        if (recipientEmail != null && recipientEmail.length() > 255) {
-            throw new IllegalArgumentException("이메일은 255자를 초과할 수 없습니다.");
-        }
-        if (recipientAddress.length() > 200) {
-            throw new IllegalArgumentException("수령인 주소는 200자를 초과할 수 없습니다.");
-        }
-        if (deliveryMessage != null && deliveryMessage.length() > 255) {
-            throw new IllegalArgumentException("배송 메시지는 255자를 초과할 수 없습니다.");
-        }
-    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CouponDiscountType.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CouponDiscountType.java
@@ -1,0 +1,15 @@
+package com.palja.order_service.application.dto;
+
+public enum CouponDiscountType {
+    PERCENTAGE,
+    FIXED;
+
+    public static CouponDiscountType from(String value) {
+        if (value == null) return null;
+        try {
+            return CouponDiscountType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
@@ -1,6 +1,5 @@
 package com.palja.order_service.application.dto;
 
-import com.palja.order_service.infrastructure.external.dto.response.CouponDTO;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,19 +25,29 @@ public class CouponRes {
     private final Integer validityDays;
     private final String status;            // ACTIVE, PAUSED, EXPIRED, DELETED
 
-    // Infrastructure DTO → Application DTO 변환
-    public static CouponRes from(CouponDTO couponDTO) {
+    public static CouponRes of(
+            UUID couponId,
+            String name,
+            String discountType,
+            int discountValue,
+            BigDecimal maxDiscountAmount,
+            BigDecimal minOrderAmount,
+            LocalDateTime issueStartAt,
+            LocalDateTime issueEndAt,
+            Integer validityDays,
+            String status
+    ) {
         return CouponRes.builder()
-                .couponId(couponDTO.getCouponId())
-                .name(couponDTO.getName())
-                .discountType(couponDTO.getDiscountType())
-                .discountValue(couponDTO.getDiscountValue())
-                .maxDiscountAmount(couponDTO.getMaxDiscountAmount())
-                .minOrderAmount(couponDTO.getMinOrderAmount())
-                .issueStartAt(couponDTO.getIssueStartAt())
-                .issueEndAt(couponDTO.getIssueEndAt())
-                .validityDays(couponDTO.getValidityDays())
-                .status(couponDTO.getStatus())
+                .couponId(couponId)
+                .name(name)
+                .discountType(discountType)
+                .discountValue(discountValue)
+                .maxDiscountAmount(maxDiscountAmount)
+                .minOrderAmount(minOrderAmount)
+                .issueStartAt(issueStartAt)
+                .issueEndAt(issueEndAt)
+                .validityDays(validityDays)
+                .status(status)
                 .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
@@ -1,7 +1,5 @@
 package com.palja.order_service.application.dto;
 
-import com.palja.common.exception.BusinessException;
-import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.infrastructure.external.dto.response.CouponDTO;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -9,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -32,10 +29,6 @@ public class CouponRes {
 
     // Infrastructure DTO → Application DTO 변환
     public static CouponRes from(CouponDTO couponDTO) {
-        if (couponDTO == null) {
-            throw new BusinessException(OrderErrorCode.COUPON_NOT_FOUND);
-        }
-
         return CouponRes.builder()
                 .couponId(couponDTO.getCouponId())
                 .name(couponDTO.getName())
@@ -48,96 +41,5 @@ public class CouponRes {
                 .validityDays(couponDTO.getValidityDays())
                 .status(couponDTO.getStatus())
                 .build();
-    }
-
-    // 쿠폰 전체 검증
-    public void validate(BigDecimal orderAmount) {
-        validateStatus();
-        validateIssuePeriod();
-        validateMinOrderAmount(orderAmount);
-    }
-
-    // 쿠폰 상태 검증
-    public void validateStatus() {
-        if (!"ACTIVE".equals(status)) {
-            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
-
-        }
-    }
-
-    // 기간 검증
-    public void validateIssuePeriod() {
-        LocalDateTime now = LocalDateTime.now();
-
-        if (now.isBefore(issueStartAt)) {
-            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
-        }
-
-        if (now.isAfter(issueEndAt)) {
-            throw new BusinessException(OrderErrorCode.COUPON_EXPIRED);
-        }
-    }
-
-    // 최소 주문 금액 검증
-    public void validateMinOrderAmount(BigDecimal orderAmount) {
-        if (minOrderAmount == null) return;
-
-        if (orderAmount == null || orderAmount.compareTo(minOrderAmount) < 0) {
-            throw new BusinessException(OrderErrorCode.COUPON_MIN_AMOUNT_NOT_MET);
-        }
-    }
-
-    // 할인 금액 계산
-    public BigDecimal calculateDiscountAmount(BigDecimal orderAmount) {
-        if (orderAmount == null || orderAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            return BigDecimal.ZERO;
-        }
-
-        if (discountType == null) {
-            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
-        }
-
-        BigDecimal discountAmount;
-
-        if ("PERCENTAGE".equalsIgnoreCase(discountType)) {
-            // 퍼센트 할인 (예: 20 → 20%)
-            BigDecimal rate = BigDecimal.valueOf(discountValue)
-                    .divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP);
-
-            discountAmount = orderAmount.multiply(rate)
-                    .setScale(0, RoundingMode.FLOOR); // 원 단위 절사
-
-        } else if ("FIXED".equalsIgnoreCase(discountType)) {
-            // 정액 할인 (예: 5,000원)
-            discountAmount = BigDecimal.valueOf(discountValue);
-
-        } else {
-            // 그 외 타입은 아직 지원 안 함
-            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
-        }
-
-        // 최대 할인 금액 제한
-        if (maxDiscountAmount != null && discountAmount.compareTo(maxDiscountAmount) > 0) {
-            discountAmount = maxDiscountAmount;
-        }
-
-        // 할인 금액은 주문 금액을 초과할 수 없음
-        if (discountAmount.compareTo(orderAmount) > 0) {
-            discountAmount = orderAmount;
-        }
-
-        if (discountAmount.compareTo(BigDecimal.ZERO) < 0) {
-            return BigDecimal.ZERO;
-        }
-
-        return discountAmount;
-    }
-
-    // 사용 가능 여부 확인
-    public boolean isUsable() {
-        LocalDateTime now = LocalDateTime.now();
-        return "ACTIVE".equals(status)
-                && now.isAfter(issueStartAt)
-                && now.isBefore(issueEndAt);
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
@@ -10,7 +10,6 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-// 쿠폰 정보
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
@@ -1,0 +1,143 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.order_service.application.exception.OrderErrorCode;
+import com.palja.order_service.infrastructure.external.dto.response.CouponDTO;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// 쿠폰 정보
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CouponRes {
+
+    private final UUID couponId;
+    private final String name;
+    private final String discountType;      // PERCENTAGE, FIXED 등
+    private final int discountValue;
+    private final BigDecimal maxDiscountAmount;
+    private final BigDecimal minOrderAmount;
+    private final LocalDateTime issueStartAt;
+    private final LocalDateTime issueEndAt;
+    private final Integer validityDays;
+    private final String status;            // ACTIVE, PAUSED, EXPIRED, DELETED
+
+    // Infrastructure DTO → Application DTO 변환
+    public static CouponRes from(CouponDTO couponDTO) {
+        if (couponDTO == null) {
+            throw new BusinessException(OrderErrorCode.COUPON_NOT_FOUND);
+        }
+
+        return CouponRes.builder()
+                .couponId(couponDTO.getCouponId())
+                .name(couponDTO.getName())
+                .discountType(couponDTO.getDiscountType())
+                .discountValue(couponDTO.getDiscountValue())
+                .maxDiscountAmount(couponDTO.getMaxDiscountAmount())
+                .minOrderAmount(couponDTO.getMinOrderAmount())
+                .issueStartAt(couponDTO.getIssueStartAt())
+                .issueEndAt(couponDTO.getIssueEndAt())
+                .validityDays(couponDTO.getValidityDays())
+                .status(couponDTO.getStatus())
+                .build();
+    }
+
+    // 쿠폰 전체 검증
+    public void validate(BigDecimal orderAmount) {
+        validateStatus();
+        validateIssuePeriod();
+        validateMinOrderAmount(orderAmount);
+    }
+
+    // 쿠폰 상태 검증
+    public void validateStatus() {
+        if (!"ACTIVE".equals(status)) {
+            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
+
+        }
+    }
+
+    // 기간 검증
+    public void validateIssuePeriod() {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(issueStartAt)) {
+            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
+        }
+
+        if (now.isAfter(issueEndAt)) {
+            throw new BusinessException(OrderErrorCode.COUPON_EXPIRED);
+        }
+    }
+
+    // 최소 주문 금액 검증
+    public void validateMinOrderAmount(BigDecimal orderAmount) {
+        if (minOrderAmount == null) return;
+
+        if (orderAmount == null || orderAmount.compareTo(minOrderAmount) < 0) {
+            throw new BusinessException(OrderErrorCode.COUPON_MIN_AMOUNT_NOT_MET);
+        }
+    }
+
+    // 할인 금액 계산
+    public BigDecimal calculateDiscountAmount(BigDecimal orderAmount) {
+        if (orderAmount == null || orderAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO;
+        }
+
+        if (discountType == null) {
+            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
+        }
+
+        BigDecimal discountAmount;
+
+        if ("PERCENTAGE".equalsIgnoreCase(discountType)) {
+            // 퍼센트 할인 (예: 20 → 20%)
+            BigDecimal rate = BigDecimal.valueOf(discountValue)
+                    .divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP);
+
+            discountAmount = orderAmount.multiply(rate)
+                    .setScale(0, RoundingMode.FLOOR); // 원 단위 절사
+
+        } else if ("FIXED".equalsIgnoreCase(discountType)) {
+            // 정액 할인 (예: 5,000원)
+            discountAmount = BigDecimal.valueOf(discountValue);
+
+        } else {
+            // 그 외 타입은 아직 지원 안 함
+            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
+        }
+
+        // 최대 할인 금액 제한
+        if (maxDiscountAmount != null && discountAmount.compareTo(maxDiscountAmount) > 0) {
+            discountAmount = maxDiscountAmount;
+        }
+
+        // 할인 금액은 주문 금액을 초과할 수 없음
+        if (discountAmount.compareTo(orderAmount) > 0) {
+            discountAmount = orderAmount;
+        }
+
+        if (discountAmount.compareTo(BigDecimal.ZERO) < 0) {
+            return BigDecimal.ZERO;
+        }
+
+        return discountAmount;
+    }
+
+    // 사용 가능 여부 확인
+    public boolean isUsable() {
+        LocalDateTime now = LocalDateTime.now();
+        return "ACTIVE".equals(status)
+                && now.isAfter(issueStartAt)
+                && now.isBefore(issueEndAt);
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CouponRes.java
@@ -16,7 +16,7 @@ public class CouponRes {
 
     private final UUID couponId;
     private final String name;
-    private final String discountType;      // PERCENTAGE, FIXED 등
+    private final CouponDiscountType discountType;      // PERCENTAGE, FIXED 등
     private final int discountValue;
     private final BigDecimal maxDiscountAmount;
     private final BigDecimal minOrderAmount;
@@ -28,7 +28,7 @@ public class CouponRes {
     public static CouponRes of(
             UUID couponId,
             String name,
-            String discountType,
+            CouponDiscountType discountType,
             int discountValue,
             BigDecimal maxDiscountAmount,
             BigDecimal minOrderAmount,

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CouponSnapshotRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CouponSnapshotRes.java
@@ -1,16 +1,12 @@
 package com.palja.order_service.application.dto;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
-/**
- * 주문에 스냅샷으로 남길 쿠폰 정보
- * - couponId
- * - couponName
- * - 최종 할인 금액
- */
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CouponSnapshotRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CouponSnapshotRes.java
@@ -1,0 +1,28 @@
+package com.palja.order_service.application.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * 주문에 스냅샷으로 남길 쿠폰 정보
+ * - couponId
+ * - couponName
+ * - 최종 할인 금액
+ */
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CouponSnapshotRes {
+
+    private UUID couponId;
+    private String couponName;
+
+    public static CouponSnapshotRes of(UUID couponId, String couponName) {
+        return CouponSnapshotRes.builder()
+                .couponId(couponId)
+                .couponName(couponName)
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CreateOrderRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CreateOrderRes.java
@@ -34,5 +34,4 @@ public class CreateOrderRes {
                 .createdAt(order.getCreatedAt())
                 .build();
     }
-
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CreateOrderRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CreateOrderRes.java
@@ -1,0 +1,38 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.order_service.domain.entity.Order;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// 주문 생성 응답 DTO
+@Getter
+@Builder
+public class CreateOrderRes {
+    private UUID orderId;
+    private String status;
+    private OrderItemRes orderItem;
+    private DeliveryRes delivery;
+    private PricingRes pricing;
+    private CouponSnapshotRes coupon;
+    private Boolean timeDealOrder;
+    private Instant createdAt;
+
+    // Order 엔티티 → 주문 생성 응답 DTO 변환
+    public static CreateOrderRes from(Order order) {
+
+        return CreateOrderRes.builder()
+                .orderId(order.getOrderId())
+                .status(order.getStatus().name())
+                .orderItem(OrderItemRes.from(order.getOrderItem()))
+                .pricing(PricingRes.from(order))
+                .coupon(CouponSnapshotRes.of(order.getCouponId(), order.getCouponName()))
+                .delivery(DeliveryRes.from(order.getDelivery()))
+                .timeDealOrder(order.isTimeDealOrder())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CreateOrderRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CreateOrderRes.java
@@ -1,6 +1,8 @@
 package com.palja.order_service.application.dto;
 
 import com.palja.order_service.domain.entity.Order;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,7 +11,8 @@ import java.util.UUID;
 
 // 주문 생성 응답 DTO
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateOrderRes {
     private UUID orderId;
     private String status;

--- a/order-service/src/main/java/com/palja/order_service/application/dto/DeliveryRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/DeliveryRes.java
@@ -1,13 +1,16 @@
 package com.palja.order_service.application.dto;
 
 import com.palja.order_service.domain.entity.OrderDelivery;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DeliveryRes {
     private String status;
     private String recipientName;

--- a/order-service/src/main/java/com/palja/order_service/application/dto/DeliveryRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/DeliveryRes.java
@@ -1,0 +1,38 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.order_service.domain.entity.OrderDelivery;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DeliveryRes {
+    private String status;
+    private String recipientName;
+    private String recipientEmail;
+    private String recipientAddress;
+    private String deliveryMessage;
+    private String trackingNumber;
+    private String courierCompany;
+    private LocalDateTime shippedAt;
+    private LocalDateTime deliveredAt;
+
+    public static DeliveryRes from(OrderDelivery delivery) {
+        if (delivery == null) {
+            return null;
+        }
+        return DeliveryRes.builder()
+                .status(delivery.getStatus().name())
+                .recipientName(delivery.getRecipient().getName())
+                .recipientEmail(delivery.getRecipient().getEmail())
+                .recipientAddress(delivery.getRecipient().getAddress())
+                .deliveryMessage(delivery.getRecipient().getDeliveryMessage())
+                .trackingNumber(delivery.getTrackingNumber())
+                .courierCompany(delivery.getCourierCompany())
+                .shippedAt(delivery.getShippedAt())
+                .deliveredAt(delivery.getDeliveredAt())
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/OrderCreateRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/OrderCreateRes.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CreateOrderRes {
+public class OrderCreateRes {
     private UUID orderId;
     private String status;
     private OrderItemRes orderItem;
@@ -24,9 +24,9 @@ public class CreateOrderRes {
     private Instant createdAt;
 
     // Order 엔티티 → 주문 생성 응답 DTO 변환
-    public static CreateOrderRes from(Order order) {
+    public static OrderCreateRes from(Order order) {
 
-        return CreateOrderRes.builder()
+        return OrderCreateRes.builder()
                 .orderId(order.getOrderId())
                 .status(order.getStatus().name())
                 .orderItem(OrderItemRes.from(order.getOrderItem()))

--- a/order-service/src/main/java/com/palja/order_service/application/dto/OrderItemRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/OrderItemRes.java
@@ -1,6 +1,8 @@
 package com.palja.order_service.application.dto;
 
 import com.palja.order_service.domain.entity.OrderItem;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,7 +11,8 @@ import java.util.UUID;
 
 // 주문 상품 정보
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderItemRes {
     private UUID orderItemId;
     private UUID productId;

--- a/order-service/src/main/java/com/palja/order_service/application/dto/OrderItemRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/OrderItemRes.java
@@ -1,0 +1,40 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.order_service.domain.entity.OrderItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+// 주문 상품 정보
+@Getter
+@Builder
+public class OrderItemRes {
+    private UUID orderItemId;
+    private UUID productId;
+    private String productName;
+    private BigDecimal unitPrice;
+    private int quantity;
+    private BigDecimal lineTotalAmount;
+    private UUID timeDealId;
+    private BigDecimal timeDealPrice;
+    private BigDecimal timeDealDiscountAmount;
+
+    public static OrderItemRes from(OrderItem orderItem) {
+        if (orderItem == null) {
+            return null;
+        }
+        return OrderItemRes.builder()
+                .orderItemId(orderItem.getOrderItemId())
+                .productId(orderItem.getProductId())
+                .productName(orderItem.getProductName())
+                .unitPrice(orderItem.getUnitPrice())
+                .quantity(orderItem.getQuantity())
+                .lineTotalAmount(orderItem.getLineTotalAmount())
+                .timeDealId(orderItem.getTimeDealId())
+                .timeDealPrice(orderItem.getTimeDealPrice())
+                .timeDealDiscountAmount(orderItem.getTimeDealDiscountAmount())
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/PaymentRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/PaymentRes.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -16,29 +15,14 @@ import java.util.UUID;
 public class PaymentRes {
 
     private final UUID paymentId;
-    private final UUID orderId;
-    private final Long userId;
     private final BigDecimal amount;
-    private final String paymentMethod;
-    private final String currency;
-    private final String paymentKey;
-    private final String status;
-    private final LocalDateTime requestedAt;
-    private final LocalDateTime completedAt;
+
 
     // Infrastructure DTO → Application DTO 변환
     public static PaymentRes from(PaymentDTO paymentDTO) {
         return PaymentRes.builder()
                 .paymentId(paymentDTO.getPaymentId())
-                .orderId(paymentDTO.getOrderId())
-                .userId(paymentDTO.getUserId())
                 .amount(paymentDTO.getAmount())
-                .paymentMethod(paymentDTO.getPaymentMethod())
-                .currency(paymentDTO.getCurrency())
-                .paymentKey(paymentDTO.getPaymentKey())
-                .status(paymentDTO.getStatus())
-                .requestedAt(paymentDTO.getRequestedAt())
-                .completedAt(paymentDTO.getCompletedAt())
                 .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/PaymentRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/PaymentRes.java
@@ -1,18 +1,44 @@
 package com.palja.order_service.application.dto;
 
 import com.palja.order_service.infrastructure.external.dto.response.PaymentDTO;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
-@AllArgsConstructor
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentRes {
 
     private final UUID paymentId;
+    private final UUID orderId;
+    private final Long userId;
+    private final BigDecimal amount;
+    private final String paymentMethod;
+    private final String currency;
+    private final String paymentKey;
+    private final String status;
+    private final LocalDateTime requestedAt;
+    private final LocalDateTime completedAt;
 
-    public static PaymentRes from(PaymentDTO dto) {
-        return new PaymentRes(dto.getPaymentId());
+    // Infrastructure DTO → Application DTO 변환
+    public static PaymentRes from(PaymentDTO paymentDTO) {
+        return PaymentRes.builder()
+                .paymentId(paymentDTO.getPaymentId())
+                .orderId(paymentDTO.getOrderId())
+                .userId(paymentDTO.getUserId())
+                .amount(paymentDTO.getAmount())
+                .paymentMethod(paymentDTO.getPaymentMethod())
+                .currency(paymentDTO.getCurrency())
+                .paymentKey(paymentDTO.getPaymentKey())
+                .status(paymentDTO.getStatus())
+                .requestedAt(paymentDTO.getRequestedAt())
+                .completedAt(paymentDTO.getCompletedAt())
+                .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/PaymentRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/PaymentRes.java
@@ -1,6 +1,5 @@
 package com.palja.order_service.application.dto;
 
-import com.palja.order_service.infrastructure.external.dto.response.PaymentDTO;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,12 +16,10 @@ public class PaymentRes {
     private final UUID paymentId;
     private final BigDecimal amount;
 
-
-    // Infrastructure DTO → Application DTO 변환
-    public static PaymentRes from(PaymentDTO paymentDTO) {
+    public static PaymentRes of(UUID paymentId, BigDecimal amount) {
         return PaymentRes.builder()
-                .paymentId(paymentDTO.getPaymentId())
-                .amount(paymentDTO.getAmount())
+                .paymentId(paymentId)
+                .amount(amount)
                 .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/PaymentRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/PaymentRes.java
@@ -1,0 +1,18 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.order_service.infrastructure.external.dto.response.PaymentDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class PaymentRes {
+
+    private final UUID paymentId;
+
+    public static PaymentRes from(PaymentDTO dto) {
+        return new PaymentRes(dto.getPaymentId());
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/PricingRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/PricingRes.java
@@ -1,0 +1,28 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.order_service.domain.entity.Order;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+// 가격 정보
+@Getter
+@Builder
+public class PricingRes {
+    private BigDecimal productTotalAmount;
+    private BigDecimal itemDiscountAmount;
+    private BigDecimal couponDiscountAmount;
+    private BigDecimal deliveryFee;
+    private BigDecimal finalAmount;
+
+    public static PricingRes from(Order order) {
+        return PricingRes.builder()
+                .productTotalAmount(order.getOrderAmount().getProductTotalAmount())
+                .itemDiscountAmount(order.getOrderAmount().getItemDiscountAmount())
+                .couponDiscountAmount(order.getOrderAmount().getCouponDiscountAmount())
+                .deliveryFee(order.getOrderAmount().getDeliveryFee())
+                .finalAmount(order.getOrderAmount().getFinalAmount())
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/PricingRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/PricingRes.java
@@ -1,6 +1,8 @@
 package com.palja.order_service.application.dto;
 
 import com.palja.order_service.domain.entity.Order;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,7 +10,8 @@ import java.math.BigDecimal;
 
 // 가격 정보
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PricingRes {
     private BigDecimal productTotalAmount;
     private BigDecimal itemDiscountAmount;

--- a/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
@@ -1,0 +1,45 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.order_service.application.exception.OrderErrorCode;
+import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class ProductRes {
+    private UUID productId;
+    private String productName;
+    private BigDecimal price;
+    private int stockQuantity;
+
+    // 외부 Product API 응답 → 주문용 ProductRes 변환
+    public static ProductRes from(ProductDTO productDTO) {
+        if (productDTO == null) {
+            throw new BusinessException(OrderErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        return ProductRes.builder()
+                .productId(productDTO.getProductId())
+                .productName(productDTO.getName())
+                .price(productDTO.getPrice())
+                .stockQuantity(productDTO.getStock())
+                .build();
+    }
+
+    // 총 상품 금액 계산 (단가 × 수량)
+    public BigDecimal calculateProductTotalAmount(int quantity) {
+        return price.multiply(BigDecimal.valueOf(quantity));
+    }
+
+    // 재고 검증
+    public void validateStock(int quantity) {
+        if (stockQuantity < quantity) {
+            throw new BusinessException(OrderErrorCode.INSUFFICIENT_STOCK);
+        }
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
@@ -1,6 +1,5 @@
 package com.palja.order_service.application.dto;
 
-import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,13 +17,17 @@ public class ProductRes {
     private BigDecimal price;
     private int stockQuantity;
 
-    // Infrastructure DTO → Application DTO 변환
-    public static ProductRes from(ProductDTO productDTO) {
+    public static ProductRes of(
+            UUID productId,
+            String productName,
+            BigDecimal price,
+            int stockQuantity
+    ) {
         return ProductRes.builder()
-                .productId(productDTO.getProductId())
-                .productName(productDTO.getName())
-                .price(productDTO.getPrice())
-                .stockQuantity(productDTO.getStock())
+                .productId(productId)
+                .productName(productName)
+                .price(price)
+                .stockQuantity(stockQuantity)
                 .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
@@ -1,7 +1,5 @@
 package com.palja.order_service.application.dto;
 
-import com.palja.common.exception.BusinessException;
-import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,29 +15,13 @@ public class ProductRes {
     private BigDecimal price;
     private int stockQuantity;
 
-    // 외부 Product API 응답 → 주문용 ProductRes 변환
+    // Infrastructure DTO → Application DTO 변환
     public static ProductRes from(ProductDTO productDTO) {
-        if (productDTO == null) {
-            throw new BusinessException(OrderErrorCode.PRODUCT_NOT_FOUND);
-        }
-
         return ProductRes.builder()
                 .productId(productDTO.getProductId())
                 .productName(productDTO.getName())
                 .price(productDTO.getPrice())
                 .stockQuantity(productDTO.getStock())
                 .build();
-    }
-
-    // 총 상품 금액 계산 (단가 × 수량)
-    public BigDecimal calculateProductTotalAmount(int quantity) {
-        return price.multiply(BigDecimal.valueOf(quantity));
-    }
-
-    // 재고 검증
-    public void validateStock(int quantity) {
-        if (stockQuantity < quantity) {
-            throw new BusinessException(OrderErrorCode.INSUFFICIENT_STOCK);
-        }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
@@ -1,6 +1,8 @@
 package com.palja.order_service.application.dto;
 
 import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,7 +10,8 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductRes {
     private UUID productId;
     private String productName;

--- a/order-service/src/main/java/com/palja/order_service/application/dto/TimeDealRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/TimeDealRes.java
@@ -1,6 +1,5 @@
 package com.palja.order_service.application.dto;
 
-import com.palja.order_service.infrastructure.external.dto.response.TimeDealDTO;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,17 +23,25 @@ public class TimeDealRes {
     private final int timeDealStockQuantity;
     private final String status;
 
-    // Infrastructure DTO → Application DTO 변환
-    public static TimeDealRes from(TimeDealDTO timeDealDTO) {
+    public static TimeDealRes of(
+            UUID timeDealId,
+            UUID productId,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            BigDecimal timeDealPrice,
+            int discountRate,
+            int timeDealStockQuantity,
+            String status
+    ) {
         return TimeDealRes.builder()
-                .timeDealId(timeDealDTO.getTimeDealId())
-                .productId(timeDealDTO.getProductId())
-                .startAt(timeDealDTO.getStartAt())
-                .endAt(timeDealDTO.getEndAt())
-                .timeDealPrice(timeDealDTO.getTimeDealPrice())
-                .discountRate(timeDealDTO.getDiscountRate())
-                .timeDealStockQuantity(timeDealDTO.getQuantity())
-                .status(timeDealDTO.getStatus())
+                .timeDealId(timeDealId)
+                .productId(productId)
+                .startAt(startAt)
+                .endAt(endAt)
+                .timeDealPrice(timeDealPrice)
+                .discountRate(discountRate)
+                .timeDealStockQuantity(timeDealStockQuantity)
+                .status(status)
                 .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/TimeDealRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/TimeDealRes.java
@@ -1,7 +1,5 @@
 package com.palja.order_service.application.dto;
 
-import com.palja.common.exception.BusinessException;
-import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.infrastructure.external.dto.response.TimeDealDTO;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,10 +26,6 @@ public class TimeDealRes {
 
     // Infrastructure DTO → Application DTO 변환
     public static TimeDealRes from(TimeDealDTO timeDealDTO) {
-        if (timeDealDTO == null) {
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_NOT_FOUND);
-        }
-
         return TimeDealRes.builder()
                 .timeDealId(timeDealDTO.getTimeDealId())
                 .productId(timeDealDTO.getProductId())
@@ -42,48 +36,5 @@ public class TimeDealRes {
                 .timeDealStockQuantity(timeDealDTO.getQuantity())
                 .status(timeDealDTO.getStatus())
                 .build();
-    }
-
-    // 타임딜 전체 검증
-    public void validate(int requestedQuantity) {
-        validatePeriod();
-        validateStatus();
-        validateStock(requestedQuantity);
-    }
-
-    // 타임딜 기간 내인지 확인
-    public void validatePeriod() {
-        LocalDateTime now = LocalDateTime.now();
-
-        if (now.isBefore(startAt)) {
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_NOT_STARTED);
-        }
-        if (now.isAfter(endAt)) {
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_EXPIRED);
-        }
-    }
-
-    // 타임딜 재고 검증
-    public void validateStock(int requestedQuantity) {
-        // 필요한 수량보다 적음
-        if (timeDealStockQuantity < requestedQuantity) {
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_INSUFFICIENT_STOCK);
-        }
-    }
-
-    // 타임딜 상태 검증
-    public void validateStatus() {
-        if (!"OPEN".equals(status)) {
-            throw new BusinessException(OrderErrorCode.INVALID_TIME_DEAL);
-        }
-    }
-
-    // 활성 상태 확인
-    public boolean isActive() {
-        LocalDateTime now = LocalDateTime.now();
-        return "OPEN".equals(status)
-                && now.isAfter(startAt)
-                && now.isBefore(endAt)
-                && timeDealStockQuantity > 0;
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/TimeDealRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/TimeDealRes.java
@@ -1,0 +1,89 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.order_service.application.exception.OrderErrorCode;
+import com.palja.order_service.infrastructure.external.dto.response.TimeDealDTO;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TimeDealRes {
+
+    private final UUID timeDealId;
+    private final UUID productId;
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+    private final BigDecimal timeDealPrice;
+    private final int discountRate;
+    private final int timeDealStockQuantity;
+    private final String status;
+
+    // Infrastructure DTO → Application DTO 변환
+    public static TimeDealRes from(TimeDealDTO timeDealDTO) {
+        if (timeDealDTO == null) {
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_NOT_FOUND);
+        }
+
+        return TimeDealRes.builder()
+                .timeDealId(timeDealDTO.getTimeDealId())
+                .productId(timeDealDTO.getProductId())
+                .startAt(timeDealDTO.getStartAt())
+                .endAt(timeDealDTO.getEndAt())
+                .timeDealPrice(timeDealDTO.getTimeDealPrice())
+                .discountRate(timeDealDTO.getDiscountRate())
+                .timeDealStockQuantity(timeDealDTO.getQuantity())
+                .status(timeDealDTO.getStatus())
+                .build();
+    }
+
+    // 타임딜 전체 검증
+    public void validate(int requestedQuantity) {
+        validatePeriod();
+        validateStatus();
+        validateStock(requestedQuantity);
+    }
+
+    // 타임딜 기간 내인지 확인
+    public void validatePeriod() {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(startAt)) {
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_NOT_STARTED);
+        }
+        if (now.isAfter(endAt)) {
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_EXPIRED);
+        }
+    }
+
+    // 타임딜 재고 검증
+    public void validateStock(int requestedQuantity) {
+        // 필요한 수량보다 적음
+        if (timeDealStockQuantity < requestedQuantity) {
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_INSUFFICIENT_STOCK);
+        }
+    }
+
+    // 타임딜 상태 검증
+    public void validateStatus() {
+        if (!"OPEN".equals(status)) {
+            throw new BusinessException(OrderErrorCode.INVALID_TIME_DEAL);
+        }
+    }
+
+    // 활성 상태 확인
+    public boolean isActive() {
+        LocalDateTime now = LocalDateTime.now();
+        return "OPEN".equals(status)
+                && now.isAfter(startAt)
+                && now.isBefore(endAt)
+                && timeDealStockQuantity > 0;
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
@@ -1,0 +1,56 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.exception.OrderErrorCode;
+import com.palja.order_service.infrastructure.external.dto.response.UserDTO;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+// 사용자 정보 응답 DTO
+@Builder
+public record UserRes(
+        Long userId,
+        String loginId,
+        String name,
+        String email,
+        String address,
+        UserRole role,
+        String status,
+        LocalDateTime createdAt
+) {
+    // Infrastructure DTO → Application DTO 변환
+    public static UserRes from(UserDTO userDTO) {
+        if (userDTO == null) {
+            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
+        }
+
+        return UserRes.builder()
+                .userId(userDTO.getUserId())
+                .loginId(userDTO.getLoginId())
+                .name(userDTO.getName())
+                .email(userDTO.getEmail())
+                .address(userDTO.getAddress())
+                .role(userDTO.getRole() != null ? userDTO.getRole() : null)
+                .status(userDTO.getStatus())
+                .createdAt(userDTO.getCreatedAt())
+                .build();
+    }
+
+    // 주문 가능 여부 검증
+    public void validateOrderable() {
+        if (!"ACTIVE".equals(status)) {
+            throw new BusinessException(OrderErrorCode.INVALID_USER_ID);
+        }
+
+        if (UserRole.COMPANY_USER.equals(role)) {
+            throw new BusinessException(OrderErrorCode.USER_NOT_ALLOWED);
+        }
+    }
+
+    // 활성 사용자 여부
+    public boolean isActive() {
+        return "ACTIVE".equals(status);
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
@@ -1,7 +1,7 @@
 package com.palja.order_service.application.dto;
 
 import com.palja.common.vo.UserRole;
-import com.palja.order_service.infrastructure.external.dto.response.UserDTO;
+import com.palja.order_service.infrastructure.external.dto.response.CustomerUserDTO;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,16 +24,16 @@ public class UserRes {
     private final LocalDateTime createdAt;
 
     // Infrastructure DTO → Application DTO 변환
-    public static UserRes from(UserDTO userDTO) {
+    public static UserRes from(CustomerUserDTO customerUserDTO) {
         return UserRes.builder()
-                .userId(userDTO.getUserId())
-                .loginId(userDTO.getLoginId())
-                .name(userDTO.getName())
-                .email(userDTO.getEmail())
-                .address(userDTO.getAddress())
-                .role(userDTO.getRole()) // null 허용
-                .status(userDTO.getStatus())
-                .createdAt(userDTO.getCreatedAt())
+                .userId(customerUserDTO.getUserId())
+                .loginId(customerUserDTO.getLoginId())
+                .name(customerUserDTO.getName())
+                .email(customerUserDTO.getEmail())
+                .address(customerUserDTO.getAddress())
+                .role(customerUserDTO.getRole()) // null 허용
+                .status(customerUserDTO.getStatus())
+                .createdAt(customerUserDTO.getCreatedAt())
                 .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
@@ -2,22 +2,27 @@ package com.palja.order_service.application.dto;
 
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.infrastructure.external.dto.response.UserDTO;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-// 사용자 정보 응답 DTO
-@Builder
-public record UserRes(
-        Long userId,
-        String loginId,
-        String name,
-        String email,
-        String address,
-        UserRole role,
-        String status,
-        LocalDateTime createdAt
-) {
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserRes {
+
+    private final Long userId;
+    private final String loginId;
+    private final String name;
+    private final String email;
+    private final String address;
+    private final UserRole role;
+    private final String status;
+    private final LocalDateTime createdAt;
+
     // Infrastructure DTO → Application DTO 변환
     public static UserRes from(UserDTO userDTO) {
         return UserRes.builder()
@@ -26,7 +31,7 @@ public record UserRes(
                 .name(userDTO.getName())
                 .email(userDTO.getEmail())
                 .address(userDTO.getAddress())
-                .role(userDTO.getRole() != null ? userDTO.getRole() : null)
+                .role(userDTO.getRole()) // null 허용
                 .status(userDTO.getStatus())
                 .createdAt(userDTO.getCreatedAt())
                 .build();

--- a/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
@@ -1,13 +1,10 @@
 package com.palja.order_service.application.dto;
 
 import com.palja.common.vo.UserRole;
-import com.palja.order_service.infrastructure.external.dto.response.CustomerUserDTO;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -18,22 +15,24 @@ public class UserRes {
     private final String loginId;
     private final String name;
     private final String email;
-    private final String address;
     private final UserRole role;
     private final String status;
-    private final LocalDateTime createdAt;
 
-    // Infrastructure DTO → Application DTO 변환
-    public static UserRes from(CustomerUserDTO customerUserDTO) {
+    public static UserRes of(
+            Long userId,
+            String loginId,
+            String name,
+            String email,
+            UserRole role,
+            String status
+    ) {
         return UserRes.builder()
-                .userId(customerUserDTO.getUserId())
-                .loginId(customerUserDTO.getLoginId())
-                .name(customerUserDTO.getName())
-                .email(customerUserDTO.getEmail())
-                .address(customerUserDTO.getAddress())
-                .role(customerUserDTO.getRole()) // null 허용
-                .status(customerUserDTO.getStatus())
-                .createdAt(customerUserDTO.getCreatedAt())
+                .userId(userId)
+                .loginId(loginId)
+                .name(name)
+                .email(email)
+                .role(role)
+                .status(status)
                 .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/UserRes.java
@@ -1,8 +1,6 @@
 package com.palja.order_service.application.dto;
 
-import com.palja.common.exception.BusinessException;
 import com.palja.common.vo.UserRole;
-import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.infrastructure.external.dto.response.UserDTO;
 import lombok.Builder;
 
@@ -22,10 +20,6 @@ public record UserRes(
 ) {
     // Infrastructure DTO → Application DTO 변환
     public static UserRes from(UserDTO userDTO) {
-        if (userDTO == null) {
-            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
-        }
-
         return UserRes.builder()
                 .userId(userDTO.getUserId())
                 .loginId(userDTO.getLoginId())
@@ -36,21 +30,5 @@ public record UserRes(
                 .status(userDTO.getStatus())
                 .createdAt(userDTO.getCreatedAt())
                 .build();
-    }
-
-    // 주문 가능 여부 검증
-    public void validateOrderable() {
-        if (!"ACTIVE".equals(status)) {
-            throw new BusinessException(OrderErrorCode.INVALID_USER_ID);
-        }
-
-        if (UserRole.COMPANY_USER.equals(role)) {
-            throw new BusinessException(OrderErrorCode.USER_NOT_ALLOWED);
-        }
-    }
-
-    // 활성 사용자 여부
-    public boolean isActive() {
-        return "ACTIVE".equals(status);
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -1,0 +1,94 @@
+package com.palja.order_service.application.exception;
+
+import com.palja.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+
+    // 사용자
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // ============ 주문 생성 관련 (400) ============
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "주문 수량은 1 이상이어야 합니다."),
+    INVALID_PRODUCT_PRICE(HttpStatus.BAD_REQUEST, "상품 가격이 유효하지 않습니다."),
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "주문자 정보가 유효하지 않습니다."),
+    MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "필수 입력 항목이 누락되었습니다."),
+
+    // ============ 재고/수량 관련 (400) ============
+    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "품절된 상품입니다."),
+
+    // ============ 타임딜 관련 (400, 404, 409) ============
+    TIME_DEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "타임딜을 찾을 수 없습니다."),
+    TIME_DEAL_EXPIRED(HttpStatus.BAD_REQUEST, "타임딜 기간이 만료되었습니다."),
+    TIME_DEAL_NOT_STARTED(HttpStatus.BAD_REQUEST, "타임딜이 아직 시작되지 않았습니다."),
+    TIME_DEAL_SOLD_OUT(HttpStatus.CONFLICT, "타임딜 수량이 모두 소진되었습니다."),
+    TIME_DEAL_INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "타임딜 재고가 부족합니다."),
+    INVALID_TIME_DEAL(HttpStatus.BAD_REQUEST, "유효하지 않은 타임딜입니다."),
+
+    // ============ 쿠폰 관련 (400) ============
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰을 찾을 수 없습니다."),
+    COUPON_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "사용할 수 없는 쿠폰입니다."),
+    COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 사용된 쿠폰입니다."),
+    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 쿠폰입니다."),
+    COUPON_MIN_AMOUNT_NOT_MET(HttpStatus.BAD_REQUEST, "쿠폰 사용 최소 금액을 충족하지 않습니다."),
+    INVALID_COUPON(HttpStatus.BAD_REQUEST, "유효하지 않은 쿠폰입니다."),
+    COUPON_USE_FAILED(HttpStatus.BAD_REQUEST, "쿠폰 사용에 실패했습니다."),
+
+    // ============ 주문 조회 관련 (404) ============
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
+    ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 상품 정보를 찾을 수 없습니다."),
+    ORDER_DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
+
+    // ============ 상품 조회 관련 (404) ============
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+    PRODUCT_UNAVAILABLE(HttpStatus.BAD_REQUEST, "판매 중단된 상품입니다."),
+
+    // ============ 주문 상태 관련 (400, 409) ============
+    INVALID_ORDER_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "주문 상태를 변경할 수 없습니다."),
+    ORDER_ALREADY_PAID(HttpStatus.CONFLICT, "이미 결제 완료된 주문입니다."),
+    ORDER_ALREADY_CANCELED(HttpStatus.CONFLICT, "이미 취소된 주문입니다."),
+    ORDER_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "취소할 수 없는 주문 상태입니다."),
+    ORDER_CANNOT_CONFIRM(HttpStatus.BAD_REQUEST, "구매 확정할 수 없는 주문 상태입니다."),
+
+    // ============ 배송 상태 관련 (400) ============
+    INVALID_DELIVERY_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "배송 상태를 변경할 수 없습니다."),
+    DELIVERY_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 배송이 시작된 주문입니다."),
+    DELIVERY_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "배송이 완료되지 않은 주문입니다."),
+    DELIVERY_INFO_NOT_EDITABLE(HttpStatus.BAD_REQUEST, "배송 정보를 수정할 수 없는 상태입니다."),
+
+    // ============ 배송 정보 관련 (400) ============
+    INVALID_RECIPIENT_INFO(HttpStatus.BAD_REQUEST, "수령인 정보가 유효하지 않습니다."),
+    INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "배송 주소가 유효하지 않습니다."),
+    INVALID_TRACKING_NUMBER(HttpStatus.BAD_REQUEST, "운송장 번호가 유효하지 않습니다."),
+
+    // ============ 결제 관련 (400, 500) ============
+    PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "결제에 실패했습니다."),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
+    PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "결제 시간이 초과되었습니다."),
+
+    // ============ 권한 관련 (403) ============
+    USER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "접근 권한이 없는 사용자입니다."),
+    ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "주문에 접근할 권한이 없습니다."),
+    ORDER_MODIFICATION_DENIED(HttpStatus.FORBIDDEN, "주문을 수정할 권한이 없습니다."),
+
+    // ============ 외부 서비스 연동 오류 (503) ============
+    PRODUCT_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "상품 서비스 연동 중 오류가 발생했습니다."),
+    COUPON_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "쿠폰 서비스 연동 중 오류가 발생했습니다."),
+    USER_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "사용자 서비스 연동 중 오류가 발생했습니다."),
+    TIME_DEAL_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "타임딜 서비스 연동 중 오류가 발생했습니다."),
+    PAYMENT_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "결제 서비스 연동 중 오류가 발생했습니다."),
+
+    // ============ 서버 내부 오류 (500) ============
+    ORDER_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "주문 생성 중 오류가 발생했습니다."),
+    ORDER_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "주문 수정 중 오류가 발생했습니다."),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -12,17 +12,21 @@ public enum OrderErrorCode implements ErrorCode {
     // 사용자
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
-    // ============ 주문 생성 관련 (400) ============
+    // ===== 주문 관련 =====
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
+    ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 상품 정보를 찾을 수 없습니다."),
+    ORDER_DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
+    INVALID_ORDER_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "주문 상태를 변경할 수 없습니다."),
+    ORDER_ALREADY_PAID(HttpStatus.CONFLICT, "이미 결제 완료된 주문입니다."),
+    ORDER_ALREADY_CANCELED(HttpStatus.CONFLICT, "이미 취소된 주문입니다."),
+    ORDER_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "취소할 수 없는 주문 상태입니다."),
+    ORDER_CANNOT_CONFIRM(HttpStatus.BAD_REQUEST, "구매 확정할 수 없는 주문 상태입니다."),
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "주문 수량은 1 이상이어야 합니다."),
     INVALID_PRODUCT_PRICE(HttpStatus.BAD_REQUEST, "상품 가격이 유효하지 않습니다."),
     INVALID_USER_ID(HttpStatus.BAD_REQUEST, "주문자 정보가 유효하지 않습니다."),
     MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "필수 입력 항목이 누락되었습니다."),
 
-    // ============ 재고/수량 관련 (400) ============
-    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
-    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "품절된 상품입니다."),
-
-    // ============ 타임딜 관련 (400, 404, 409) ============
+    // ===== 타임딜 관련 =====
     TIME_DEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "타임딜을 찾을 수 없습니다."),
     TIME_DEAL_EXPIRED(HttpStatus.BAD_REQUEST, "타임딜 기간이 만료되었습니다."),
     TIME_DEAL_NOT_STARTED(HttpStatus.BAD_REQUEST, "타임딜이 아직 시작되지 않았습니다."),
@@ -30,7 +34,7 @@ public enum OrderErrorCode implements ErrorCode {
     TIME_DEAL_INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "타임딜 재고가 부족합니다."),
     INVALID_TIME_DEAL(HttpStatus.BAD_REQUEST, "유효하지 않은 타임딜입니다."),
 
-    // ============ 쿠폰 관련 (400) ============
+    // ==== 쿠폰 관련 ====
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰을 찾을 수 없습니다."),
     COUPON_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "사용할 수 없는 쿠폰입니다."),
     COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 사용된 쿠폰입니다."),
@@ -39,51 +43,39 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_COUPON(HttpStatus.BAD_REQUEST, "유효하지 않은 쿠폰입니다."),
     COUPON_USE_FAILED(HttpStatus.BAD_REQUEST, "쿠폰 사용에 실패했습니다."),
 
-    // ============ 주문 조회 관련 (404) ============
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
-    ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 상품 정보를 찾을 수 없습니다."),
-    ORDER_DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
-
-    // ============ 상품 조회 관련 (404) ============
+    // ==== 상품 관련 =====
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
     PRODUCT_UNAVAILABLE(HttpStatus.BAD_REQUEST, "판매 중단된 상품입니다."),
+    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "품절된 상품입니다."),
 
-    // ============ 주문 상태 관련 (400, 409) ============
-    INVALID_ORDER_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "주문 상태를 변경할 수 없습니다."),
-    ORDER_ALREADY_PAID(HttpStatus.CONFLICT, "이미 결제 완료된 주문입니다."),
-    ORDER_ALREADY_CANCELED(HttpStatus.CONFLICT, "이미 취소된 주문입니다."),
-    ORDER_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "취소할 수 없는 주문 상태입니다."),
-    ORDER_CANNOT_CONFIRM(HttpStatus.BAD_REQUEST, "구매 확정할 수 없는 주문 상태입니다."),
-
-    // ============ 배송 상태 관련 (400) ============
+    // ===== 배송 관련 =====
     INVALID_DELIVERY_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "배송 상태를 변경할 수 없습니다."),
     DELIVERY_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 배송이 시작된 주문입니다."),
     DELIVERY_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "배송이 완료되지 않은 주문입니다."),
     DELIVERY_INFO_NOT_EDITABLE(HttpStatus.BAD_REQUEST, "배송 정보를 수정할 수 없는 상태입니다."),
-
-    // ============ 배송 정보 관련 (400) ============
     INVALID_RECIPIENT_INFO(HttpStatus.BAD_REQUEST, "수령인 정보가 유효하지 않습니다."),
     INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "배송 주소가 유효하지 않습니다."),
     INVALID_TRACKING_NUMBER(HttpStatus.BAD_REQUEST, "운송장 번호가 유효하지 않습니다."),
 
-    // ============ 결제 관련 (400, 500) ============
+    // ===== 결제 관련 =====
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "결제에 실패했습니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "결제 시간이 초과되었습니다."),
 
-    // ============ 권한 관련 (403) ============
+    // ===== 권한 관련 =====
     USER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "접근 권한이 없는 사용자입니다."),
     ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "주문에 접근할 권한이 없습니다."),
     ORDER_MODIFICATION_DENIED(HttpStatus.FORBIDDEN, "주문을 수정할 권한이 없습니다."),
 
-    // ============ 외부 서비스 연동 오류 (503) ============
+    // ===== 외부 서비스 연동 오류 =====
     PRODUCT_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "상품 서비스 연동 중 오류가 발생했습니다."),
     COUPON_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "쿠폰 서비스 연동 중 오류가 발생했습니다."),
     USER_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "사용자 서비스 연동 중 오류가 발생했습니다."),
     TIME_DEAL_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "타임딜 서비스 연동 중 오류가 발생했습니다."),
     PAYMENT_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "결제 서비스 연동 중 오류가 발생했습니다."),
 
-    // ============ 서버 내부 오류 (500) ============
+    // ===== 서버 내부 오류 =====
     ORDER_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "주문 생성 중 오류가 발생했습니다."),
     ORDER_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "주문 수정 중 오류가 발생했습니다."),
 

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -42,6 +42,8 @@ public enum OrderErrorCode implements ErrorCode {
     COUPON_MIN_AMOUNT_NOT_MET(HttpStatus.BAD_REQUEST, "쿠폰 사용 최소 금액을 충족하지 않습니다."),
     INVALID_COUPON(HttpStatus.BAD_REQUEST, "유효하지 않은 쿠폰입니다."),
     COUPON_USE_FAILED(HttpStatus.BAD_REQUEST, "쿠폰 사용에 실패했습니다."),
+    INVALID_COUPON_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 쿠폰 타입입니다."),
+    INVALID_COUPON_VALUE(HttpStatus.BAD_REQUEST, "쿠폰 할인 값이 올바르지 않습니다."),
 
     // ==== 상품 관련 =====
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),

--- a/order-service/src/main/java/com/palja/order_service/application/service/CouponService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/CouponService.java
@@ -1,4 +1,12 @@
 package com.palja.order_service.application.service;
 
+import com.palja.order_service.application.dto.CouponRes;
+
+import java.util.UUID;
+
 public interface CouponService {
+
+    CouponRes getCoupon(UUID couponId);
+
+    void useCoupon(UUID couponId, UUID orderId);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
@@ -1,4 +1,8 @@
 package com.palja.order_service.application.service;
 
+import com.palja.order_service.application.command.CreateOrderCommand;
+import com.palja.order_service.application.dto.CreateOrderRes;
+
 public interface OrderService {
+    CreateOrderRes createOrder(CreateOrderCommand command);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
@@ -1,8 +1,8 @@
 package com.palja.order_service.application.service;
 
 import com.palja.order_service.application.command.CreateOrderCommand;
-import com.palja.order_service.application.dto.CreateOrderRes;
+import com.palja.order_service.application.dto.OrderCreateRes;
 
 public interface OrderService {
-    CreateOrderRes createOrder(CreateOrderCommand command);
+    OrderCreateRes createOrder(CreateOrderCommand command);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/PaymentService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/PaymentService.java
@@ -1,0 +1,11 @@
+package com.palja.order_service.application.service;
+
+import com.palja.order_service.application.dto.PaymentRes;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public interface PaymentService {
+
+    PaymentRes createPayment(UUID orderId, Long userId, BigDecimal amount, String paymentMethod);
+}

--- a/order-service/src/main/java/com/palja/order_service/application/service/ProductService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/ProductService.java
@@ -1,4 +1,17 @@
 package com.palja.order_service.application.service;
 
+import com.palja.order_service.application.dto.ProductRes;
+
+import java.util.UUID;
+
 public interface ProductService {
+
+    // 주문 생성 시 상품 정보 조회
+    ProductRes getProduct(UUID productId, int quantity);
+
+    // 주문 확정 시 상품 재고 차감
+    void deductStock(UUID productId, int quantity);
+
+    // 주문 취소 시 상품 재고 복구
+    void restoreStock(UUID productId, int quantity);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/TimeDealService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/TimeDealService.java
@@ -1,4 +1,14 @@
 package com.palja.order_service.application.service;
 
+import com.palja.order_service.application.dto.TimeDealRes;
+
+import java.util.UUID;
+
 public interface TimeDealService {
+
+    TimeDealRes getTimeDeal(UUID timeDealId, int quantity);
+
+    void deductTimeDealStock(UUID timeDealId, int quantity);
+
+    void restoreTimeDealStock(UUID timeDealId, int quantity);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/UserService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/UserService.java
@@ -1,4 +1,8 @@
 package com.palja.order_service.application.service;
 
+import com.palja.order_service.application.dto.UserRes;
+
 public interface UserService {
+
+    UserRes getUserByLoginId(String loginId);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/calculator/OrderCalculator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/calculator/OrderCalculator.java
@@ -1,0 +1,83 @@
+package com.palja.order_service.application.service.calculator;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.order_service.application.dto.CouponRes;
+import com.palja.order_service.application.dto.ProductRes;
+import com.palja.order_service.application.dto.TimeDealRes;
+import com.palja.order_service.application.exception.OrderErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+// 주문 금액 계산을 담당
+@Slf4j
+@Component
+public class OrderCalculator {
+
+    /**
+     * 쿠폰 할인 전 총 금액 계산
+     */
+    public BigDecimal calculateAmountBeforeCoupon(
+            ProductRes product,
+            TimeDealRes timeDeal,
+            int quantity) {
+
+        BigDecimal unitPrice = (timeDeal != null)
+                ? timeDeal.getTimeDealPrice()
+                : product.getPrice();
+
+        return unitPrice.multiply(BigDecimal.valueOf(quantity));
+    }
+
+    /**
+     * 쿠폰 할인 금액 계산
+     */
+    public BigDecimal calculateCouponDiscount(CouponRes coupon, BigDecimal orderAmount) {
+        if (orderAmount == null || orderAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO;
+        }
+
+        if (coupon.getDiscountType() == null) {
+            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
+        }
+
+        BigDecimal discountAmount;
+
+        if ("PERCENTAGE".equalsIgnoreCase(coupon.getDiscountType())) {
+            // 퍼센트 할인
+            discountAmount = calculatePercentageDiscount(coupon.getDiscountValue(), orderAmount);
+        } else if ("FIXED".equalsIgnoreCase(coupon.getDiscountType())) {
+            // 정액 할인
+            discountAmount = BigDecimal.valueOf(coupon.getDiscountValue());
+        } else {
+            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
+        }
+
+        // 최대 할인 금액 제한
+        if (coupon.getMaxDiscountAmount() != null
+                && discountAmount.compareTo(coupon.getMaxDiscountAmount()) > 0) {
+            discountAmount = coupon.getMaxDiscountAmount();
+        }
+
+        // 할인 금액은 주문 금액을 초과할 수 없음
+        if (discountAmount.compareTo(orderAmount) > 0) {
+            discountAmount = orderAmount;
+        }
+
+        if (discountAmount.compareTo(BigDecimal.ZERO) < 0) {
+            return BigDecimal.ZERO;
+        }
+
+        return discountAmount;
+    }
+
+    private BigDecimal calculatePercentageDiscount(int discountValue, BigDecimal orderAmount) {
+        BigDecimal rate = BigDecimal.valueOf(discountValue)
+                .divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP);
+
+        return orderAmount.multiply(rate)
+                .setScale(0, RoundingMode.FLOOR); // 원 단위 절사
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/service/calculator/OrderCalculator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/calculator/OrderCalculator.java
@@ -11,14 +11,12 @@ import org.springframework.stereotype.Component;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
-// 주문 금액 계산을 담당
+// 주문 금액 계산 담당
 @Slf4j
 @Component
 public class OrderCalculator {
 
-    /**
-     * 쿠폰 할인 전 총 금액 계산
-     */
+    // 쿠폰 할인 전 총 금액 계산
     public BigDecimal calculateAmountBeforeCoupon(
             ProductRes product,
             TimeDealRes timeDeal,
@@ -31,9 +29,7 @@ public class OrderCalculator {
         return unitPrice.multiply(BigDecimal.valueOf(quantity));
     }
 
-    /**
-     * 쿠폰 할인 금액 계산
-     */
+    // 쿠폰 할인 금액 계산
     public BigDecimal calculateCouponDiscount(CouponRes coupon, BigDecimal orderAmount) {
         if (orderAmount == null || orderAmount.compareTo(BigDecimal.ZERO) <= 0) {
             return BigDecimal.ZERO;
@@ -43,25 +39,13 @@ public class OrderCalculator {
             throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
         }
 
-        BigDecimal discountAmount;
+        BigDecimal discountAmount = calculateDiscountByType(coupon, orderAmount);
 
-        if ("PERCENTAGE".equalsIgnoreCase(coupon.getDiscountType())) {
-            // 퍼센트 할인
-            discountAmount = calculatePercentageDiscount(coupon.getDiscountValue(), orderAmount);
-        } else if ("FIXED".equalsIgnoreCase(coupon.getDiscountType())) {
-            // 정액 할인
-            discountAmount = BigDecimal.valueOf(coupon.getDiscountValue());
-        } else {
-            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
-        }
-
-        // 최대 할인 금액 제한
         if (coupon.getMaxDiscountAmount() != null
                 && discountAmount.compareTo(coupon.getMaxDiscountAmount()) > 0) {
             discountAmount = coupon.getMaxDiscountAmount();
         }
 
-        // 할인 금액은 주문 금액을 초과할 수 없음
         if (discountAmount.compareTo(orderAmount) > 0) {
             discountAmount = orderAmount;
         }
@@ -71,6 +55,14 @@ public class OrderCalculator {
         }
 
         return discountAmount;
+    }
+
+    private BigDecimal calculateDiscountByType(CouponRes coupon, BigDecimal orderAmount) {
+        return switch (coupon.getDiscountType()) {
+            case PERCENTAGE -> calculatePercentageDiscount(coupon.getDiscountValue(), orderAmount);
+            case FIXED -> BigDecimal.valueOf(coupon.getDiscountValue());
+            default -> throw new BusinessException(OrderErrorCode.INVALID_COUPON_TYPE);
+        };
     }
 
     private BigDecimal calculatePercentageDiscount(int discountValue, BigDecimal orderAmount) {

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -35,7 +35,7 @@ public class OrderServiceImpl implements OrderService {
     private final OrderCalculator orderCalculator;
 
     @Transactional
-    public CreateOrderRes createOrder(CreateOrderCommand command) {
+    public OrderCreateRes createOrder(CreateOrderCommand command) {
         log.info("주문 생성 시작: loginId={}, productId={}", command.loginId(), command.productId());
 
         orderValidator.validateCreateOrderCommand(command);
@@ -46,7 +46,7 @@ public class OrderServiceImpl implements OrderService {
 
         BigDecimal amountBeforeCoupon = calculateAmountBeforeCoupon(product, timeDeal, command.quantity());
 
-        CouponResult couponResult = CalculateValidCoupon(command.couponId(), amountBeforeCoupon);
+        CouponResult couponResult = calculateValidCoupon(command.couponId(), amountBeforeCoupon);
 
         Recipient recipient = createRecipient(command);
 
@@ -67,7 +67,7 @@ public class OrderServiceImpl implements OrderService {
         log.info("주문 생성 완료: orderId={}, finalAmount={}",
                 order.getOrderId(), order.getOrderAmount().getFinalAmount());
 
-        return CreateOrderRes.from(order);
+        return OrderCreateRes.from(order);
     }
 
     // ===== 도메인 객체 생성 =====
@@ -130,7 +130,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     // 쿠폰 검증 및 할인 계산
-    private CouponResult CalculateValidCoupon(UUID couponId, BigDecimal amountBeforeCoupon) {
+    private CouponResult calculateValidCoupon(UUID couponId, BigDecimal amountBeforeCoupon) {
         if (couponId == null) {
             return new CouponResult(BigDecimal.ZERO, null, null);
         }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -3,6 +3,8 @@ package com.palja.order_service.application.service.impl;
 import com.palja.order_service.application.command.CreateOrderCommand;
 import com.palja.order_service.application.dto.*;
 import com.palja.order_service.application.service.*;
+import com.palja.order_service.application.service.calculator.OrderCalculator;
+import com.palja.order_service.application.service.validator.OrderValidator;
 import com.palja.order_service.domain.entity.Order;
 import com.palja.order_service.domain.repository.OrderRepository;
 import com.palja.order_service.domain.service.OrderDomainService;
@@ -27,45 +29,43 @@ public class OrderServiceImpl implements OrderService {
     private final UserService userService;
     private final OrderDomainService orderDomainService;
 
-    // 주문 생성
+    private final OrderValidator orderValidator;
+    private final OrderCalculator orderCalculator;
+
     @Transactional
     public CreateOrderRes createOrder(CreateOrderCommand command) {
         log.info("주문 생성 시작: loginId={}, productId={}",
                 command.loginId(), command.productId());
 
         // 1. 요청 검증
-        command.validate();
+        orderValidator.validateCreateOrderCommand(command);
 
         // 2. 사용자 검증 및 정보 조회
         UserRes user = userService.getUserByLoginId(command.loginId());
-        user.validateOrderable();
+        orderValidator.validateUserOrderable(user);
 
         // 3. 상품 검증 및 정보 조회
         ProductRes product = productService.getProduct(command.productId(), command.quantity());
-        product.validateStock(command.quantity());
+        orderValidator.validateProductStock(product, command.quantity());
 
         // 4. 타임딜 검증 및 정보 조회 (타임딜 주문인 경우)
         TimeDealRes timeDeal = null;
-        if (command.isTimeDealOrder()) {
+        if (command.timeDealId() != null) {
             timeDeal = timeDealService.getTimeDeal(command.timeDealId(), command.quantity());
-            timeDeal.validate(command.quantity());
+            orderValidator.validateTimeDeal(timeDeal, command.quantity());
         }
 
-        // 5.할인 전 금액 계산 (상품 총액 - 타임딜 할인)
-        BigDecimal amountBeforeCoupon = calculateAmountBeforeCoupon(
+        // 5. 할인 전 금액 계산 (상품 총액 - 타임딜 할인)
+        BigDecimal amountBeforeCoupon = orderCalculator.calculateAmountBeforeCoupon(
                 product, timeDeal, command.quantity());
 
         // 6. 쿠폰 검증 및 할인 금액 계산 (쿠폰 사용 시)
         BigDecimal couponDiscountAmount = BigDecimal.ZERO;
         String couponName = null;
-        if (command.hasCoupon()) {
-            // 검증 및 정보 조회
-            CouponRes coupon = couponService.getCoupon(
-                    command.couponId());
-
-            // 쿠폰 검증 및 할인 금액 계산
-            coupon.validate(amountBeforeCoupon);
-            couponDiscountAmount = coupon.calculateDiscountAmount(amountBeforeCoupon);
+        if (command.couponId() != null) {
+            CouponRes coupon = couponService.getCoupon(command.couponId());
+            orderValidator.validateCoupon(coupon, amountBeforeCoupon);
+            couponDiscountAmount = orderCalculator.calculateCouponDiscount(coupon, amountBeforeCoupon);
             couponName = coupon.getName();
 
             log.info("쿠폰 할인 적용: couponId={}, discount={}",
@@ -74,10 +74,11 @@ public class OrderServiceImpl implements OrderService {
 
         // 7. 배송 정보 생성
         Recipient recipient = createRecipient(command);
-        // 8. 배송비 (쿠폰 적용가에서 판단)
+
+        // 8. 배송비 계산
         BigDecimal deliveryFee = orderDomainService.calculateDeliveryFee(amountBeforeCoupon);
 
-        // 9. 주문 생성 (상품 및  배송 생성)
+        // 9. 주문 생성
         Order order = Order.create(
                 user.userId(),
                 command.productId(),
@@ -99,7 +100,7 @@ public class OrderServiceImpl implements OrderService {
 
         // TODO: 추후 동기 -> 비동기 고려 및 변경 예정
         // 11. 쿠폰 사용 처리
-        if (command.hasCoupon()) {
+        if (command.couponId() != null) {
             couponService.useCoupon(command.couponId(), order.getOrderId());
         }
 
@@ -109,29 +110,16 @@ public class OrderServiceImpl implements OrderService {
                 savedOrder.getOrderId(), savedOrder.getOrderAmount().getFinalAmount());
 
         // TODO: 추후 동기 -> 비동기 고려 및 변경 예정
-        // 12. 도메인 이벤트 발행 (결제 서비스로 전달)
+        // 13. 결제
 
-        // 13. 응답 생성
-        return CreateOrderRes.from(order);
+        // 14. 응답 생성
+        return CreateOrderRes.from(savedOrder);
     }
 
-    /**
-     * 쿠폰 할인 전 금액 계산
-     */
-    private BigDecimal calculateAmountBeforeCoupon(ProductRes product, TimeDealRes timeDeal, int quantity) {
-
-        BigDecimal unitPrice = (timeDeal != null)
-                ? timeDeal.getTimeDealPrice()
-                : product.getPrice();
-
-        return unitPrice.multiply(BigDecimal.valueOf(quantity));
-    }
-
-    /**
-     * 배송 정보 생성
-     */
+    // ===== 도메인 객체 생성 =====
+    // 배송 정보 생성
     private Recipient createRecipient(CreateOrderCommand command) {
-        return Recipient.of(
+        return Recipient.create(
                 command.delivery().recipientName(),
                 command.delivery().recipientEmail(),
                 command.delivery().recipientAddress(),
@@ -139,12 +127,12 @@ public class OrderServiceImpl implements OrderService {
         );
     }
 
-    /**
-     * 재고 차감
-     */
+    // ===== 외부 서비스 호출 =====
+
+    // 재고 차감
     private void deductStock(CreateOrderCommand command, TimeDealRes timeDeal) {
         // 타임딜 주문인 경우 타임딜 재고 차감
-        if (command.isTimeDealOrder() && timeDeal != null) {
+        if (command.timeDealId() != null && timeDeal != null) {
             timeDealService.deductTimeDealStock(
                     command.timeDealId(), command.quantity());
 

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -27,6 +28,7 @@ public class OrderServiceImpl implements OrderService {
     private final TimeDealService timeDealService;
     private final CouponService couponService;
     private final UserService userService;
+    private final PaymentService paymentService;
     private final OrderDomainService orderDomainService;
 
     private final OrderValidator orderValidator;
@@ -34,86 +36,38 @@ public class OrderServiceImpl implements OrderService {
 
     @Transactional
     public CreateOrderRes createOrder(CreateOrderCommand command) {
-        log.info("주문 생성 시작: loginId={}, productId={}",
-                command.loginId(), command.productId());
+        log.info("주문 생성 시작: loginId={}, productId={}", command.loginId(), command.productId());
 
-        // 1. 요청 검증
         orderValidator.validateCreateOrderCommand(command);
 
-        // 2. 사용자 검증 및 정보 조회
-        UserRes user = userService.getUserByLoginId(command.loginId());
-        orderValidator.validateUserOrderable(user);
+        UserRes user = getValidUser(command);
+        ProductRes product = getValidProduct(command);
+        TimeDealRes timeDeal = getValidTimeDeal(command);
 
-        // 3. 상품 검증 및 정보 조회
-        ProductRes product = productService.getProduct(command.productId(), command.quantity());
-        orderValidator.validateProductStock(product, command.quantity());
+        BigDecimal amountBeforeCoupon = calculateAmountBeforeCoupon(product, timeDeal, command.quantity());
 
-        // 4. 타임딜 검증 및 정보 조회 (타임딜 주문인 경우)
-        TimeDealRes timeDeal = null;
-        if (command.timeDealId() != null) {
-            timeDeal = timeDealService.getTimeDeal(command.timeDealId(), command.quantity());
-            orderValidator.validateTimeDeal(timeDeal, command.quantity());
-        }
+        CouponResult couponResult = CalculateValidCoupon(command.couponId(), amountBeforeCoupon);
 
-        // 5. 할인 전 금액 계산 (상품 총액 - 타임딜 할인)
-        BigDecimal amountBeforeCoupon = orderCalculator.calculateAmountBeforeCoupon(
-                product, timeDeal, command.quantity());
-
-        // 6. 쿠폰 검증 및 할인 금액 계산 (쿠폰 사용 시)
-        BigDecimal couponDiscountAmount = BigDecimal.ZERO;
-        String couponName = null;
-        if (command.couponId() != null) {
-            CouponRes coupon = couponService.getCoupon(command.couponId());
-            orderValidator.validateCoupon(coupon, amountBeforeCoupon);
-            couponDiscountAmount = orderCalculator.calculateCouponDiscount(coupon, amountBeforeCoupon);
-            couponName = coupon.getName();
-
-            log.info("쿠폰 할인 적용: couponId={}, discount={}",
-                    command.couponId(), couponDiscountAmount);
-        }
-
-        // 7. 배송 정보 생성
         Recipient recipient = createRecipient(command);
 
-        // 8. 배송비 계산
         BigDecimal deliveryFee = orderDomainService.calculateDeliveryFee(amountBeforeCoupon);
 
-        // 9. 주문 생성
-        Order order = Order.create(
-                user.userId(),
-                command.productId(),
-                product.getProductName(),
-                product.getPrice(),
-                command.quantity(),
-                command.timeDealId(),
-                timeDeal != null ? timeDeal.getTimeDealPrice() : null,
-                command.couponId(),
-                couponName,
-                couponDiscountAmount,
-                deliveryFee,
-                recipient
-        );
+        Order order = createOrder(command, user, product, timeDeal, couponResult, deliveryFee, recipient);
+        orderRepository.save(order);
+        log.info("주문 임시 저장 완료(결제 전): orderId={}", order.getOrderId());
 
         // TODO: 추후 동기 -> 비동기 고려 및 변경 예정
-        // 10. 재고 차감
         deductStock(command, timeDeal);
-
         // TODO: 추후 동기 -> 비동기 고려 및 변경 예정
-        // 11. 쿠폰 사용 처리
-        if (command.couponId() != null) {
-            couponService.useCoupon(command.couponId(), order.getOrderId());
-        }
+        processCouponUsage(command.couponId(), order.getOrderId());
+        // TODO: 추후 동기 -> 비동기 고려 및 변경 예정
+        processPayment(order, user.getUserId(), "CARD");
 
-        // 12. 주문 저장
-        Order savedOrder = orderRepository.save(order);
+        orderRepository.save(order);
         log.info("주문 생성 완료: orderId={}, finalAmount={}",
-                savedOrder.getOrderId(), savedOrder.getOrderAmount().getFinalAmount());
+                order.getOrderId(), order.getOrderAmount().getFinalAmount());
 
-        // TODO: 추후 동기 -> 비동기 고려 및 변경 예정
-        // 13. 결제
-
-        // 14. 응답 생성
-        return CreateOrderRes.from(savedOrder);
+        return CreateOrderRes.from(order);
     }
 
     // ===== 도메인 객체 생성 =====
@@ -127,8 +81,7 @@ public class OrderServiceImpl implements OrderService {
         );
     }
 
-    // ===== 외부 서비스 호출 =====
-
+    // ====== 외부 서비스 호출 ======
     // 재고 차감
     private void deductStock(CreateOrderCommand command, TimeDealRes timeDeal) {
         // 타임딜 주문인 경우 타임딜 재고 차감
@@ -145,5 +98,104 @@ public class OrderServiceImpl implements OrderService {
 
         log.info("상품 재고 차감 완료: productId={}, quantity={}",
                 command.productId(), command.quantity());
+    }
+
+    // ====== private ======
+    // 사용자 검증 및 정보 조회
+    private UserRes getValidUser(CreateOrderCommand command) {
+        UserRes user = userService.getUserByLoginId(command.loginId());
+        orderValidator.validateUserOrderable(user);
+        return user;
+    }
+
+    // 상품 검증 및 정보 조회
+    private ProductRes getValidProduct(CreateOrderCommand command) {
+        ProductRes product = productService.getProduct(command.productId(), command.quantity());
+        orderValidator.validateProductStock(product, command.quantity());
+        return product;
+    }
+
+    // 타임딜 검증 및 정보 조회 (타임딜 주문인 경우)
+    private TimeDealRes getValidTimeDeal(CreateOrderCommand command) {
+        if (command.timeDealId() == null) return null;
+
+        TimeDealRes timeDeal = timeDealService.getTimeDeal(command.timeDealId(), command.quantity());
+        orderValidator.validateTimeDeal(timeDeal, command.quantity());
+        return timeDeal;
+    }
+
+    // 쿠폰 사용 전 금액 계산 (상품 총액 - 타임딜 할인)
+    private BigDecimal calculateAmountBeforeCoupon(ProductRes product, TimeDealRes timeDeal, Integer quantity) {
+        return orderCalculator.calculateAmountBeforeCoupon(product, timeDeal, quantity);
+    }
+
+    // 쿠폰 검증 및 할인 계산
+    private CouponResult CalculateValidCoupon(UUID couponId, BigDecimal amountBeforeCoupon) {
+        if (couponId == null) {
+            return new CouponResult(BigDecimal.ZERO, null, null);
+        }
+
+        CouponRes coupon = couponService.getCoupon(couponId);
+        orderValidator.validateCoupon(coupon, amountBeforeCoupon);
+
+        BigDecimal discountAmount = orderCalculator.calculateCouponDiscount(coupon, amountBeforeCoupon);
+
+        log.info("쿠폰 할인 적용: couponId={}, discount={}", couponId, discountAmount);
+
+        return new CouponResult(discountAmount, couponId, coupon.getName());
+    }
+
+    // 주문 엔티티 생성 (CouponResult 사용)
+    private Order createOrder(
+            CreateOrderCommand command,
+            UserRes user,
+            ProductRes product,
+            TimeDealRes timeDeal,
+            CouponResult couponResult,
+            BigDecimal deliveryFee,
+            Recipient recipient) {
+
+        return Order.create(
+                user.getUserId(),
+                command.productId(),
+                product.getProductName(),
+                product.getPrice(),
+                command.quantity(),
+                command.timeDealId(),
+                timeDeal != null ? timeDeal.getTimeDealPrice() : null,
+                couponResult.couponId(),
+                couponResult.couponName(),
+                couponResult.discountAmount(),
+                deliveryFee,
+                recipient
+        );
+    }
+
+    // 쿠폰 사용 처리
+    private void processCouponUsage(UUID couponId, UUID orderId) {
+        if (couponId != null) {
+            couponService.useCoupon(couponId, orderId);
+        }
+    }
+
+    // 결제 처리
+    private void processPayment(Order order, Long userId, String paymentMethod) {
+        PaymentRes payment = paymentService.createPayment(
+                order.getOrderId(),
+                userId,
+                order.getOrderAmount().getFinalAmount(),
+                paymentMethod
+        );
+
+        order.markAsPaid(payment.getPaymentId());
+        log.info("주문 결제 완료: paymentId={}, amount={}", payment.getPaymentId(), payment.getAmount());
+    }
+
+    // 쿠폰 처리 결과를 담는 내부 레코드
+    private record CouponResult(
+            BigDecimal discountAmount,
+            UUID couponId,
+            String couponName
+    ) {
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -1,15 +1,161 @@
 package com.palja.order_service.application.service.impl;
 
-import com.palja.order_service.application.service.OrderService;
+import com.palja.order_service.application.command.CreateOrderCommand;
+import com.palja.order_service.application.dto.*;
+import com.palja.order_service.application.service.*;
+import com.palja.order_service.domain.entity.Order;
 import com.palja.order_service.domain.repository.OrderRepository;
 import com.palja.order_service.domain.service.OrderDomainService;
+import com.palja.order_service.domain.vo.Recipient;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderServiceImpl implements OrderService {
 
     private final OrderRepository orderRepository;
+    private final ProductService productService;
+    private final TimeDealService timeDealService;
+    private final CouponService couponService;
+    private final UserService userService;
     private final OrderDomainService orderDomainService;
+
+    // 주문 생성
+    @Transactional
+    public CreateOrderRes createOrder(CreateOrderCommand command) {
+        log.info("주문 생성 시작: loginId={}, productId={}",
+                command.loginId(), command.productId());
+
+        // 1. 요청 검증
+        command.validate();
+
+        // 2. 사용자 검증 및 정보 조회
+        UserRes user = userService.getUserByLoginId(command.loginId());
+        user.validateOrderable();
+
+        // 3. 상품 검증 및 정보 조회
+        ProductRes product = productService.getProduct(command.productId(), command.quantity());
+        product.validateStock(command.quantity());
+
+        // 4. 타임딜 검증 및 정보 조회 (타임딜 주문인 경우)
+        TimeDealRes timeDeal = null;
+        if (command.isTimeDealOrder()) {
+            timeDeal = timeDealService.getTimeDeal(command.timeDealId(), command.quantity());
+            timeDeal.validate(command.quantity());
+        }
+
+        // 5.할인 전 금액 계산 (상품 총액 - 타임딜 할인)
+        BigDecimal amountBeforeCoupon = calculateAmountBeforeCoupon(
+                product, timeDeal, command.quantity());
+
+        // 6. 쿠폰 검증 및 할인 금액 계산 (쿠폰 사용 시)
+        BigDecimal couponDiscountAmount = BigDecimal.ZERO;
+        String couponName = null;
+        if (command.hasCoupon()) {
+            // 검증 및 정보 조회
+            CouponRes coupon = couponService.getCoupon(
+                    command.couponId());
+
+            // 쿠폰 검증 및 할인 금액 계산
+            coupon.validate(amountBeforeCoupon);
+            couponDiscountAmount = coupon.calculateDiscountAmount(amountBeforeCoupon);
+            couponName = coupon.getName();
+
+            log.info("쿠폰 할인 적용: couponId={}, discount={}",
+                    command.couponId(), couponDiscountAmount);
+        }
+
+        // 7. 배송 정보 생성
+        Recipient recipient = createRecipient(command);
+        // 8. 배송비 (쿠폰 적용가에서 판단)
+        BigDecimal deliveryFee = orderDomainService.calculateDeliveryFee(amountBeforeCoupon);
+
+        // 9. 주문 생성 (상품 및  배송 생성)
+        Order order = Order.create(
+                user.userId(),
+                command.productId(),
+                product.getProductName(),
+                product.getPrice(),
+                command.quantity(),
+                command.timeDealId(),
+                timeDeal != null ? timeDeal.getTimeDealPrice() : null,
+                command.couponId(),
+                couponName,
+                couponDiscountAmount,
+                deliveryFee,
+                recipient
+        );
+
+        // TODO: 추후 동기 -> 비동기 고려 및 변경 예정
+        // 10. 재고 차감
+        deductStock(command, timeDeal);
+
+        // TODO: 추후 동기 -> 비동기 고려 및 변경 예정
+        // 11. 쿠폰 사용 처리
+        if (command.hasCoupon()) {
+            couponService.useCoupon(command.couponId(), order.getOrderId());
+        }
+
+        // 12. 주문 저장
+        Order savedOrder = orderRepository.save(order);
+        log.info("주문 생성 완료: orderId={}, finalAmount={}",
+                savedOrder.getOrderId(), savedOrder.getOrderAmount().getFinalAmount());
+
+        // TODO: 추후 동기 -> 비동기 고려 및 변경 예정
+        // 12. 도메인 이벤트 발행 (결제 서비스로 전달)
+
+        // 13. 응답 생성
+        return CreateOrderRes.from(order);
+    }
+
+    /**
+     * 쿠폰 할인 전 금액 계산
+     */
+    private BigDecimal calculateAmountBeforeCoupon(ProductRes product, TimeDealRes timeDeal, int quantity) {
+
+        BigDecimal unitPrice = (timeDeal != null)
+                ? timeDeal.getTimeDealPrice()
+                : product.getPrice();
+
+        return unitPrice.multiply(BigDecimal.valueOf(quantity));
+    }
+
+    /**
+     * 배송 정보 생성
+     */
+    private Recipient createRecipient(CreateOrderCommand command) {
+        return Recipient.of(
+                command.delivery().recipientName(),
+                command.delivery().recipientEmail(),
+                command.delivery().recipientAddress(),
+                command.delivery().deliveryMessage()
+        );
+    }
+
+    /**
+     * 재고 차감
+     */
+    private void deductStock(CreateOrderCommand command, TimeDealRes timeDeal) {
+        // 타임딜 주문인 경우 타임딜 재고 차감
+        if (command.isTimeDealOrder() && timeDeal != null) {
+            timeDealService.deductTimeDealStock(
+                    command.timeDealId(), command.quantity());
+
+            log.info("타임딜 재고 차감 완료: timeDealId={}, quantity={}",
+                    command.timeDealId(), command.quantity());
+        }
+
+        // 일반 상품 재고 차감
+        productService.deductStock(command.productId(), command.quantity());
+
+        log.info("상품 재고 차감 완료: productId={}, quantity={}",
+                command.productId(), command.quantity());
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
@@ -92,13 +92,13 @@ public class OrderValidator {
     }
 
     private void validateUserStatus(UserRes user) {
-        if (!"ACTIVE".equals(user.status())) {
+        if (!"ACTIVE".equals(user.getStatus())) {
             throw new BusinessException(OrderErrorCode.INVALID_USER_ID);
         }
     }
 
     private void validateUserRoleForOrder(UserRes user) {
-        if (UserRole.COMPANY_USER.equals(user.role())) {
+        if (UserRole.COMPANY_USER.equals(user.getRole())) {
             throw new BusinessException(OrderErrorCode.USER_NOT_ALLOWED);
         }
     }

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
@@ -1,0 +1,185 @@
+package com.palja.order_service.application.service.validator;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.command.CreateOrderCommand;
+import com.palja.order_service.application.command.DeliveryCommand;
+import com.palja.order_service.application.dto.CouponRes;
+import com.palja.order_service.application.dto.ProductRes;
+import com.palja.order_service.application.dto.TimeDealRes;
+import com.palja.order_service.application.dto.UserRes;
+import com.palja.order_service.application.exception.OrderErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+// 주문 관련 검증을 담당하는 컴포넌트
+@Slf4j
+@Component
+public class OrderValidator {
+
+    // ===== 주문 생성 검증 =====
+    // 주문 생성 커맨드 검증
+    public void validateCreateOrderCommand(CreateOrderCommand command) {
+        validateRequiredFields(command);
+        validateQuantity(command.quantity());
+        validateDeliveryInfo(command.delivery());
+    }
+
+    private void validateRequiredFields(CreateOrderCommand command) {
+        if (command.loginId() == null || command.loginId().isBlank()) {
+            throw new BusinessException(OrderErrorCode.MISSING_REQUIRED_FIELD);
+        }
+        if (command.productId() == null) {
+            throw new BusinessException(OrderErrorCode.MISSING_REQUIRED_FIELD);
+        }
+        if (command.delivery() == null) {
+            throw new BusinessException(OrderErrorCode.MISSING_REQUIRED_FIELD);
+        }
+    }
+
+    private void validateQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new BusinessException(OrderErrorCode.INVALID_QUANTITY);
+        }
+    }
+
+    // 배송 정보 검증
+    private void validateDeliveryInfo(DeliveryCommand delivery) {
+        validateRecipientName(delivery.recipientName());
+        validateRecipientEmail(delivery.recipientEmail());
+        validateRecipientAddress(delivery.recipientAddress());
+        validateDeliveryMessage(delivery.deliveryMessage());
+    }
+
+    private void validateRecipientName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new BusinessException(OrderErrorCode.INVALID_RECIPIENT_INFO);
+        }
+        if (name.length() > 50) {
+            throw new BusinessException(OrderErrorCode.INVALID_RECIPIENT_INFO);
+        }
+    }
+
+    private void validateRecipientEmail(String email) {
+        if (email != null && email.length() > 255) {
+            throw new BusinessException(OrderErrorCode.INVALID_RECIPIENT_INFO);
+        }
+    }
+
+    private void validateRecipientAddress(String address) {
+        if (address == null || address.isBlank()) {
+            throw new BusinessException(OrderErrorCode.INVALID_ADDRESS);
+        }
+        if (address.length() > 200) {
+            throw new BusinessException(OrderErrorCode.INVALID_ADDRESS);
+        }
+    }
+
+    private void validateDeliveryMessage(String message) {
+        if (message != null && message.length() > 255) {
+            throw new BusinessException(OrderErrorCode.INVALID_RECIPIENT_INFO);
+        }
+    }
+
+    // ===== 사용자 검증 =====
+    // 사용자 주문 가능 여부 검증
+    public void validateUserOrderable(UserRes user) {
+        validateUserStatus(user);
+        validateUserRoleForOrder(user);
+    }
+
+    private void validateUserStatus(UserRes user) {
+        if (!"ACTIVE".equals(user.status())) {
+            throw new BusinessException(OrderErrorCode.INVALID_USER_ID);
+        }
+    }
+
+    private void validateUserRoleForOrder(UserRes user) {
+        if (UserRole.COMPANY_USER.equals(user.role())) {
+            throw new BusinessException(OrderErrorCode.USER_NOT_ALLOWED);
+        }
+    }
+
+    // ===== 상품 검증 =====
+    public void validateProductStock(ProductRes product, int requestedQuantity) {
+        if (product.getStockQuantity() < requestedQuantity) {
+            throw new BusinessException(OrderErrorCode.INSUFFICIENT_STOCK);
+        }
+    }
+
+    // ===== 타임딜 검증 =====
+    // 상품 재고 검증
+    public void validateTimeDeal(TimeDealRes timeDeal, int requestedQuantity) {
+        validateTimeDealPeriod(timeDeal);
+        validateTimeDealStatus(timeDeal);
+        validateTimeDealStock(timeDeal, requestedQuantity);
+    }
+
+    // 타임딜 기간 검증
+    private void validateTimeDealPeriod(TimeDealRes timeDeal) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(timeDeal.getStartAt())) {
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_NOT_STARTED);
+        }
+
+        if (now.isAfter(timeDeal.getEndAt())) {
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_EXPIRED);
+        }
+    }
+
+    // 타임딜 상태 검증
+    private void validateTimeDealStatus(TimeDealRes timeDeal) {
+        if (!"OPEN".equals(timeDeal.getStatus())) {
+            throw new BusinessException(OrderErrorCode.INVALID_TIME_DEAL);
+        }
+    }
+
+    // 타임딜 재고 검증
+    private void validateTimeDealStock(TimeDealRes timeDeal, int requestedQuantity) {
+        if (timeDeal.getTimeDealStockQuantity() < requestedQuantity) {
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_INSUFFICIENT_STOCK);
+        }
+    }
+
+    // ===== 쿠폰 검증 =====
+    public void validateCoupon(CouponRes coupon, BigDecimal orderAmount) {
+        validateCouponStatus(coupon);
+        validateCouponIssuePeriod(coupon);
+        validateCouponMinOrderAmount(coupon, orderAmount);
+    }
+
+    // 쿠폰 상태 검증
+    private void validateCouponStatus(CouponRes coupon) {
+        if (!"ACTIVE".equals(coupon.getStatus())) {
+            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
+        }
+    }
+
+    // 쿠폰 발급 기간 검증
+    private void validateCouponIssuePeriod(CouponRes coupon) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(coupon.getIssueStartAt())) {
+            throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
+        }
+
+        if (now.isAfter(coupon.getIssueEndAt())) {
+            throw new BusinessException(OrderErrorCode.COUPON_EXPIRED);
+        }
+    }
+
+    // 쿠폰 최소 주문 금액 검증
+    private void validateCouponMinOrderAmount(CouponRes coupon, BigDecimal orderAmount) {
+        if (coupon.getMinOrderAmount() == null) {
+            return;
+        }
+
+        if (orderAmount == null || orderAmount.compareTo(coupon.getMinOrderAmount()) < 0) {
+            throw new BusinessException(OrderErrorCode.COUPON_MIN_AMOUNT_NOT_MET);
+        }
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
@@ -4,10 +4,7 @@ import com.palja.common.exception.BusinessException;
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CreateOrderCommand;
 import com.palja.order_service.application.command.DeliveryCommand;
-import com.palja.order_service.application.dto.CouponRes;
-import com.palja.order_service.application.dto.ProductRes;
-import com.palja.order_service.application.dto.TimeDealRes;
-import com.palja.order_service.application.dto.UserRes;
+import com.palja.order_service.application.dto.*;
 import com.palja.order_service.application.exception.OrderErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -148,6 +145,7 @@ public class OrderValidator {
     // ===== 쿠폰 검증 =====
     public void validateCoupon(CouponRes coupon, BigDecimal orderAmount) {
         validateCouponStatus(coupon);
+        validateCouponDiscountType(coupon);   // ← 추가
         validateCouponIssuePeriod(coupon);
         validateCouponMinOrderAmount(coupon, orderAmount);
     }
@@ -156,6 +154,22 @@ public class OrderValidator {
     private void validateCouponStatus(CouponRes coupon) {
         if (!"ACTIVE".equals(coupon.getStatus())) {
             throw new BusinessException(OrderErrorCode.COUPON_NOT_AVAILABLE);
+        }
+    }
+
+    // 쿠폰 할인 타입/할인값 검증
+    private void validateCouponDiscountType(CouponRes coupon) {
+        if (coupon.getDiscountType() == null) {
+            throw new BusinessException(OrderErrorCode.INVALID_COUPON_TYPE);
+        }
+
+        if (coupon.getDiscountValue() <= 0) {
+            throw new BusinessException(OrderErrorCode.INVALID_COUPON_VALUE);
+        }
+
+        if (coupon.getDiscountType() == CouponDiscountType.PERCENTAGE
+                && coupon.getDiscountValue() > 100) {
+            throw new BusinessException(OrderErrorCode.INVALID_COUPON_VALUE);
         }
     }
 

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
@@ -2,6 +2,7 @@ package com.palja.order_service.domain.entity;
 
 import com.palja.common.entity.BaseEntity;
 import com.palja.order_service.domain.vo.OrderAmount;
+import com.palja.order_service.domain.vo.OrderCancellation;
 import com.palja.order_service.domain.vo.OrderStatus;
 import com.palja.order_service.domain.vo.Recipient;
 import jakarta.persistence.*;
@@ -46,14 +47,8 @@ public class Order extends BaseEntity {
     @Column(name = "time_deal_order", nullable = false)
     private Boolean timeDealOrder;
 
-    @Column(name = "canceled_at")
-    private LocalDateTime canceledAt;
-
-    @Column(name = "cancel_reason")
-    private String cancelReason;
-
-    @Column(name = "canceled_by")
-    private String canceledBy;
+    @Embedded
+    private OrderCancellation cancellation;
 
     @Column(name = "confirmed_at")
     private LocalDateTime confirmedAt;
@@ -65,8 +60,7 @@ public class Order extends BaseEntity {
     @OneToOne(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private OrderDelivery delivery;
 
-    // 주문 생성
-    // 주문, 주문상품, 배송정보를 한 번에 생성
+    // 주문 생성 (주문, 주문상품, 배송정보)
     public static Order create(
             Long userId,
             UUID productId,
@@ -81,25 +75,46 @@ public class Order extends BaseEntity {
             BigDecimal deliveryFee,
             Recipient recipient
     ) {
-        // 1. 주문자 검증
         validateUserId(userId);
-        // 2. 주문 상품 검증
         validateProductId(productId);
 
-        // 3. 타임딜 주문 여부 결정
+        Order order = createOrder(userId, timeDealId, timeDealPrice, couponId, couponName);
+
+        createOrderItem(order, productId, productName, unitPrice, quantity, timeDealId, timeDealPrice);
+        createOrderDelivery(order, recipient);
+        calculateAmount(order, couponDiscountAmount, deliveryFee);
+
+        return order;
+    }
+
+    private static Order createOrder(
+            Long userId,
+            UUID timeDealId,
+            BigDecimal timeDealPrice,
+            UUID couponId,
+            String couponName
+    ) {
         boolean isTimeDealOrder = (timeDealId != null && timeDealPrice != null);
 
-        // 4. Order 생성 (아직 자식 없음)
-        Order order = Order.builder()
+        return Order.builder()
                 .userId(userId)
                 .status(OrderStatus.CREATED)
                 .timeDealOrder(isTimeDealOrder)
                 .couponId(couponId)
                 .couponName(couponName)
                 .build();
+    }
 
-        // 5. OrderItem 생성 및 연결
-        OrderItem orderItem = OrderItem.create(
+    private static void createOrderItem(
+            Order order,
+            UUID productId,
+            String productName,
+            BigDecimal unitPrice,
+            int quantity,
+            UUID timeDealId,
+            BigDecimal timeDealPrice
+    ) {
+        order.orderItem = OrderItem.create(
                 order,
                 productId,
                 productName,
@@ -108,33 +123,28 @@ public class Order extends BaseEntity {
                 timeDealId,
                 timeDealPrice
         );
-        order.orderItem = orderItem;
+    }
 
-        // 6. OrderDelivery 생성 및 연결
-        order.delivery = OrderDelivery.create(order, recipient);
+    private static void calculateAmount(
+            Order order,
+            BigDecimal couponDiscountAmount,
+            BigDecimal deliveryFee
+    ) {
+        BigDecimal productTotal = order.orderItem.getLineTotalAmount();
+        BigDecimal itemDiscount = order.orderItem.getTimeDealDiscountAmount();
 
-        // 7. 금액 계산 (OrderItem의 할인 정보 활용)
-        BigDecimal productTotalAmount = orderItem.getLineTotalAmount();
-        BigDecimal itemDiscountAmount = orderItem.getTimeDealDiscountAmount();
-
-        order.orderAmount = OrderAmount.of(
-                productTotalAmount,
-                itemDiscountAmount,
+        order.orderAmount = OrderAmount.create(
+                productTotal,
+                itemDiscount,
                 couponDiscountAmount != null ? couponDiscountAmount : BigDecimal.ZERO,
                 deliveryFee != null ? deliveryFee : BigDecimal.ZERO
         );
-
-        return order;
     }
 
-    // 결제 완료 처리
-    public void markAsPaid(UUID paymentId) {
-        validatePaymentId(paymentId);
-        this.status.validateTransition(OrderStatus.PAID);
-
-        this.paymentId = paymentId;
-        this.status = OrderStatus.PAID;
+    private static void createOrderDelivery(Order order, Recipient recipient) {
+        order.delivery = OrderDelivery.create(order, recipient);
     }
+
 
     // 주문 취소
     public void cancel(String cancelReason, String canceledBy) {
@@ -146,21 +156,15 @@ public class Order extends BaseEntity {
         }
 
         // 2. 배송 상태 검증 (배송 시작 전만 가능)
-        if (this.delivery != null && !this.delivery.getStatus().isOrderCancellable()) {
+        if (this.delivery != null && !this.delivery.isOrderCancellable()) {
             throw new IllegalStateException(
                     String.format("취소할 수 없는 배송 상태입니다: %s",
                             this.delivery.getStatus().getDescription())
             );
         }
 
-        // 3. 상태 전환 검증
-        this.status.validateTransition(OrderStatus.CANCELED);
-
-        // 4. 취소 처리
-        this.status = OrderStatus.CANCELED;
-        this.canceledAt = LocalDateTime.now();
-        this.cancelReason = validateCancelReason(cancelReason);
-        this.canceledBy = validateCanceledBy(canceledBy);
+        transitionTo(OrderStatus.CANCELED);
+        this.cancellation = OrderCancellation.create(cancelReason, canceledBy);
     }
 
     // 구매 확정
@@ -173,32 +177,40 @@ public class Order extends BaseEntity {
         }
 
         // 2. 배송 완료 확인
-        if (this.delivery == null || !this.delivery.getStatus().isDelivered()) {
+        if (this.delivery == null || !this.delivery.isDelivered()) {
             throw new IllegalStateException("배송이 완료되지 않은 주문입니다.");
         }
 
         // 3. 상태 전환
-        this.status.validateTransition(OrderStatus.COMPLETED);
-        this.status = OrderStatus.COMPLETED;
+        transitionTo(OrderStatus.COMPLETED);
         this.confirmedAt = LocalDateTime.now();
+    }
+
+    // 주문 상태 전환 (CREATED/PAID/PREPARING/SHIPPED/DELIVERED)
+    private void transitionTo(OrderStatus newStatus) {
+        this.status.validateTransition(newStatus);
+        this.status = newStatus;
     }
 
     // 상품 준비 중으로 상태 변경
     public void markAsPreparing() {
-        this.status.validateTransition(OrderStatus.PREPARING);
-        this.status = OrderStatus.PREPARING;
+        transitionTo(OrderStatus.PREPARING);
     }
 
     /// 배송 출발로 상태 변경
     public void markAsShipped() {
-        this.status.validateTransition(OrderStatus.SHIPPED);
-        this.status = OrderStatus.SHIPPED;
+        transitionTo(OrderStatus.SHIPPED);
+    }
+
+    public void markAsDelivered() {
+        transitionTo(OrderStatus.DELIVERED);
     }
 
     // 배송 완료로 상태 변경
-    public void markAsDelivered() {
-        this.status.validateTransition(OrderStatus.DELIVERED);
-        this.status = OrderStatus.DELIVERED;
+    public void markAsPaid(UUID paymentId) {
+        validatePaymentId(paymentId);
+        this.paymentId = paymentId;
+        transitionTo(OrderStatus.PAID);
     }
 
     // 타임딜 주문인지 확인
@@ -211,7 +223,7 @@ public class Order extends BaseEntity {
         return couponId != null;
     }
 
-    // ====== Validation ======
+    // ===== Validation ===== //
 
     private static void validateUserId(Long userId) {
         if (userId == null) {
@@ -229,25 +241,5 @@ public class Order extends BaseEntity {
         if (paymentId == null) {
             throw new IllegalArgumentException("결제 ID는 필수입니다.");
         }
-    }
-
-    private String validateCancelReason(String cancelReason) {
-        if (cancelReason == null || cancelReason.isBlank()) {
-            throw new IllegalArgumentException("취소 사유는 필수입니다.");
-        }
-        if (cancelReason.length() > 500) {
-            throw new IllegalArgumentException("취소 사유는 500자를 초과할 수 없습니다.");
-        }
-        return cancelReason.trim();
-    }
-
-    private String validateCanceledBy(String canceledBy) {
-        if (canceledBy == null || canceledBy.isBlank()) {
-            throw new IllegalArgumentException("취소자 정보는 필수입니다.");
-        }
-        if (canceledBy.length() > 50) {
-            throw new IllegalArgumentException("취소자 정보는 50자를 초과할 수 없습니다.");
-        }
-        return canceledBy.trim();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
@@ -1,7 +1,9 @@
 package com.palja.order_service.domain.entity;
 
 import com.palja.common.entity.BaseEntity;
+import com.palja.order_service.domain.vo.OrderAmount;
 import com.palja.order_service.domain.vo.OrderStatus;
+import com.palja.order_service.domain.vo.Recipient;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -23,7 +25,7 @@ public class Order extends BaseEntity {
     private UUID orderId;
 
     @Column(name = "user_id", nullable = false)
-    private UUID userId;
+    private Long userId;
 
     @Column(name = "coupon_id")
     private UUID couponId;
@@ -35,20 +37,8 @@ public class Order extends BaseEntity {
     @Column(name = "status", nullable = false, length = 20)
     private OrderStatus status;
 
-    @Column(name = "product_total_amount", nullable = false)
-    private BigDecimal productTotalAmount;
-
-    @Column(name = "item_discount_amount", nullable = false)
-    private BigDecimal itemDiscountAmount;
-
-    @Column(name = "coupon_discount_amount")
-    private BigDecimal couponDiscountAmount;
-
-    @Column(name = "delivery_fee", nullable = false)
-    private BigDecimal deliveryFee;
-
-    @Column(name = "final_amount", nullable = false)
-    private BigDecimal finalAmount;
+    @Embedded
+    private OrderAmount orderAmount;
 
     @Column(name = "coupon_name", length = 100)
     private String couponName;
@@ -63,21 +53,201 @@ public class Order extends BaseEntity {
     private String cancelReason;
 
     @Column(name = "canceled_by")
-    private Long canceledBy;
+    private String canceledBy;
 
     @Column(name = "confirmed_at")
     private LocalDateTime confirmedAt;
 
     // 연관관계 (도메인상 Order → 자식 사용, JPA owner는 자식)
-    @OneToOne(mappedBy = "order",
-            fetch = FetchType.LAZY,
-            cascade = CascadeType.ALL,
-            orphanRemoval = true)
+    @OneToOne(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private OrderItem orderItem;
 
-    @OneToOne(mappedBy = "order",
-            fetch = FetchType.LAZY,
-            cascade = CascadeType.ALL,
-            orphanRemoval = true)
+    @OneToOne(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private OrderDelivery delivery;
+
+    // 주문 생성
+    // 주문, 주문상품, 배송정보를 한 번에 생성
+    public static Order create(
+            Long userId,
+            UUID productId,
+            String productName,
+            BigDecimal unitPrice,
+            int quantity,
+            UUID timeDealId,
+            BigDecimal timeDealPrice,
+            UUID couponId,
+            String couponName,
+            BigDecimal couponDiscountAmount,
+            BigDecimal deliveryFee,
+            Recipient recipient
+    ) {
+        // 1. 주문자 검증
+        validateUserId(userId);
+        // 2. 주문 상품 검증
+        validateProductId(productId);
+
+        // 3. 타임딜 주문 여부 결정
+        boolean isTimeDealOrder = (timeDealId != null && timeDealPrice != null);
+
+        // 4. Order 생성 (아직 자식 없음)
+        Order order = Order.builder()
+                .userId(userId)
+                .status(OrderStatus.CREATED)
+                .timeDealOrder(isTimeDealOrder)
+                .couponId(couponId)
+                .couponName(couponName)
+                .build();
+
+        // 5. OrderItem 생성 및 연결
+        OrderItem orderItem = OrderItem.create(
+                order,
+                productId,
+                productName,
+                unitPrice,
+                quantity,
+                timeDealId,
+                timeDealPrice
+        );
+        order.orderItem = orderItem;
+
+        // 6. OrderDelivery 생성 및 연결
+        order.delivery = OrderDelivery.create(order, recipient);
+
+        // 7. 금액 계산 (OrderItem의 할인 정보 활용)
+        BigDecimal productTotalAmount = orderItem.getLineTotalAmount();
+        BigDecimal itemDiscountAmount = orderItem.getTimeDealDiscountAmount();
+
+        order.orderAmount = OrderAmount.of(
+                productTotalAmount,
+                itemDiscountAmount,
+                couponDiscountAmount != null ? couponDiscountAmount : BigDecimal.ZERO,
+                deliveryFee != null ? deliveryFee : BigDecimal.ZERO
+        );
+
+        return order;
+    }
+
+    // 결제 완료 처리
+    public void markAsPaid(UUID paymentId) {
+        validatePaymentId(paymentId);
+        this.status.validateTransition(OrderStatus.PAID);
+
+        this.paymentId = paymentId;
+        this.status = OrderStatus.PAID;
+    }
+
+    // 주문 취소
+    public void cancel(String cancelReason, String canceledBy) {
+        // 1. 주문 상태 검증
+        if (!this.status.isCancelableCandidate()) {
+            throw new IllegalStateException(
+                    String.format("취소할 수 없는 주문 상태입니다: %s", this.status.getDescription())
+            );
+        }
+
+        // 2. 배송 상태 검증 (배송 시작 전만 가능)
+        if (this.delivery != null && !this.delivery.getStatus().isOrderCancellable()) {
+            throw new IllegalStateException(
+                    String.format("취소할 수 없는 배송 상태입니다: %s",
+                            this.delivery.getStatus().getDescription())
+            );
+        }
+
+        // 3. 상태 전환 검증
+        this.status.validateTransition(OrderStatus.CANCELED);
+
+        // 4. 취소 처리
+        this.status = OrderStatus.CANCELED;
+        this.canceledAt = LocalDateTime.now();
+        this.cancelReason = validateCancelReason(cancelReason);
+        this.canceledBy = validateCanceledBy(canceledBy);
+    }
+
+    // 구매 확정
+    public void confirm() {
+        // 1. 상태 검증 (DELIVERED 상태에서만 가능)
+        if (!this.status.isConfirmable()) {
+            throw new IllegalStateException(
+                    String.format("구매 확정할 수 없는 주문 상태입니다: %s", this.status.getDescription())
+            );
+        }
+
+        // 2. 배송 완료 확인
+        if (this.delivery == null || !this.delivery.getStatus().isDelivered()) {
+            throw new IllegalStateException("배송이 완료되지 않은 주문입니다.");
+        }
+
+        // 3. 상태 전환
+        this.status.validateTransition(OrderStatus.COMPLETED);
+        this.status = OrderStatus.COMPLETED;
+        this.confirmedAt = LocalDateTime.now();
+    }
+
+    // 상품 준비 중으로 상태 변경
+    public void markAsPreparing() {
+        this.status.validateTransition(OrderStatus.PREPARING);
+        this.status = OrderStatus.PREPARING;
+    }
+
+    /// 배송 출발로 상태 변경
+    public void markAsShipped() {
+        this.status.validateTransition(OrderStatus.SHIPPED);
+        this.status = OrderStatus.SHIPPED;
+    }
+
+    // 배송 완료로 상태 변경
+    public void markAsDelivered() {
+        this.status.validateTransition(OrderStatus.DELIVERED);
+        this.status = OrderStatus.DELIVERED;
+    }
+
+    // 타임딜 주문인지 확인
+    public boolean isTimeDealOrder() {
+        return Boolean.TRUE.equals(this.timeDealOrder);
+    }
+
+    // 쿠폰 사용 여부
+    public boolean hasCoupon() {
+        return couponId != null;
+    }
+
+    // ====== Validation ======
+
+    private static void validateUserId(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("주문자 ID는 필수입니다.");
+        }
+    }
+
+    private static void validateProductId(UUID productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("주문상품 ID는 필수입니다.");
+        }
+    }
+
+    private void validatePaymentId(UUID paymentId) {
+        if (paymentId == null) {
+            throw new IllegalArgumentException("결제 ID는 필수입니다.");
+        }
+    }
+
+    private String validateCancelReason(String cancelReason) {
+        if (cancelReason == null || cancelReason.isBlank()) {
+            throw new IllegalArgumentException("취소 사유는 필수입니다.");
+        }
+        if (cancelReason.length() > 500) {
+            throw new IllegalArgumentException("취소 사유는 500자를 초과할 수 없습니다.");
+        }
+        return cancelReason.trim();
+    }
+
+    private String validateCanceledBy(String canceledBy) {
+        if (canceledBy == null || canceledBy.isBlank()) {
+            throw new IllegalArgumentException("취소자 정보는 필수입니다.");
+        }
+        if (canceledBy.length() > 50) {
+            throw new IllegalArgumentException("취소자 정보는 50자를 초과할 수 없습니다.");
+        }
+        return canceledBy.trim();
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/OrderDelivery.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/OrderDelivery.java
@@ -58,7 +58,7 @@ public class OrderDelivery {
 
     // 송장 등록
     public void registerTracking(String trackingNumber, String courierCompany) {
-        if (this.status != DeliveryStatus.READY) {
+        if (!this.status.canRegisterTracking()) {
             throw new IllegalStateException("배송 준비 상태에서만 송장을 등록할 수 있습니다.");
         }
 
@@ -67,7 +67,9 @@ public class OrderDelivery {
 
         this.trackingNumber = trackingNumber;
         this.courierCompany = courierCompany;
-        transitionToRequested();
+
+        // 송장 발행/배송요청 상태로 변경
+        transitionTo(DeliveryStatus.REQUESTED);
     }
 
     // 배송 정보 수정 (READY 상태에서만)
@@ -91,11 +93,27 @@ public class OrderDelivery {
         }
     }
 
-    private void transitionToRequested() {
-        this.status = DeliveryStatus.REQUESTED;
+    public boolean isOrderCancellable() {
+        return this.status.isOrderCancellable();
     }
 
-    // ====== Validation ======
+    public boolean isDelivered() {
+        return this.status.isDelivered();
+    }
+
+    public boolean isBeforeTransit() {
+        return this.status.isBeforeTransit();
+    }
+
+    public boolean isReady() {
+        return this.status.isReady();
+    }
+
+    public boolean isRequested() {
+        return this.status.isRequested();
+    }
+
+    // ===== Validation =====
     private void validateTrackingNumber(String trackingNumber) {
         if (trackingNumber == null || trackingNumber.isBlank()) {
             throw new IllegalArgumentException("운송장 번호는 필수입니다.");

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/OrderDelivery.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/OrderDelivery.java
@@ -1,15 +1,14 @@
 package com.palja.order_service.domain.entity;
 
 import com.palja.order_service.domain.vo.DeliveryStatus;
+import com.palja.order_service.domain.vo.Recipient;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Getter
 @Entity
 @Table(name = "p_order_delivery")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,21 +26,12 @@ public class OrderDelivery {
     @JoinColumn(name = "order_id")
     private Order order;
 
-    @Column(name = "delivery_message", length = 255)
-    private String deliveryMessage;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private DeliveryStatus status;
 
-    @Column(name = "recipient_name", nullable = false, length = 50)
-    private String recipientName;
-
-    @Column(name = "recipient_email", length = 255)
-    private String recipientEmail;
-
-    @Column(name = "recipient_address", nullable = false, length = 200)
-    private String recipientAddress;
+    @Embedded
+    private Recipient recipient;
 
     @Column(name = "tracking_number", length = 100)
     private String trackingNumber;
@@ -54,4 +44,73 @@ public class OrderDelivery {
 
     @Column(name = "delivered_at")
     private LocalDateTime deliveredAt;
+
+    // OrderDelivery 생성
+    public static OrderDelivery create(Order order, Recipient recipient) {
+
+        return OrderDelivery.builder()
+                .orderId(order.getOrderId())
+                .order(order)
+                .status(DeliveryStatus.READY)
+                .recipient(recipient)
+                .build();
+    }
+
+    // 송장 등록
+    public void registerTracking(String trackingNumber, String courierCompany) {
+        if (this.status != DeliveryStatus.READY) {
+            throw new IllegalStateException("배송 준비 상태에서만 송장을 등록할 수 있습니다.");
+        }
+
+        validateTrackingNumber(trackingNumber);
+        validateCourierCompany(courierCompany);
+
+        this.trackingNumber = trackingNumber;
+        this.courierCompany = courierCompany;
+        transitionToRequested();
+    }
+
+    // 배송 정보 수정 (READY 상태에서만)
+    public void updateRecipient(Recipient newRecipient) {
+        if (!this.status.isDeliveryEditable()) {
+            throw new IllegalStateException("배송 정보를 수정할 수 없는 상태입니다.");
+        }
+        this.recipient = newRecipient;
+    }
+
+    // 배송 상태 변경
+    public void transitionTo(DeliveryStatus newStatus) {
+        this.status.validateTransition(newStatus);
+        this.status = newStatus;
+
+        // 상태별 시간 기록
+        if (newStatus == DeliveryStatus.IN_TRANSIT && this.shippedAt == null) {
+            this.shippedAt = LocalDateTime.now();
+        } else if (newStatus == DeliveryStatus.DELIVERED && this.deliveredAt == null) {
+            this.deliveredAt = LocalDateTime.now();
+        }
+    }
+
+    private void transitionToRequested() {
+        this.status = DeliveryStatus.REQUESTED;
+    }
+
+    // ====== Validation ======
+    private void validateTrackingNumber(String trackingNumber) {
+        if (trackingNumber == null || trackingNumber.isBlank()) {
+            throw new IllegalArgumentException("운송장 번호는 필수입니다.");
+        }
+        if (trackingNumber.length() > 100) {
+            throw new IllegalArgumentException("운송장 번호는 100자를 초과할 수 없습니다.");
+        }
+    }
+
+    private void validateCourierCompany(String courierCompany) {
+        if (courierCompany == null || courierCompany.isBlank()) {
+            throw new IllegalArgumentException("택배사는 필수입니다.");
+        }
+        if (courierCompany.length() > 50) {
+            throw new IllegalArgumentException("택배사명은 50자를 초과할 수 없습니다.");
+        }
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/OrderItem.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/OrderItem.java
@@ -2,14 +2,12 @@ package com.palja.order_service.domain.entity;
 
 import com.palja.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.util.UUID;
 
+@Getter
 @Entity
 @Table(name = "p_order_item")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,10 +24,6 @@ public class OrderItem extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", nullable = false, unique = true)
     private Order order;
-
-    // 조회용으로만 쓰는 read-only FK
-    @Column(name = "order_id", nullable = false, insertable = false, updatable = false)
-    private UUID orderId;
 
     @Column(name = "product_id", nullable = false)
     private UUID productId;
@@ -54,4 +48,87 @@ public class OrderItem extends BaseEntity {
 
     @Column(name = "time_deal_discount_amount")
     private BigDecimal timeDealDiscountAmount;
+
+     // OrderItem 생성
+    public static OrderItem create(
+            Order order,
+            UUID productId,
+            String productName,
+            BigDecimal unitPrice,
+            int quantity,
+            UUID timeDealId,
+            BigDecimal timeDealPrice
+    ) {
+        validateQuantity(quantity);
+        validateUnitPrice(unitPrice);
+        validateProductName(productName);
+
+        // 자동 계산
+        BigDecimal lineTotalAmount = calculateLineTotalAmount(unitPrice, quantity);
+        BigDecimal timeDealDiscountAmount = calculateTimeDealDiscount(unitPrice, timeDealPrice, quantity);
+
+        return OrderItem.builder()
+                .order(order)
+                .productId(productId)
+                .productName(productName)
+                .unitPrice(unitPrice)
+                .quantity(quantity)
+                .timeDealId(timeDealId)
+                .timeDealPrice(timeDealPrice)
+                .lineTotalAmount(lineTotalAmount)
+                .timeDealDiscountAmount(timeDealDiscountAmount)
+                .build();
+    }
+
+    // 할인 전 총 금액 계산
+    private static BigDecimal calculateLineTotalAmount(BigDecimal unitPrice, int quantity) {
+        return unitPrice.multiply(BigDecimal.valueOf(quantity));
+    }
+
+    // 타임딜 할인 금액 계산
+    private static BigDecimal calculateTimeDealDiscount(
+            BigDecimal unitPrice,
+            BigDecimal timeDealPrice,
+            int quantity
+    ) {
+        if (timeDealPrice == null) {
+            return BigDecimal.ZERO;
+        }
+
+        BigDecimal discountPerUnit = unitPrice.subtract(timeDealPrice);
+
+        if (discountPerUnit.compareTo(BigDecimal.ZERO) <= 0) {
+            // 타임딜 가격이 정상이거나 더 비싸다면 할인 없음
+            return BigDecimal.ZERO;
+        }
+
+        return discountPerUnit.multiply(BigDecimal.valueOf(quantity));
+    }
+
+    // 타임딜 주문 여부
+    public boolean isTimeDeal() {
+        return timeDealId != null;
+    }
+
+    // ====== Validation ======
+    private static void validateQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+        }
+    }
+
+    private static void validateUnitPrice(BigDecimal unitPrice) {
+        if (unitPrice == null || unitPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("상품 단가는 0보다 커야 합니다.");
+        }
+    }
+
+    private static void validateProductName(String productName) {
+        if (productName == null || productName.isBlank()) {
+            throw new IllegalArgumentException("상품명은 필수입니다.");
+        }
+        if (productName.length() > 200) {
+            throw new IllegalArgumentException("상품명은 200자를 초과할 수 없습니다.");
+        }
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/repository/OrderRepository.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/repository/OrderRepository.java
@@ -1,4 +1,8 @@
 package com.palja.order_service.domain.repository;
 
+import com.palja.order_service.domain.entity.Order;
+
 public interface OrderRepository {
+
+    Order save(Order order);
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/service/OrderDomainService.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/service/OrderDomainService.java
@@ -1,17 +1,33 @@
 package com.palja.order_service.domain.service;
 
-import com.palja.order_service.domain.repository.OrderDeliveryRepository;
-import com.palja.order_service.domain.repository.OrderItemRepository;
-import com.palja.order_service.domain.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
 public class OrderDomainService {
 
-    private final OrderRepository orderRepository;
-    private final OrderItemRepository orderItemRepository;
-    private final OrderDeliveryRepository orderDeliveryRepository;
+    private static final BigDecimal FREE_DELIVERY_THRESHOLD = BigDecimal.valueOf(20000); // 무료배송 기준
+    private static final BigDecimal DELIVERY_FEE = BigDecimal.valueOf(3000);             // 기본 배송비
 
+    /**
+     * 배송비 계산 (BigDecimal 버전)
+     * - 20,000원 이상: 무료 배송
+     * - 20,000원 미만: 3,000원
+     */
+    public BigDecimal calculateDeliveryFee(BigDecimal productTotalAmount) {
+
+        if (productTotalAmount == null) {
+            throw new IllegalArgumentException("총 상품 금액이 null 일 수 없습니다.");
+        }
+
+        // compareTo 사용 (>= 20000)
+        if (productTotalAmount.compareTo(FREE_DELIVERY_THRESHOLD) >= 0) {
+            return BigDecimal.ZERO;
+        }
+
+        return DELIVERY_FEE;
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/DeliveryStatus.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/DeliveryStatus.java
@@ -10,45 +10,67 @@ public enum DeliveryStatus {
     READY("배송 준비 (출고 전)") {
         @Override
         public boolean canTransitionTo(DeliveryStatus newStatus) {
+            // 송장 등록 → REQUESTED
             return newStatus == REQUESTED;
         }
 
         @Override
         public boolean isOrderCancellable() {
-            return true;                // 주문 취소 가능
+            // 주문 취소 가능
+            return true;
         }
 
         @Override
         public boolean isBeforeTransit() {
-            return true;                // 집하 전
+            // 집하 전
+            return true;
         }
 
         @Override
         public boolean isDeliveryEditable() {
-            return true;                // 배송 정보 수정 가능 (READY만)
+            // 배송 정보 수정 가능 (READY만)
+            return true;
+        }
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public boolean canRegisterTracking() {
+            return true;
         }
     },
 
     REQUESTED("송장 발행/배송요청 (수거 전)") {
         @Override
         public boolean canTransitionTo(DeliveryStatus newStatus) {
+            // 집하 완료 → IN_TRANSIT
             return newStatus == IN_TRANSIT;
         }
 
         @Override
         public boolean isOrderCancellable() {
-            return true;                // 주문 취소 가능
+            // 주문 취소 가능
+            return true;
         }
 
         @Override
         public boolean isBeforeTransit() {
-            return true;                // 집하 전
+            // 집하 전
+            return true;
+        }
+
+        @Override
+        public boolean isRequested() {
+            return true;
         }
     },
 
     IN_TRANSIT("배송 중 (집하/이동 시작)") {
         @Override
         public boolean canTransitionTo(DeliveryStatus newStatus) {
+            // 배송 완료 → DELIVERED
             return newStatus == DELIVERED;
         }
 
@@ -61,6 +83,7 @@ public enum DeliveryStatus {
     DELIVERED("배송 완료") {
         @Override
         public boolean canTransitionTo(DeliveryStatus newStatus) {
+            // 완료 이후 상태 전이 없음
             return false;
         }
 
@@ -77,8 +100,6 @@ public enum DeliveryStatus {
 
     private final String description;
 
-    // --- 상태 전이 검증 ---
-
     public abstract boolean canTransitionTo(DeliveryStatus newStatus);
 
     public void validateTransition(DeliveryStatus newStatus) {
@@ -93,7 +114,15 @@ public enum DeliveryStatus {
         }
     }
 
-    // --- 기본 정책 (override하지 않으면 false) ---
+    /** 배송 준비 상태인지 */
+    public boolean isReady() {
+        return false;
+    }
+
+    /** 배송 요청 상태인지 */
+    public boolean isRequested() {
+        return false;
+    }
 
     /** 배송 상태 기준 주문 취소 가능 여부 (READY, REQUESTED만 true) */
     public boolean isOrderCancellable() {
@@ -122,6 +151,11 @@ public enum DeliveryStatus {
 
     /** 배송 정보 수정 가능 여부 (정책: READY만 true) */
     public boolean isDeliveryEditable() {
+        return false;
+    }
+
+    /** 송장 등록 가능한 상태인지 (운송장 번호 + 택배사 등록 가능 여부) */
+    public boolean canRegisterTracking() {
         return false;
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/DeliveryStatus.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/DeliveryStatus.java
@@ -6,10 +6,122 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum DeliveryStatus {
-    PENDING("배송 준비 중"),
-    REQUESTED("배송 요청"),
-    IN_TRANSIT("배송 중"),
-    DELIVERED("배송 완료");
+
+    READY("배송 준비 (출고 전)") {
+        @Override
+        public boolean canTransitionTo(DeliveryStatus newStatus) {
+            return newStatus == REQUESTED;
+        }
+
+        @Override
+        public boolean isOrderCancellable() {
+            return true;                // 주문 취소 가능
+        }
+
+        @Override
+        public boolean isBeforeTransit() {
+            return true;                // 집하 전
+        }
+
+        @Override
+        public boolean isDeliveryEditable() {
+            return true;                // 배송 정보 수정 가능 (READY만)
+        }
+    },
+
+    REQUESTED("송장 발행/배송요청 (수거 전)") {
+        @Override
+        public boolean canTransitionTo(DeliveryStatus newStatus) {
+            return newStatus == IN_TRANSIT;
+        }
+
+        @Override
+        public boolean isOrderCancellable() {
+            return true;                // 주문 취소 가능
+        }
+
+        @Override
+        public boolean isBeforeTransit() {
+            return true;                // 집하 전
+        }
+    },
+
+    IN_TRANSIT("배송 중 (집하/이동 시작)") {
+        @Override
+        public boolean canTransitionTo(DeliveryStatus newStatus) {
+            return newStatus == DELIVERED;
+        }
+
+        @Override
+        public boolean isInTransit() {
+            return true;
+        }
+    },
+
+    DELIVERED("배송 완료") {
+        @Override
+        public boolean canTransitionTo(DeliveryStatus newStatus) {
+            return false;
+        }
+
+        @Override
+        public boolean isDelivered() {
+            return true;
+        }
+
+        @Override
+        public boolean isFinalState() {
+            return true;
+        }
+    };
 
     private final String description;
+
+    // --- 상태 전이 검증 ---
+
+    public abstract boolean canTransitionTo(DeliveryStatus newStatus);
+
+    public void validateTransition(DeliveryStatus newStatus) {
+        if (!canTransitionTo(newStatus)) {
+            throw new IllegalStateException(
+                    String.format(
+                            "배송 상태를 %s(%s) → %s(%s) 로 변경할 수 없습니다.",
+                            this.name(), this.description,
+                            newStatus.name(), newStatus.description
+                    )
+            );
+        }
+    }
+
+    // --- 기본 정책 (override하지 않으면 false) ---
+
+    /** 배송 상태 기준 주문 취소 가능 여부 (READY, REQUESTED만 true) */
+    public boolean isOrderCancellable() {
+        return false;
+    }
+
+    /** 배송 시작 전 여부 (READY, REQUESTED) */
+    public boolean isBeforeTransit() {
+        return false;
+    }
+
+    /** 실제 배송 진행 중 여부 */
+    public boolean isInTransit() {
+        return false;
+    }
+
+    /** 배송 완료 여부 */
+    public boolean isDelivered() {
+        return false;
+    }
+
+    /** 최종 상태(더 이상 변경 불가) 여부 */
+    public boolean isFinalState() {
+        return false;
+    }
+
+    /** 배송 정보 수정 가능 여부 (정책: READY만 true) */
+    public boolean isDeliveryEditable() {
+        return false;
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/OrderAmount.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/OrderAmount.java
@@ -1,0 +1,83 @@
+package com.palja.order_service.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderAmount {
+
+    @Column(name = "product_total_amount", nullable = false)
+    private BigDecimal productTotalAmount;
+
+    @Column(name = "item_discount_amount", nullable = false)
+    private BigDecimal itemDiscountAmount;
+
+    @Column(name = "coupon_discount_amount")
+    private BigDecimal couponDiscountAmount;
+
+    @Column(name = "delivery_fee", nullable = false)
+    private BigDecimal deliveryFee;
+
+    @Column(name = "final_amount", nullable = false)
+    private BigDecimal finalAmount;
+
+    private OrderAmount(
+            BigDecimal productTotalAmount,
+            BigDecimal itemDiscountAmount,
+            BigDecimal couponDiscountAmount,
+            BigDecimal deliveryFee
+    ) {
+        this.productTotalAmount = defaultZero(productTotalAmount);
+        this.itemDiscountAmount = defaultZero(itemDiscountAmount);
+        this.couponDiscountAmount = defaultZero(couponDiscountAmount);
+        this.deliveryFee = defaultZero(deliveryFee);
+        this.finalAmount = calculateFinalAmount();
+    }
+
+    public static OrderAmount of(
+            BigDecimal productTotalAmount,
+            BigDecimal itemDiscountAmount,
+            BigDecimal couponDiscountAmount,
+            BigDecimal deliveryFee
+    ) {
+        return new OrderAmount(productTotalAmount, itemDiscountAmount, couponDiscountAmount, deliveryFee);
+    }
+
+    private BigDecimal calculateFinalAmount() {
+        BigDecimal result = productTotalAmount
+                .subtract(itemDiscountAmount)
+                .subtract(couponDiscountAmount)
+                .add(deliveryFee);
+
+        // 최종 금액은 최소 0원
+        if (result.compareTo(BigDecimal.ZERO) < 0) {
+            return BigDecimal.ZERO;
+        }
+
+        return result;
+    }
+
+    private BigDecimal defaultZero(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+
+    /**
+     * 쿠폰이 나중에 적용되는 경우 withCouponDiscount 메서드를 추가해서
+     * 금액 변경은 항상 VO를 통하게 만듬.
+     */
+    public OrderAmount withCouponDiscount(BigDecimal couponDiscountAmount) {
+        return new OrderAmount(
+                this.productTotalAmount,
+                this.itemDiscountAmount,
+                couponDiscountAmount,
+                this.deliveryFee
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/OrderAmount.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/OrderAmount.java
@@ -2,15 +2,15 @@ package com.palja.order_service.domain.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class OrderAmount {
 
     @Column(name = "product_total_amount", nullable = false)
@@ -28,56 +28,49 @@ public class OrderAmount {
     @Column(name = "final_amount", nullable = false)
     private BigDecimal finalAmount;
 
-    private OrderAmount(
+    public static OrderAmount create(
             BigDecimal productTotalAmount,
             BigDecimal itemDiscountAmount,
             BigDecimal couponDiscountAmount,
             BigDecimal deliveryFee
     ) {
-        this.productTotalAmount = defaultZero(productTotalAmount);
-        this.itemDiscountAmount = defaultZero(itemDiscountAmount);
-        this.couponDiscountAmount = defaultZero(couponDiscountAmount);
-        this.deliveryFee = defaultZero(deliveryFee);
-        this.finalAmount = calculateFinalAmount();
+        BigDecimal validatedProductTotal   = defaultZero(productTotalAmount);
+        BigDecimal validatedItemDiscount   = defaultZero(itemDiscountAmount);
+        BigDecimal validatedCouponDiscount = defaultZero(couponDiscountAmount);
+        BigDecimal validatedDeliveryFee    = defaultZero(deliveryFee);
+
+        BigDecimal finalAmount = calculateFinalAmount(
+                validatedProductTotal,
+                validatedItemDiscount,
+                validatedCouponDiscount,
+                validatedDeliveryFee
+        );
+
+        return OrderAmount.builder()
+                .productTotalAmount(validatedProductTotal)
+                .itemDiscountAmount(validatedItemDiscount)
+                .couponDiscountAmount(validatedCouponDiscount)
+                .deliveryFee(validatedDeliveryFee)
+                .finalAmount(finalAmount)
+                .build();
     }
 
-    public static OrderAmount of(
+    // ===== 금액 계산 =====
+    private static BigDecimal calculateFinalAmount(
             BigDecimal productTotalAmount,
             BigDecimal itemDiscountAmount,
             BigDecimal couponDiscountAmount,
             BigDecimal deliveryFee
     ) {
-        return new OrderAmount(productTotalAmount, itemDiscountAmount, couponDiscountAmount, deliveryFee);
-    }
-
-    private BigDecimal calculateFinalAmount() {
         BigDecimal result = productTotalAmount
                 .subtract(itemDiscountAmount)
                 .subtract(couponDiscountAmount)
                 .add(deliveryFee);
 
-        // 최종 금액은 최소 0원
-        if (result.compareTo(BigDecimal.ZERO) < 0) {
-            return BigDecimal.ZERO;
-        }
-
-        return result;
+        return result.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : result;
     }
 
-    private BigDecimal defaultZero(BigDecimal value) {
+    private static BigDecimal defaultZero(BigDecimal value) {
         return value == null ? BigDecimal.ZERO : value;
-    }
-
-    /**
-     * 쿠폰이 나중에 적용되는 경우 withCouponDiscount 메서드를 추가해서
-     * 금액 변경은 항상 VO를 통하게 만듬.
-     */
-    public OrderAmount withCouponDiscount(BigDecimal couponDiscountAmount) {
-        return new OrderAmount(
-                this.productTotalAmount,
-                this.itemDiscountAmount,
-                couponDiscountAmount,
-                this.deliveryFee
-        );
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/OrderCancellation.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/OrderCancellation.java
@@ -1,0 +1,60 @@
+package com.palja.order_service.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class OrderCancellation {
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    @Column(name = "cancel_reason")
+    private String cancelReason;
+
+    @Column(name = "canceled_by")
+    private String canceledBy;
+
+    public static OrderCancellation create(String cancelReason, String canceledBy) {
+        String validatedReason = validateCancelReason(cancelReason);
+        String validatedBy = validateCanceledBy(canceledBy);
+
+        return OrderCancellation.builder()
+                .canceledAt(LocalDateTime.now())
+                .cancelReason(validatedReason)
+                .canceledBy(validatedBy)
+                .build();
+    }
+
+    public boolean isCanceled() {
+        return canceledAt != null;
+    }
+
+    // ===== 내부 검증 =====
+    private static String validateCancelReason(String cancelReason) {
+        if (cancelReason == null || cancelReason.isBlank()) {
+            throw new IllegalArgumentException("취소 사유는 필수입니다.");
+        }
+        if (cancelReason.length() > 500) {
+            throw new IllegalArgumentException("취소 사유는 500자를 초과할 수 없습니다.");
+        }
+        return cancelReason.trim();
+    }
+
+    private static String validateCanceledBy(String canceledBy) {
+        if (canceledBy == null || canceledBy.isBlank()) {
+            throw new IllegalArgumentException("취소자 정보는 필수입니다.");
+        }
+        if (canceledBy.length() > 50) {
+            throw new IllegalArgumentException("취소자 정보는 50자를 초과할 수 없습니다.");
+        }
+        return canceledBy.trim();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
@@ -6,13 +6,189 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum OrderStatus {
-    CREATED("주문 생성"),
-    PAID("결제 완료"),
-    PREPARING("상품 준비 중"),
-    SHIPPED("배송 출발"),
-    DELIVERED("배송 완료"),
-    COMPLETED("구매 확정"),
-    CANCELED("주문 취소");
+
+    CREATED("주문 생성") {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return newStatus == PAID || newStatus == CANCELED;
+        }
+
+        @Override
+        public boolean isCancelableCandidate() {
+            return true;
+        }
+    },
+
+    PAID("결제 완료") {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return newStatus == PREPARING || newStatus == CANCELED;
+        }
+
+        @Override
+        public boolean isPaid() {
+            return true;
+        }
+
+        @Override
+        public boolean isCancelableCandidate() {
+            return true;
+        }
+    },
+
+    PREPARING("상품 준비 중") {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return newStatus == SHIPPED || newStatus == CANCELED;
+        }
+
+        @Override
+        public boolean isPreparing() {
+            return true;
+        }
+
+        @Override
+        public boolean isCancelableCandidate() {
+            return true;
+        }
+    },
+
+    SHIPPED("배송 출발") {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return newStatus == DELIVERED;
+        }
+
+        @Override
+        public boolean isShipped() {
+            return true;
+        }
+    },
+
+    DELIVERED("모든 배송 완료") {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return newStatus == COMPLETED;
+        }
+
+        @Override
+        public boolean isDelivered() {
+            return true;
+        }
+    },
+
+    COMPLETED("구매 확정") {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            // 구매확정 이후에는 상태 전이 불가
+            return false;
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return true;
+        }
+
+        @Override
+        public boolean isFinalState() {
+            return true;
+        }
+    },
+
+    CANCELED("주문 취소") {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            // 취소 이후에는 상태 전이 불가
+            return false;
+        }
+
+        @Override
+        public boolean isCanceled() {
+            return true;
+        }
+
+        @Override
+        public boolean isFinalState() {
+            return true;
+        }
+    };
 
     private final String description;
+
+    /** 상태 전환 가능 여부 */
+    public abstract boolean canTransitionTo(OrderStatus newStatus);
+
+    /** 공통 상태 전환 검증 */
+    public void validateTransition(OrderStatus newStatus) {
+        if (!canTransitionTo(newStatus)) {
+            throw new IllegalStateException(
+                    String.format(
+                            "주문 상태를 %s(%s) → %s(%s) 로 변경할 수 없습니다.",
+                            this.name(), this.description,
+                            newStatus.name(), newStatus.description
+                    )
+            );
+        }
+    }
+
+    // === 헬퍼 메서드들 (필요한 것만 override) === //
+
+    /** 최종 상태 여부 (CANCELED, COMPLETED 등) */
+    public boolean isFinalState() {
+        return false;
+    }
+
+    /** 결제 완료 상태인지 */
+    public boolean isPaid() {
+        return false;
+    }
+
+    /** 준비중 상태인지 */
+    public boolean isPreparing() {
+        return false;
+    }
+
+    /** 배송 출발 이후인지 (SHIPPED 이상) */
+    public boolean isShippedOrBeyond() {
+        return this == SHIPPED || this == DELIVERED || this == COMPLETED;
+    }
+
+    public boolean isShipped() {
+        return false;
+    }
+
+    public boolean isDelivered() {
+        return false;
+    }
+
+    public boolean isCompleted() {
+        return false;
+    }
+
+    public boolean isCanceled() {
+        return false;
+    }
+
+    /**
+     * "상태 기준"으로만 봤을 때 취소 후보 상태인지
+     * - CREATED / PAID / PREPARING
+     * - 실제 취소 가능 여부는 배송 상태(READY/REQUESTED 이하)까지 같이 체크해야 함
+     */
+    public boolean isCancelableCandidate() {
+        return false;
+    }
+
+    /**
+     * 취소 가능한 상태인지 확인
+     */
+    public boolean isCancellable() {
+        return this == CREATED || this == PAID || this == PREPARING;
+    }
+
+    /**
+     * 구매 확정 가능한 상태인지 확인
+     */
+    public boolean isConfirmable() {
+        return this == DELIVERED;
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
@@ -131,9 +131,9 @@ public enum OrderStatus {
         }
     }
 
-    // === 헬퍼 메서드들 (필요한 것만 override) === //
+    // ==== 헬퍼 메서드 (필요한 것만 override) ===== //
 
-    /** 최종 상태 여부 (CANCELED, COMPLETED 등) */
+    /** 최종 상태 여부 (CANCELED, COMPLETED) */
     public boolean isFinalState() {
         return false;
     }
@@ -170,9 +170,9 @@ public enum OrderStatus {
     }
 
     /**
-     * "상태 기준"으로만 봤을 때 취소 후보 상태인지
+     * 상태 기준 취소 가능 상태인지
      * - CREATED / PAID / PREPARING
-     * - 실제 취소 가능 여부는 배송 상태(READY/REQUESTED 이하)까지 같이 체크해야 함
+     * - 실제 취소 가능 여부는 배송 상태(READY/REQUESTED 이하)까지 같이 확인
      */
     public boolean isCancelableCandidate() {
         return false;

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/Recipient.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/Recipient.java
@@ -2,15 +2,15 @@ package com.palja.order_service.domain.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.regex.Pattern;
 
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class Recipient {
 
     // 이메일 형식
@@ -29,30 +29,36 @@ public class Recipient {
     @Column(name = "delivery_message", length = 255)
     private String deliveryMessage;
 
-    private Recipient(
+    public static Recipient create(
             String name,
             String email,
             String address,
             String deliveryMessage
     ) {
-        this.name = validateName(name);
-        this.email = validateEmail(email);
-        this.address = validateAddress(address);
-        this.deliveryMessage = validateDeliveryMessage(deliveryMessage);
+        String validatedName = validateName(name);
+        String validatedEmail = validateEmail(email);
+        String validatedAddress = validateAddress(address);
+        String validatedMessage = validateDeliveryMessage(deliveryMessage);
+
+        return Recipient.builder()
+                .name(validatedName)
+                .email(validatedEmail)
+                .address(validatedAddress)
+                .deliveryMessage(validatedMessage)
+                .build();
     }
 
-    // 생성
-    public static Recipient of(
+    public Recipient change(
             String name,
             String email,
             String address,
             String deliveryMessage
     ) {
-        return new Recipient(name, email, address, deliveryMessage);
+        return create(name, email, address, deliveryMessage);
     }
 
-    // ======= Validation + Normalization ======
-    private String validateName(String name) {
+    // ====== Validation + Normalization ======
+    private static String validateName(String name) {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("수령인 이름은 필수입니다.");
         }
@@ -62,7 +68,7 @@ public class Recipient {
         return name.trim();
     }
 
-    private String validateAddress(String address) {
+    private static String validateAddress(String address) {
         if (address == null || address.isBlank()) {
             throw new IllegalArgumentException("수령인 주소는 필수입니다.");
         }
@@ -72,7 +78,7 @@ public class Recipient {
         return address.trim();
     }
 
-    private String validateEmail(String email) {
+    private static String validateEmail(String email) {
         // optional
         if (email == null || email.isBlank()) {
             return null;
@@ -91,7 +97,7 @@ public class Recipient {
         return trimmed.toLowerCase();
     }
 
-    private String validateDeliveryMessage(String message) {
+    private static String validateDeliveryMessage(String message) {
         // optional
         if (message == null || message.isBlank()) {
             return null;
@@ -102,15 +108,5 @@ public class Recipient {
         }
 
         return message.trim();
-    }
-
-    // 변경 시 새 VO 반환
-    public Recipient change(
-            String name,
-            String email,
-            String address,
-            String deliveryMessage
-    ) {
-        return new Recipient(name, email, address, deliveryMessage);
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/Recipient.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/Recipient.java
@@ -1,0 +1,116 @@
+package com.palja.order_service.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.regex.Pattern;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recipient {
+
+    // 이메일 형식
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
+
+    @Column(name = "recipient_name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "recipient_email", length = 255)
+    private String email;
+
+    @Column(name = "recipient_address", nullable = false, length = 200)
+    private String address;
+
+    @Column(name = "delivery_message", length = 255)
+    private String deliveryMessage;
+
+    private Recipient(
+            String name,
+            String email,
+            String address,
+            String deliveryMessage
+    ) {
+        this.name = validateName(name);
+        this.email = validateEmail(email);
+        this.address = validateAddress(address);
+        this.deliveryMessage = validateDeliveryMessage(deliveryMessage);
+    }
+
+    // 생성
+    public static Recipient of(
+            String name,
+            String email,
+            String address,
+            String deliveryMessage
+    ) {
+        return new Recipient(name, email, address, deliveryMessage);
+    }
+
+    // ======= Validation + Normalization ======
+    private String validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("수령인 이름은 필수입니다.");
+        }
+        if (name.length() > 50) {
+            throw new IllegalArgumentException("수령인 이름은 50자를 초과할 수 없습니다.");
+        }
+        return name.trim();
+    }
+
+    private String validateAddress(String address) {
+        if (address == null || address.isBlank()) {
+            throw new IllegalArgumentException("수령인 주소는 필수입니다.");
+        }
+        if (address.length() > 200) {
+            throw new IllegalArgumentException("수령인 주소는 200자를 초과할 수 없습니다.");
+        }
+        return address.trim();
+    }
+
+    private String validateEmail(String email) {
+        // optional
+        if (email == null || email.isBlank()) {
+            return null;
+        }
+
+        String trimmed = email.trim();
+
+        if (trimmed.length() > 255) {
+            throw new IllegalArgumentException("이메일은 255자를 초과할 수 없습니다.");
+        }
+
+        if (!EMAIL_PATTERN.matcher(trimmed).matches()) {
+            throw new IllegalArgumentException("유효한 이메일 형식이 아닙니다.");
+        }
+
+        return trimmed.toLowerCase();
+    }
+
+    private String validateDeliveryMessage(String message) {
+        // optional
+        if (message == null || message.isBlank()) {
+            return null;
+        }
+
+        if (message.length() > 255) {
+            throw new IllegalArgumentException("배송 메시지는 255자를 초과할 수 없습니다.");
+        }
+
+        return message.trim();
+    }
+
+    // 변경 시 새 VO 반환
+    public Recipient change(
+            String name,
+            String email,
+            String address,
+            String deliveryMessage
+    ) {
+        return new Recipient(name, email, address, deliveryMessage);
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/CouponClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/CouponClient.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.UUID;
 
-@FeignClient(name = "coupon", path = "/api/v1/coupons")
+@FeignClient(name = "coupon-service", path = "/api/v1/coupons")
 public interface CouponClient {
 
     // 쿠폰 단건 조회

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/CouponClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/CouponClient.java
@@ -1,7 +1,25 @@
 package com.palja.order_service.infrastructure.external;
 
+import com.palja.common.response.ApiResponse;
+import com.palja.order_service.infrastructure.external.dto.request.UseCouponDTO;
+import com.palja.order_service.infrastructure.external.dto.response.CouponDTO;
+import com.palja.order_service.infrastructure.external.dto.response.CouponUseDTO;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
 
 @FeignClient(name = "coupon", path = "/api/v1/coupons")
 public interface CouponClient {
+
+    // 쿠폰 단건 조회
+    @GetMapping("/{couponId}")
+    ApiResponse<CouponDTO> getCoupon(@PathVariable("couponId") UUID couponId);
+
+    // 쿠폰 사용
+    @PostMapping("/{couponId}/use")
+    ApiResponse<CouponUseDTO> useCoupon(@PathVariable UUID couponId, @RequestBody UseCouponDTO request);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/PaymentClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/PaymentClient.java
@@ -1,0 +1,16 @@
+package com.palja.order_service.infrastructure.external;
+
+import com.palja.common.response.ApiResponse;
+import com.palja.order_service.infrastructure.external.dto.request.CreatePaymentDTO;
+import com.palja.order_service.infrastructure.external.dto.response.PaymentDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "payment-service", path = "/api/v1/payments")
+public interface PaymentClient {
+
+    // 결제 생성 요청
+    @PostMapping
+    ApiResponse<PaymentDTO> createPayment(@RequestBody CreatePaymentDTO request);
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/ProductClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/ProductClient.java
@@ -11,6 +11,6 @@ import java.util.UUID;
 @FeignClient(name = "product-service", path = "/api/v1/products")
 public interface ProductClient {
 
-    @GetMapping("{productId}")
+    @GetMapping("/{productId}")
     ApiResponse<ProductDTO> getProduct(@PathVariable("productId") UUID productId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/ProductClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/ProductClient.java
@@ -1,7 +1,16 @@
 package com.palja.order_service.infrastructure.external;
 
+import com.palja.common.response.ApiResponse;
+import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "product", path = "/api/v1/products")
+import java.util.UUID;
+
+@FeignClient(name = "product-service", path = "/api/v1/products")
 public interface ProductClient {
+
+    @GetMapping("{productId}")
+    ApiResponse<ProductDTO> getProduct(@PathVariable("productId") UUID productId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/TimeDealClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/TimeDealClient.java
@@ -1,7 +1,16 @@
 package com.palja.order_service.infrastructure.external;
 
+import com.palja.common.response.ApiResponse;
+import com.palja.order_service.infrastructure.external.dto.response.TimeDealDTO;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "time-deal", path = "api/v1/time-deals")
+import java.util.UUID;
+
+@FeignClient(name = "timedeal-service", path = "/api/v1/time-deals")
 public interface TimeDealClient {
+
+    @GetMapping("/{timeDealId}")
+    ApiResponse<TimeDealDTO> getTimeDeal(@PathVariable("timeDealId") UUID timeDealId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
@@ -1,7 +1,8 @@
 package com.palja.order_service.infrastructure.external;
 
 import com.palja.common.response.ApiResponse;
-import com.palja.order_service.infrastructure.external.dto.response.UserDTO;
+import com.palja.order_service.infrastructure.external.dto.response.CustomerUserDTO;
+import com.palja.order_service.infrastructure.external.dto.response.ManagerUserDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,7 +10,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name = "user-service", path = "/api/v1")
 public interface UserClient {
 
-    // 사용자 정보 조회
+    // customer 사용자 정보 조회
     @GetMapping("/customers/{loginId}")
-    ApiResponse<UserDTO> getUserByLoginId(@PathVariable("loginId") String loginId);
+    ApiResponse<CustomerUserDTO> getCustomerUserByLoginId(@PathVariable("loginId") String loginId);
+
+    // manager 사용자 정보 조회
+    @GetMapping("managers/{loginId}")
+    ApiResponse<ManagerUserDTO> getManagerUserByLoginId(@PathVariable("loginId") String loginId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
@@ -1,7 +1,15 @@
 package com.palja.order_service.infrastructure.external;
 
+import com.palja.common.response.ApiResponse;
+import com.palja.order_service.infrastructure.external.dto.response.UserDTO;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "user", path = "/api/v1")
+@FeignClient(name = "user-service", path = "/api/v1/users")
 public interface UserClient {
+
+    // 사용자 정보 조회
+    @GetMapping("/{loginId}")
+    ApiResponse<UserDTO> getUserByLoginId(@PathVariable("loginId") String loginId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
@@ -15,6 +15,6 @@ public interface UserClient {
     ApiResponse<CustomerUserDTO> getCustomerUserByLoginId(@PathVariable("loginId") String loginId);
 
     // manager 사용자 정보 조회
-    @GetMapping("managers/{loginId}")
+    @GetMapping("/managers/{loginId}")
     ApiResponse<ManagerUserDTO> getManagerUserByLoginId(@PathVariable("loginId") String loginId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
@@ -6,10 +6,10 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "user-service", path = "/api/v1/users")
+@FeignClient(name = "user-service", path = "/api/v1")
 public interface UserClient {
 
     // 사용자 정보 조회
-    @GetMapping("/{loginId}")
+    @GetMapping("/customers/{loginId}")
     ApiResponse<UserDTO> getUserByLoginId(@PathVariable("loginId") String loginId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
@@ -41,6 +41,5 @@ public class CouponAdapter implements CouponService {
         CouponUseDTO response = CouponUseDTO.dummy(couponId, orderId);
 
         log.info("쿠폰 사용 완료: couponId={}, orderId={}", couponId, orderId);
-
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
@@ -1,13 +1,46 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
+import com.palja.order_service.application.dto.CouponRes;
 import com.palja.order_service.application.service.CouponService;
+import com.palja.order_service.infrastructure.external.dto.response.CouponDTO;
+import com.palja.order_service.infrastructure.external.dto.response.CouponUseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CouponAdapter implements CouponService {
 
     // TODO: 쿠폰 서비스 연동 시 CouponClient 주입 및 구현 추가
-    // private final CouponClient couponClient;
+    //private final CouponClient couponClient;
+
+    @Override
+    public CouponRes getCoupon(UUID couponId) {
+        log.debug("쿠폰 정보 조회: couponId={}", couponId);
+
+        // TODO: 실제 쿠폰 서비스 API 호출 (Feign)
+        //CouponDTO response = couponClient.getCoupon(couponId).data();
+        // 임시 더미 데이터
+        CouponDTO response = CouponDTO.dummy(couponId);
+        CouponRes coupon = CouponRes.from(response);
+
+        return coupon;
+    }
+
+    @Override
+    public void useCoupon(UUID couponId, UUID orderId) {
+        log.debug("쿠폰 사용 처리: couponId={}, orderId={}", couponId, orderId);
+
+        // TODO: 실제 쿠폰 서비스 API 호출 (Feign)
+        // UseCouponDTO request = new UseCouponDTO(orderId);
+        // CouponUseDTO response = couponClient.useCoupon(couponId, request).data();
+        CouponUseDTO response = CouponUseDTO.dummy(couponId, orderId);
+
+        log.info("쿠폰 사용 완료: couponId={}, orderId={}", couponId, orderId);
+
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
@@ -38,6 +38,7 @@ public class CouponAdapter implements CouponService {
         // TODO: 실제 쿠폰 서비스 API 호출 (Feign)
         // UseCouponDTO request = new UseCouponDTO(orderId);
         // CouponUseDTO response = couponClient.useCoupon(couponId, request).data();
+        // TODO: 실제 쿠폰 서비스 연동 시 위의 코드로 교체
         CouponUseDTO response = CouponUseDTO.dummy(couponId, orderId);
 
         log.info("쿠폰 사용 완료: couponId={}, orderId={}", couponId, orderId);

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
@@ -1,5 +1,6 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
+import com.palja.order_service.application.dto.CouponDiscountType;
 import com.palja.order_service.application.dto.CouponRes;
 import com.palja.order_service.application.service.CouponService;
 import com.palja.order_service.infrastructure.external.dto.response.CouponDTO;
@@ -31,10 +32,13 @@ public class CouponAdapter implements CouponService {
     }
 
     private CouponRes toCouponRes(CouponDTO dto) {
+
+        CouponDiscountType discountType = CouponDiscountType.from(dto.getDiscountType());
+
         return CouponRes.of(
                 dto.getCouponId(),
                 dto.getName(),
-                dto.getDiscountType(),
+                discountType,
                 dto.getDiscountValue(),
                 dto.getMaxDiscountAmount(),
                 dto.getMinOrderAmount(),

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/CouponAdapter.java
@@ -26,9 +26,23 @@ public class CouponAdapter implements CouponService {
         //CouponDTO response = couponClient.getCoupon(couponId).data();
         // 임시 더미 데이터
         CouponDTO response = CouponDTO.dummy(couponId);
-        CouponRes coupon = CouponRes.from(response);
 
-        return coupon;
+        return toCouponRes(response);
+    }
+
+    private CouponRes toCouponRes(CouponDTO dto) {
+        return CouponRes.of(
+                dto.getCouponId(),
+                dto.getName(),
+                dto.getDiscountType(),
+                dto.getDiscountValue(),
+                dto.getMaxDiscountAmount(),
+                dto.getMinOrderAmount(),
+                dto.getIssueStartAt(),
+                dto.getIssueEndAt(),
+                dto.getValidityDays(),
+                dto.getStatus()
+        );
     }
 
     @Override

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 public class PaymentAdapter implements PaymentService {
 
     // TODO: 결제 서비스 연동 시 PaymentClient 주입 및 구현 추가
-     private final PaymentClient paymentClient;
+    //private final PaymentClient paymentClient;
 
     @Override
     public PaymentRes createPayment(UUID orderId, Long userId, BigDecimal amount, String paymentMethod) {

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
@@ -1,0 +1,36 @@
+package com.palja.order_service.infrastructure.external.adapter;
+
+import com.palja.order_service.application.dto.PaymentRes;
+import com.palja.order_service.application.service.PaymentService;
+import com.palja.order_service.infrastructure.external.PaymentClient;
+import com.palja.order_service.infrastructure.external.dto.response.PaymentDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentAdapter implements PaymentService {
+
+    // TODO: 결제 서비스 연동 시 PaymentClient 주입 및 구현 추가
+     private final PaymentClient paymentClient;
+
+    @Override
+    public PaymentRes createPayment(UUID orderId, Long userId, BigDecimal amount, String paymentMethod) {
+        log.debug("결제 생성 요청: orderId={}, userId={}, amount={}, paymentMethod={}",
+                orderId, userId, amount, paymentMethod);
+
+        // TODO: payment-service 연동 시 FeignClient 호출 사용
+        // CreatePaymentDTO request = new CreatePaymentDTO(orderId, userId, amount, paymentMethod);
+        // PaymentDTO response = paymentClient.createPayment(request).data();
+        // TODO: 실제 결제 서비스 연동 시 위의 코드로 교체
+        // 임시 더미 데이터
+        PaymentDTO dummy = PaymentDTO.dummy(orderId, userId, amount);
+
+        return PaymentRes.from(dummy);
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
@@ -2,7 +2,6 @@ package com.palja.order_service.infrastructure.external.adapter;
 
 import com.palja.order_service.application.dto.PaymentRes;
 import com.palja.order_service.application.service.PaymentService;
-import com.palja.order_service.infrastructure.external.PaymentClient;
 import com.palja.order_service.infrastructure.external.dto.response.PaymentDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +30,6 @@ public class PaymentAdapter implements PaymentService {
         // 임시 더미 데이터
         PaymentDTO dummy = PaymentDTO.dummy(orderId, userId, amount);
 
-        return PaymentRes.from(dummy);
+        return PaymentRes.of(dummy.getPaymentId(), dummy.getAmount());
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
@@ -1,13 +1,53 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
+import com.palja.order_service.application.dto.ProductRes;
 import com.palja.order_service.application.service.ProductService;
+import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
+// 상품 서비스 클라이언트 구현
+// FeignClient를 통한 외부 서비스 호출
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProductAdapter implements ProductService {
 
     // TODO: 상품 서비스 연동 시 productClient 주입 및 구현 추가
-    //private final ProductClient productClient;
+     //private final ProductClient productClient;
+
+    @Override
+    public ProductRes getProduct(UUID productId, int quantity) {
+        log.debug("상품 정보 조회: productId={}", productId);
+
+        // TODO: 실제 상품 API 호출 (Feign)
+        // ProductDTO response = productClient.getProduct(productId).data();
+        // TODO: 실제 상품 서비스 연동 시 위의 코드로 교체
+        // 임시 더미 데이터
+        ProductDTO response = ProductDTO.dummy(productId);
+
+        ProductRes product = ProductRes.from(response);
+
+        // 재고 검증
+        product.validateStock(quantity);
+
+        return product;
+    }
+
+    @Override
+    public void deductStock(UUID productId, int quantity) {
+        log.debug("재고 차감 요청: productId={}, quantity={}", productId, quantity);
+        // TODO: 상품 재고 차감 API 호출 구현
+        log.error("재고 차감 실패: productId={}, quantity={}", productId, quantity);
+    }
+
+    @Override
+    public void restoreStock(UUID productId, int quantity) {
+        log.debug("재고 복구 요청: productId={}, quantity={}", productId, quantity);
+        // TODO: 상품 재고 차감 API 호출 구현
+        log.error("재고 복구 실패: productId={}, quantity={}", productId, quantity);
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
@@ -1,8 +1,6 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
-import com.palja.common.exception.BusinessException;
 import com.palja.order_service.application.dto.ProductRes;
-import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.ProductService;
 import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +29,16 @@ public class ProductAdapter implements ProductService {
         // 임시 더미 데이터
         ProductDTO response = ProductDTO.dummy(productId);
 
-        return ProductRes.from(response);
+        return toProductRes(response);
+    }
+
+    private ProductRes toProductRes(ProductDTO dto) {
+        return ProductRes.of(
+                dto.getProductId(),
+                dto.getName(),
+                dto.getPrice(),
+                dto.getStock()
+        );
     }
 
     @Override

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
@@ -1,6 +1,8 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
+import com.palja.common.exception.BusinessException;
 import com.palja.order_service.application.dto.ProductRes;
+import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.ProductService;
 import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
 import lombok.RequiredArgsConstructor;
@@ -29,12 +31,7 @@ public class ProductAdapter implements ProductService {
         // 임시 더미 데이터
         ProductDTO response = ProductDTO.dummy(productId);
 
-        ProductRes product = ProductRes.from(response);
-
-        // 재고 검증
-        product.validateStock(quantity);
-
-        return product;
+        return ProductRes.from(response);
     }
 
     @Override

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
@@ -27,7 +27,20 @@ public class TimeDealAdapter implements TimeDealService {
         // 임시 더미 데이터
         TimeDealDTO response = TimeDealDTO.dummy(timeDealId);
 
-        return TimeDealRes.from(response);
+        return toTimeDealRes(response);
+    }
+
+    private TimeDealRes toTimeDealRes(TimeDealDTO dto) {
+        return TimeDealRes.of(
+                dto.getTimeDealId(),
+                dto.getProductId(),
+                dto.getStartAt(),
+                dto.getEndAt(),
+                dto.getTimeDealPrice(),
+                dto.getDiscountRate(),
+                dto.getQuantity(),
+                dto.getStatus()
+        );
     }
 
     @Override

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
@@ -27,13 +27,7 @@ public class TimeDealAdapter implements TimeDealService {
         // 임시 더미 데이터
         TimeDealDTO response = TimeDealDTO.dummy(timeDealId);
 
-        TimeDealRes timeDeal = TimeDealRes.from(response);
-
-        // 판매기간/재고 검증
-        timeDeal.validatePeriod();
-        timeDeal.validateStock(quantity);
-
-        return timeDeal;
+        return TimeDealRes.from(response);
     }
 
     @Override

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
@@ -1,16 +1,52 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
-import com.palja.order_service.application.service.ProductService;
+import com.palja.order_service.application.dto.TimeDealRes;
 import com.palja.order_service.application.service.TimeDealService;
-import com.palja.order_service.infrastructure.external.ProductClient;
-import com.palja.order_service.infrastructure.external.TimeDealClient;
+import com.palja.order_service.infrastructure.external.dto.response.TimeDealDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TimeDealAdapter implements TimeDealService {
 
     // TODO: 타임딜 서비스 연동 시 timeDealClient 주입 및 구현 추가
     //private final TimeDealClient timeDealClient;
+
+    @Override
+    public TimeDealRes getTimeDeal(UUID timeDealId, int quantity) {
+        log.debug("타임딜 정보 조회: timeDealId={}", timeDealId);
+
+        //TODO: 실제 타임딜 API 호출 (Feign)
+        //TimeDealDTO response = timeDealClient.getTimeDeal(timeDealId).data();
+        // TODO: 실제 타임딜 서비스 연동 시 위의 코드로 교체
+        // 임시 더미 데이터
+        TimeDealDTO response = TimeDealDTO.dummy(timeDealId);
+
+        TimeDealRes timeDeal = TimeDealRes.from(response);
+
+        // 판매기간/재고 검증
+        timeDeal.validatePeriod();
+        timeDeal.validateStock(quantity);
+
+        return timeDeal;
+    }
+
+    @Override
+    public void deductTimeDealStock(UUID timeDealId, int quantity) {
+        log.debug("타임딜 재고 차감 요청: timeDealId={}, quantity={}", timeDealId, quantity);
+        // TODO: 타임딜 재고 차감 API 호출 구현
+        log.error("타임딜 재고 차감 실패: productId={}, quantity={}", timeDealId, quantity);
+    }
+
+    @Override
+    public void restoreTimeDealStock(UUID timeDealId, int quantity) {
+        log.debug("타임딜 재고 복구 요청: timeDealId={}, quantity={}", timeDealId, quantity);
+        // TODO: 상품 재고 차감 API 호출 구현
+        log.error("타임딜 재고 복구 실패: timeDealId={}, quantity={}", timeDealId, quantity);
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -1,13 +1,35 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
+import com.palja.order_service.application.dto.UserRes;
 import com.palja.order_service.application.service.UserService;
+import com.palja.order_service.infrastructure.external.dto.response.UserDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserAdapter implements UserService {
 
     // TODO: 유저 서비스 연동 시 userClient 주입 및 구현 추가
     //private final UserClient userClient;
+
+    @Override
+    public UserRes getUserByLoginId(String loginId) {
+        log.debug("사용자 조회 요청: loginId={}", loginId);
+
+        // TODO: user-service 연동 시 FeignClient 호출 사용
+        // UserDTO response = userClient.getUserByLoginId(loginId).data();
+        // TODO: 실제 타임딜 서비스 연동 시 위의 코드로 교체
+        // 임시 더미 데이터
+        UserDTO response = UserDTO.dummy(loginId);
+
+        UserRes user = UserRes.from(response);
+
+        // 주문 가능한 사용자 여부 검증
+        user.validateOrderable();
+
+        return user;
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -21,7 +21,7 @@ public class UserAdapter implements UserService {
         // TODO: 권한에 따라 다른 엔드포인트 연결하기 (MANAGER, CUSTOMER, COMPANY_USER)
         // TODO: user-service 연동 시 FeignClient 호출 사용
         // UserDTO response = userClient.getUserByLoginId(loginId).data();
-        // TODO: 실제 타임딜 서비스 연동 시 위의 코드로 교체
+        // TODO: 실제 유저 서비스 연동 시 위의 코드로 교체
         // 임시 더미 데이터
         UserDTO response = UserDTO.dummy(loginId);
 

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -25,11 +25,6 @@ public class UserAdapter implements UserService {
         // 임시 더미 데이터
         UserDTO response = UserDTO.dummy(loginId);
 
-        UserRes user = UserRes.from(response);
-
-        // 주문 가능한 사용자 여부 검증
-        user.validateOrderable();
-
-        return user;
+        return UserRes.from(response);
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -18,7 +18,7 @@ public class UserAdapter implements UserService {
     @Override
     public UserRes getUserByLoginId(String loginId) {
         log.debug("사용자 조회 요청: loginId={}", loginId);
-
+        // TODO: 권한에 따라 다른 엔드포인트 연결하기 (MANAGER, CUSTOMER, COMPANY_USER)
         // TODO: user-service 연동 시 FeignClient 호출 사용
         // UserDTO response = userClient.getUserByLoginId(loginId).data();
         // TODO: 실제 타임딜 서비스 연동 시 위의 코드로 교체

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -2,7 +2,7 @@ package com.palja.order_service.infrastructure.external.adapter;
 
 import com.palja.order_service.application.dto.UserRes;
 import com.palja.order_service.application.service.UserService;
-import com.palja.order_service.infrastructure.external.dto.response.UserDTO;
+import com.palja.order_service.infrastructure.external.dto.response.CustomerUserDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -20,10 +20,11 @@ public class UserAdapter implements UserService {
         log.debug("사용자 조회 요청: loginId={}", loginId);
         // TODO: 권한에 따라 다른 엔드포인트 연결하기 (MANAGER, CUSTOMER, COMPANY_USER)
         // TODO: user-service 연동 시 FeignClient 호출 사용
-        // UserDTO response = userClient.getUserByLoginId(loginId).data();
+        // CustomerUserDTO response = userClient.getCustomerUserByLoginId(loginId).data();
+        // ManagerUserDTO response = userClient.getManagerUserByLoginId(loginId).data();
         // TODO: 실제 유저 서비스 연동 시 위의 코드로 교체
         // 임시 더미 데이터
-        UserDTO response = UserDTO.dummy(loginId);
+        CustomerUserDTO response = CustomerUserDTO.dummy(loginId);
 
         return UserRes.from(response);
     }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -26,6 +26,18 @@ public class UserAdapter implements UserService {
         // 임시 더미 데이터
         CustomerUserDTO response = CustomerUserDTO.dummy(loginId);
 
-        return UserRes.from(response);
+        return toUserRes(response);
     }
+
+    private UserRes toUserRes(CustomerUserDTO dto) {
+        return UserRes.of(
+                dto.getUserId(),
+                dto.getLoginId(),
+                dto.getName(),
+                dto.getEmail(),
+                dto.getRole(),
+                dto.getStatus()
+        );
+    }
+
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CreatePaymentDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CreatePaymentDTO.java
@@ -1,0 +1,31 @@
+package com.palja.order_service.infrastructure.external.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreatePaymentDTO {
+
+    private UUID orderId;
+    private Long userId;
+    private BigDecimal amount;
+    private String paymentMethod; // CARD 등
+
+    /**
+     * TODO: 결제 서비스 연동 전까지 사용하는 더미 데이터. payment-service 연동 후 삭제.
+     */
+    public static CreatePaymentDTO dummy(UUID orderId, Long userId, BigDecimal amount) {
+        return new CreatePaymentDTO(
+                orderId,
+                userId,
+                amount,
+                "CARD"
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/UseCouponDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/UseCouponDTO.java
@@ -1,0 +1,14 @@
+package com.palja.order_service.infrastructure.external.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UseCouponDTO {
+    private UUID orderId;
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CouponDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CouponDTO.java
@@ -1,0 +1,52 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CouponDTO {
+
+    private UUID couponId;
+    private String name;
+    private String discountType;      // PERCENTAGE, FIXED
+    private int discountValue;        // 20 (% 또는 정액 금액, 타입에 따라 의미 달라짐)
+    private int totalQuantity;
+    private int issuedQuantity;
+    private BigDecimal maxDiscountAmount;
+    private BigDecimal minOrderAmount;
+    private LocalDateTime issueStartAt;
+    private LocalDateTime issueEndAt;
+    private Integer validityDays;     // 발급 후 N일
+    private String status;            // ACTIVE, PAUSED, EXPIRED, DELETED
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    // TODO: 쿠폰 서비스 연동 전까지 사용하는 더미 데이터. coupon-service 연결 후 삭제.
+    public static CouponDTO dummy(UUID couponId) {
+        return new CouponDTO(
+                couponId,
+                "블랙프라이데이 20% 할인",
+                "PERCENTAGE",
+                20,
+                1000,
+                150,
+                BigDecimal.valueOf(30000),
+                BigDecimal.valueOf(1000),
+                LocalDateTime.of(2025, 12, 1, 0, 0),
+                LocalDateTime.of(2025, 12, 10, 23, 59, 59),
+                7,
+                "ACTIVE",
+                LocalDateTime.of(2025, 11, 30, 10, 0),
+                LocalDateTime.of(2025, 11, 30, 15, 0),
+                null
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CouponUseDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CouponUseDTO.java
@@ -1,0 +1,39 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CouponUseDTO {
+
+    private UUID couponUserId;
+    private UUID couponId;
+    private Long userId;
+    private UUID orderId;
+    private LocalDateTime expireAt;
+    private String status;              // UNUSED , USED, EXPIRE
+    private LocalDateTime usedAt;
+    private BigDecimal discountAmount;
+
+    /**
+     * TODO: 쿠폰 서비스 연동 전까지 사용하는 더미 데이터.
+     *       coupon-service 연동 후 삭제 예정.
+     */
+    public static CouponUseDTO dummy(UUID couponId, UUID orderId) {
+        return new CouponUseDTO(
+                UUID.randomUUID(),
+                couponId,
+                1L,
+                orderId,
+                LocalDateTime.now().plusDays(30),
+                "USED",
+                LocalDateTime.now(),
+                BigDecimal.valueOf(5000)
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CustomerUserDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CustomerUserDTO.java
@@ -1,0 +1,43 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import com.palja.common.vo.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerUserDTO {
+
+    private Long userId;
+    private String loginId;
+    private String name;
+    private String email;
+    private String address;
+    private UserRole role;   // MASTER, MANAGER, CUSTOMER, COMPANY_USER
+    private String status;   // PENDING, ACTIVE
+    private LocalDateTime createdAt;
+    private String createdBy;
+    private LocalDateTime updatedAt;
+    private String updatedBy;
+
+    // TODO: 사용자 서비스 연동 전까지 사용하는 더미 데이터. user-service 연결 후 삭제.
+    public static CustomerUserDTO dummy(String loginId) {
+        return new CustomerUserDTO(
+                1L,
+                loginId,
+                loginId,
+                loginId + "@example.com",
+                "서울시 강남구 테헤란로 123",
+                UserRole.CUSTOMER,
+                "ACTIVE",
+                LocalDateTime.now(),
+                loginId,
+                LocalDateTime.now(),
+                loginId
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ManagerUserDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ManagerUserDTO.java
@@ -10,13 +10,12 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserDTO {
+public class ManagerUserDTO {
 
     private Long userId;
     private String loginId;
     private String name;
     private String email;
-    private String address;
     private UserRole role;   // MASTER, MANAGER, CUSTOMER, COMPANY_USER
     private String status;   // PENDING, ACTIVE
     private LocalDateTime createdAt;
@@ -25,13 +24,12 @@ public class UserDTO {
     private String updatedBy;
 
     // TODO: 사용자 서비스 연동 전까지 사용하는 더미 데이터. user-service 연결 후 삭제.
-    public static UserDTO dummy(String loginId) {
-        return new UserDTO(
+    public static ManagerUserDTO dummy(String loginId) {
+        return new ManagerUserDTO(
                 1L,
                 loginId,
                 loginId,
                 loginId + "@example.com",
-                "서울시 강남구 테헤란로 123",
                 UserRole.CUSTOMER,
                 "ACTIVE",
                 LocalDateTime.now(),

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentDTO.java
@@ -1,0 +1,47 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 결제 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentDTO {
+
+    private UUID paymentId;
+    private UUID orderId;
+    private Long userId;
+    private BigDecimal amount;
+    private String paymentMethod;   // CARD, ACCOUNT,  EASY_PAY, MOBILE, VIRTUAL_ACCOUNT
+    private String currency;        // KRW
+    private String paymentKey;      // tossKey-abc123
+    private String status;          // PENDING, APPROVED, FAILED, CANCELED
+    private LocalDateTime requestedAt;
+    private LocalDateTime completedAt;
+
+    /**
+     * TODO: 결제 서비스 연동 전까지 사용하는 더미 데이터. payment-service 연동 후 삭제.
+     */
+    public static PaymentDTO dummy(UUID orderId, Long userId, BigDecimal amount) {
+        return new PaymentDTO(
+                UUID.randomUUID(),
+                orderId,
+                userId,
+                amount,
+                "CARD",
+                "KRW",
+                "dummy-payment-key-" + UUID.randomUUID(),
+                "APPROVED",
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentDTO.java
@@ -8,9 +8,6 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-/**
- * 결제 응답 DTO
- */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductDTO.java
@@ -1,0 +1,35 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductDTO {
+
+    private UUID productId;
+    private String name;
+    private String description;
+    private String companyName;
+    private int stock;
+    private BigDecimal price;
+    private String category;
+
+    // TODO: 상품 서비스 연동 전까지 사용하는 더미 데이터. product-service 연결 후 삭제.
+    public static ProductDTO dummy(UUID productId) {
+        return new ProductDTO(
+                productId,
+                "샘플 상품",
+                "샘플 상품 설명입니다.",
+                "팔자컴퍼니",
+                100,
+                BigDecimal.valueOf(10000),
+                "FOOD"
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/TimeDealDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/TimeDealDTO.java
@@ -1,0 +1,44 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeDealDTO {
+
+    private UUID timeDealId;
+    private UUID productId;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private BigDecimal timeDealPrice;
+    private int discountRate;
+    private String status; // ENUM(PENDING, OPEN, SOLD_OUT, CLOSED)
+    private int quantity;
+    private LocalDateTime createdAt;
+    private Long createdBy;
+    private LocalDateTime updatedAt;
+    private Long updatedBy;
+
+    // TODO: 타임딜 서비스 연동 전까지 사용하는 더미 데이터. time-deal-service 연결 후 삭제.
+    public static TimeDealDTO dummy(UUID timeDealId) {
+        return new TimeDealDTO(
+                timeDealId,
+                UUID.randomUUID(),
+                LocalDateTime.of(2025, 12, 1, 0, 0),
+                LocalDateTime.of(2025, 12, 10, 23, 59, 59),
+                BigDecimal.valueOf(9900),
+                10,
+                "OPEN",
+                37,
+                LocalDateTime.of(2025, 12, 3, 19, 0),
+                3L,
+                LocalDateTime.of(2025, 12, 3, 20, 0),
+                3L
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/UserDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/UserDTO.java
@@ -1,0 +1,43 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import com.palja.common.vo.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDTO {
+
+    private Long userId;
+    private String loginId;
+    private String name;
+    private String email;
+    private String address;
+    private UserRole role;   // MASTER, MANAGER, CUSTOMER, COMPANY_USER
+    private String status;   // PENDING, ACTIVE
+    private LocalDateTime createdAt;
+    private String createdBy;
+    private LocalDateTime updatedAt;
+    private String updatedBy;
+
+    // TODO: 사용자 서비스 연동 전까지 사용하는 더미 데이터. user-service 연결 후 삭제.
+    public static UserDTO dummy(String loginId) {
+        return new UserDTO(
+                1L,
+                loginId,
+                loginId,
+                loginId + "@example.com",
+                "서울시 강남구 테헤란로 123",
+                UserRole.CUSTOMER,
+                "ACTIVE",
+                LocalDateTime.now(),
+                loginId,
+                LocalDateTime.now(),
+                loginId
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/repository/impl/OrderRepositoryImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/repository/impl/OrderRepositoryImpl.java
@@ -1,13 +1,22 @@
 package com.palja.order_service.infrastructure.repository.impl;
 
+import com.palja.order_service.domain.entity.Order;
 import com.palja.order_service.domain.repository.OrderRepository;
 import com.palja.order_service.infrastructure.repository.JpaOrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderRepositoryImpl implements OrderRepository {
 
     private final JpaOrderRepository jpaOrderRepository;
+
+    @Override
+    @Transactional
+    public Order save(Order order) {
+        return jpaOrderRepository.save(order);
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.palja.order_service.presentation.controller;
 
+import com.palja.common.annotation.RequiredRole;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.dto.CreateOrderRes;
@@ -19,6 +20,7 @@ public class OrderController {
     private final OrderService orderService;
 
     // 주문 생성
+    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER})
     @PostMapping
     public ResponseEntity<ApiResponse<CreateOrderRes>> createOrder(
             @Valid @RequestBody CreateOrderReq request,

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.palja.order_service.presentation.controller;
 
 import com.palja.common.annotation.RequiredRole;
+import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.dto.CreateOrderRes;
@@ -23,14 +24,11 @@ public class OrderController {
     @PostMapping
     @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER})
     public ResponseEntity<ApiResponse<CreateOrderRes>> createOrder(
-            @Valid @RequestBody CreateOrderReq request,
-            // TODO: 추후 AuditorContext로 변경
-            @RequestHeader("X-Login-Id") String loginId,
-            @RequestHeader("X-User-Role") UserRole userRole
+            @Valid @RequestBody CreateOrderReq request
         ) {
 
         // Request → Command 변환
-        CreateOrderRes response = orderService.createOrder(request.toCommand(loginId));
+        CreateOrderRes response = orderService.createOrder(request.toCommand(CurrentUser.getLoginId()));
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
@@ -1,9 +1,15 @@
 package com.palja.order_service.presentation.controller;
 
+import com.palja.common.response.ApiResponse;
+import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.dto.CreateOrderRes;
 import com.palja.order_service.application.service.OrderService;
+import com.palja.order_service.presentation.dto.request.CreateOrderReq;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/orders")
@@ -12,4 +18,20 @@ public class OrderController {
 
     private final OrderService orderService;
 
+    // 주문 생성
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateOrderRes>> createOrder(
+            @Valid @RequestBody CreateOrderReq request,
+            // TODO: 추후 AuditorContext로 변경
+            @RequestHeader("X-Login-Id") String loginId,
+            @RequestHeader("X-User-Role") UserRole userRole
+        ) {
+
+        // Request → Command 변환
+        CreateOrderRes response = orderService.createOrder(request.toCommand(loginId));
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "주문이 생성되었습니다."));
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
@@ -4,14 +4,17 @@ import com.palja.common.annotation.RequiredRole;
 import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.vo.UserRole;
-import com.palja.order_service.application.dto.CreateOrderRes;
+import com.palja.order_service.application.dto.OrderCreateRes;
 import com.palja.order_service.application.service.OrderService;
 import com.palja.order_service.presentation.dto.request.CreateOrderReq;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/orders")
@@ -23,12 +26,12 @@ public class OrderController {
     // 주문 생성
     @PostMapping
     @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER})
-    public ResponseEntity<ApiResponse<CreateOrderRes>> createOrder(
+    public ResponseEntity<ApiResponse<OrderCreateRes>> createOrder(
             @Valid @RequestBody CreateOrderReq request
         ) {
 
         // Request → Command 변환
-        CreateOrderRes response = orderService.createOrder(request.toCommand(CurrentUser.getLoginId()));
+        OrderCreateRes response = orderService.createOrder(request.toCommand(CurrentUser.getLoginId()));
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
@@ -20,8 +20,8 @@ public class OrderController {
     private final OrderService orderService;
 
     // 주문 생성
-    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER})
     @PostMapping
+    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER})
     public ResponseEntity<ApiResponse<CreateOrderRes>> createOrder(
             @Valid @RequestBody CreateOrderReq request,
             // TODO: 추후 AuditorContext로 변경

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
@@ -1,4 +1,41 @@
 package com.palja.order_service.presentation.dto.request;
 
+import com.palja.order_service.application.command.CreateOrderCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.UUID;
+
+// 주문 생성 요청 DTO
+@Builder
 public class CreateOrderReq {
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private UUID productId;
+
+    @NotNull(message = "주문 수량은 필수입니다.")
+    @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
+    private int quantity;
+
+    private UUID timeDealId;
+
+    private UUID couponId;
+
+    @NotNull(message = "배송 정보는 필수입니다.")
+    @Valid
+    private DeliveryReq delivery;
+
+    // Request → Command 변환
+    public CreateOrderCommand toCommand(String loginId) {
+        return CreateOrderCommand.builder()
+                .loginId(loginId)
+                .productId(productId)
+                .quantity(quantity)
+                .timeDealId(timeDealId)
+                .couponId(couponId)
+                .delivery(delivery.toCommand())
+                .build();
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/DeliveryReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/DeliveryReq.java
@@ -1,0 +1,37 @@
+package com.palja.order_service.presentation.dto.request;
+
+import com.palja.order_service.application.command.DeliveryCommand;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+// 배송 정보 요청 DTO
+@Builder
+public class DeliveryReq {
+
+    @NotBlank(message = "수령인 이름은 필수입니다.")
+    @Size(max = 50, message = "수령인 이름은 50자를 초과할 수 없습니다.")
+    private String recipientName;
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Size(max = 255, message = "이메일은 255자를 초과할 수 없습니다.")
+    private String recipientEmail;
+
+    @NotBlank(message = "수령인 주소는 필수입니다.")
+    @Size(max = 200, message = "주소는 200자를 초과할 수 없습니다.")
+    private String recipientAddress;
+
+    @Size(max = 255, message = "배송 메시지는 255자를 초과할 수 없습니다.")
+    private String deliveryMessage;
+
+    // DeliveryRequest → DeliveryCommand 변환
+    public DeliveryCommand toCommand() {
+        return DeliveryCommand.builder()
+                .recipientName(recipientName)
+                .recipientEmail(recipientEmail)
+                .recipientAddress(recipientAddress)
+                .deliveryMessage(deliveryMessage)
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/response/OrderCreateRes.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/response/OrderCreateRes.java
@@ -1,4 +1,0 @@
-package com.palja.order_service.presentation.dto.response;
-
-public class OrderCreateRes {
-}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정
<br>

## ❗️ 관련 이슈 링크
Close #49 
<br>

## 📌 개요
- 주문 생성 API (`POST /api/v1/orders`)를 구현했습니다.  
- 주문 생성 시 **주문상품 및 배송정보가 함께 생성**되도록 구성했습니다.
<br>

## 🔁 변경 사항

### **Application 레이어**
- 주문 생성 응답 DTO 추가  
  - `CreateOrderRes`, `OrderItemRes`, `DeliveryRes`, `PricingRes`, `CouponSnapshotRes`
- 검증 및 금액 계산 로직을 `OrderValidator`, `OrderCalculator`로 분리하여 재사용성 강화
- 서비스 로직을 private 메서드로 분리

### **Domain 레이어**
- `Recipient`, `OrderAmount` 등 새로운 VO(Value Object) 추가
- `Order.create(...)` 내부에서 도메인 규칙 적용  
  - 주문자/상품/배송 기본 검증  
  - `OrderItem`, `OrderDelivery` 생성 및 연관관계 설정  
  - 상품 금액, 타임딜 할인, 쿠폰 할인, 배송비를 포함한 `OrderAmount` 계산
- 상태 전환 로직을 `transitionTo()` 기반으로 통일

### **Infrastructure 레이어**
- 외부 API 호출을 Adapter 패턴으로 추상화  
  (`ProductService`, `TimeDealService`, `CouponService`, `UserService`)
- 실제 연동 전까지 `DTO.dummy(...)`를 활용한 임시 구현 유지

### **Presentation 레이어**
- 주문 생성 API 추가 (`POST /api/v1/orders`)
  - **요청:** 상품, 쿠폰, 타임딜, 배송정보 기반으로 주문 생성  
  - **응답:** 주문/상품/배송/할인/쿠폰 스냅샷으로 구성된 CreateOrderRes 반환

<br>

## 📸 스크린샷

<details>
  <summary>주문 생성</summary>
<img width="1110" height="1280" alt="주문 생성" src="https://github.com/user-attachments/assets/c806083c-f603-4858-93a8-b3de87f85184" />

</details>

<br>

## 👀 기타 더 이야기해볼 점
- 현재는 외부 서비스(상품/재고/쿠폰/결제)에 대해 동기 호출 구조
→ 향후 Saga / Outbox 기반 비동기 구조로 개선 예정
- 외부 연동 API 개발 완료 시  
  → 통합 테스트 및 예외 처리 검증 추가 필요

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
