### PR TITLE
FEAT/ UserService 관리자 수정 API 구현

### DIFF
--- a/user-service/src/main/java/com/palja/user_service/application/command/UpdateManagerCommand.java
+++ b/user-service/src/main/java/com/palja/user_service/application/command/UpdateManagerCommand.java
@@ -1,0 +1,11 @@
+package com.palja.user_service.application.command;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateManagerCommand(
+
+	String address
+
+) {
+}

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateManagerDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateManagerDetailRes.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
-public class ReadManagerDetailRes {
+public class UpdateManagerDetailRes {
 
 	private Long userId;
 	private String loginId;
@@ -24,8 +24,8 @@ public class ReadManagerDetailRes {
 	private Instant updatedAt;
 	private String updatedBy;
 
-	public static ReadManagerDetailRes from(User user) {
-		return ReadManagerDetailRes.builder()
+	public static UpdateManagerDetailRes from(User user) {
+		return UpdateManagerDetailRes.builder()
 			.userId(user.getId())
 			.loginId(user.getLoginId())
 			.name(user.getName())

--- a/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
@@ -26,4 +26,6 @@ public interface ManagerService {
 
 	UpdateManagerDetailRes updateManagerByLoginId(String currentUserLoginId, String loginId, UpdateManagerCommand command);
 
+	UpdateManagerDetailRes updateMe(String currentUserLoginId, UpdateManagerCommand command);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
@@ -4,9 +4,11 @@ import org.springframework.data.domain.Pageable;
 
 import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.command.CreateManagerCommand;
+import com.palja.user_service.application.command.UpdateManagerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadManagerDetailRes;
 import com.palja.user_service.application.dto.response.ReadManagerSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateManagerDetailRes;
 
 public interface ManagerService {
 
@@ -21,5 +23,7 @@ public interface ManagerService {
 	ReadManagerDetailRes getManagerByUserId(String currentUserLoginId, Long userId);
 
 	ReadManagerDetailRes getMe(String currentUserLoginId);
+
+	UpdateManagerDetailRes updateManagerByLoginId(String currentUserLoginId, String loginId, UpdateManagerCommand command);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -10,9 +10,11 @@ import com.palja.common.exception.BusinessException;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateManagerCommand;
+import com.palja.user_service.application.command.UpdateManagerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadManagerDetailRes;
 import com.palja.user_service.application.dto.response.ReadManagerSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateManagerDetailRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.ManagerService;
 import com.palja.user_service.domain.entity.User;
@@ -79,6 +81,17 @@ public class ManagerServiceImpl implements ManagerService {
 	@Override
 	public ReadManagerDetailRes getMe(String currentUserLoginId) {
 		return ReadManagerDetailRes.from(getUserByLoginId(currentUserLoginId));
+	}
+
+	@Override
+	@Transactional
+	public UpdateManagerDetailRes updateManagerByLoginId(String currentUserLoginId, String loginId, UpdateManagerCommand command) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		User user = getUserByLoginId(loginId);
+		user.update(command.address());
+
+		return UpdateManagerDetailRes.from(user);
 	}
 
 	private User getUserByLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -94,6 +94,15 @@ public class ManagerServiceImpl implements ManagerService {
 		return UpdateManagerDetailRes.from(user);
 	}
 
+	@Override
+	@Transactional
+	public UpdateManagerDetailRes updateMe(String currentUserLoginId, UpdateManagerCommand command) {
+		User user = getUserByLoginId(currentUserLoginId);
+		user.update(command.address());
+
+		return UpdateManagerDetailRes.from(user);
+	}
+
 	private User getUserByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
@@ -64,6 +64,10 @@ public class User extends BaseEntity {
 		this.status = this.role == UserRole.COMPANY_USER ? UserStatus.PENDING : UserStatus.ACTIVE;
 	}
 
+	public void update(String address) {
+		this.address = address;
+	}
+
 	public void updateStatus(String status) {
 		UserStatus newStatus = validateAndGetStatus(status);
 		if (!this.status.canTransitionTo(newStatus)) {

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
@@ -28,4 +28,7 @@ public interface ManagerController {
 
 	ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateByLoginId(String loginId, UpdateManagerReq requestDto);
 
+	ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateMe(UpdateManagerReq requestDto);
+
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
@@ -8,7 +8,9 @@ import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadManagerDetailRes;
 import com.palja.user_service.application.dto.response.ReadManagerSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateManagerDetailRes;
 import com.palja.user_service.presentation.dto.request.CreateManagerReq;
+import com.palja.user_service.presentation.dto.request.UpdateManagerReq;
 
 public interface ManagerController {
 
@@ -23,5 +25,7 @@ public interface ManagerController {
 	ResponseEntity<ApiResponse<ReadManagerDetailRes>> getByUserId(Long userId);
 
 	ResponseEntity<ApiResponse<ReadManagerDetailRes>> getMe();
+
+	ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateByLoginId(String loginId, UpdateManagerReq requestDto);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
@@ -115,4 +115,16 @@ public class ManagerControllerImpl implements ManagerController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "관리자가 수정되었습니다."));
 	}
 
+	@Override
+	@RequiredRole({UserRole.MASTER, UserRole.MANAGER})
+	@PutMapping("/me")
+	public ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateMe(@Valid @RequestBody UpdateManagerReq requestDto) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		UpdateManagerCommand command = UpdateManagerReq.of(requestDto);
+		UpdateManagerDetailRes responseDto = managerService.updateMe(currentUserLoginId, command);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "관리자가 수정되었습니다."));
+	}
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,12 +18,15 @@ import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateManagerCommand;
+import com.palja.user_service.application.command.UpdateManagerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadManagerDetailRes;
 import com.palja.user_service.application.dto.response.ReadManagerSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateManagerDetailRes;
 import com.palja.user_service.application.service.ManagerService;
 import com.palja.user_service.presentation.controller.ManagerController;
 import com.palja.user_service.presentation.dto.request.CreateManagerReq;
+import com.palja.user_service.presentation.dto.request.UpdateManagerReq;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -86,6 +90,7 @@ public class ManagerControllerImpl implements ManagerController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "관리자를 조회했습니다."));
 	}
 
+	@Override
 	@RequiredRole({UserRole.MASTER, UserRole.MANAGER})
 	@GetMapping("/me")
 	public ResponseEntity<ApiResponse<ReadManagerDetailRes>> getMe() {
@@ -94,6 +99,20 @@ public class ManagerControllerImpl implements ManagerController {
 		ReadManagerDetailRes responseDto = managerService.getMe(currentUserLoginId);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "관리자를 조회했습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MASTER})
+	@PutMapping("/{loginId}")
+	public ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateByLoginId(
+		@PathVariable String loginId, @Valid @RequestBody UpdateManagerReq requestDto
+	) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		UpdateManagerCommand command = UpdateManagerReq.of(requestDto);
+		UpdateManagerDetailRes responseDto = managerService.updateManagerByLoginId(currentUserLoginId, loginId, command);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "관리자가 수정되었습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateManagerReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateManagerReq.java
@@ -1,0 +1,23 @@
+package com.palja.user_service.presentation.dto.request;
+
+import com.palja.user_service.application.command.UpdateManagerCommand;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateManagerReq {
+
+	@NotBlank(message = "주소를 입력해주세요.")
+	private String address;
+
+	public static UpdateManagerCommand of(UpdateManagerReq requestDto) {
+		return UpdateManagerCommand.builder()
+			.address(requestDto.getAddress())
+			.build();
+	}
+
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #95 

<br>

## 📌 개요
- 관리자 수정 API를 구현했습니다.

<br>

## 🔁 변경 사항
- loginId로 관리자를 수정하는 API를 구현했습니다.
- 관리자 본인을 수정하는 API를 구현했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
수정될 수 있는 필드가 딱히 없는 것 같아서 일단 주소만 받아서 수정하도록 했습니다.
나중에 이메일 인증을 도입해서 이메일을 변경하는 API를 따로 추가하겠습니다!

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
