### PR TITLE
FEAT/ UserService 관리자 삭제 API 구현

### DIFF
--- a/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
@@ -28,4 +28,6 @@ public interface ManagerService {
 
 	UpdateManagerDetailRes updateMe(String currentUserLoginId, UpdateManagerCommand command);
 
+	void deleteManagerByLoginId(String loginId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/ManagerService.java
@@ -12,7 +12,7 @@ import com.palja.user_service.application.dto.response.UpdateManagerDetailRes;
 
 public interface ManagerService {
 
-	CreateUserRes createManager(String currentUserLoginId, CreateManagerCommand command);
+	CreateUserRes createManager(CreateManagerCommand command);
 
 	PageResponse<ReadManagerSummaryRes> getAllManagers(
 		String currentUserLoginId, String loginId, String email, String name, Pageable pageable
@@ -24,7 +24,7 @@ public interface ManagerService {
 
 	ReadManagerDetailRes getMe(String currentUserLoginId);
 
-	UpdateManagerDetailRes updateManagerByLoginId(String currentUserLoginId, String loginId, UpdateManagerCommand command);
+	UpdateManagerDetailRes updateManagerByLoginId(String loginId, UpdateManagerCommand command);
 
 	UpdateManagerDetailRes updateMe(String currentUserLoginId, UpdateManagerCommand command);
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.palja.common.auditor.AuditorContext;
 import com.palja.common.exception.BusinessException;
+import com.palja.common.exception.CommonErrorCode;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateManagerCommand;
@@ -100,6 +101,14 @@ public class ManagerServiceImpl implements ManagerService {
 		return UpdateManagerDetailRes.from(user);
 	}
 
+	@Override
+	@Transactional
+	public void deleteManagerByLoginId(String loginId) {
+		User user = getUserByLoginId(loginId);
+		validateNotMaster(user);
+		user.softDelete();
+	}
+
 	private User getUserByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
@@ -133,6 +142,12 @@ public class ManagerServiceImpl implements ManagerService {
 	private void validateDuplicateEmail(String email) {
 		if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
 			throw new BusinessException(UserErrorCode.DUPLICATED_EMAIL);
+		}
+	}
+
+	private void validateNotMaster(User user) {
+		if (user.getRole().equals(UserRole.MASTER)) {
+			throw new BusinessException(CommonErrorCode.FORBIDDEN);
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -32,8 +32,7 @@ public class ManagerServiceImpl implements ManagerService {
 
 	@Override
 	@Transactional
-	public CreateUserRes createManager(String currentUserLoginId, CreateManagerCommand command) {
-		validateUserExistsByLoginId(currentUserLoginId);
+	public CreateUserRes createManager(CreateManagerCommand command) {
 		validateDuplicateLoginId(command.loginId());
 		validateDuplicateEmail(command.email());
 
@@ -85,9 +84,7 @@ public class ManagerServiceImpl implements ManagerService {
 
 	@Override
 	@Transactional
-	public UpdateManagerDetailRes updateManagerByLoginId(String currentUserLoginId, String loginId, UpdateManagerCommand command) {
-		validateUserExistsByLoginId(currentUserLoginId);
-
+	public UpdateManagerDetailRes updateManagerByLoginId(String loginId, UpdateManagerCommand command) {
 		User user = getUserByLoginId(loginId);
 		user.update(command.address());
 

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
@@ -28,7 +28,7 @@ public class User extends BaseEntity {
 	@Column(name = "user_id")
 	private Long id;
 
-	@Column(name = "login_id", length = 10, nullable = false, unique = true)
+	@Column(name = "login_id", length = 10, nullable = false)
 	private String loginId;
 
 	@Column(name = "password", nullable = false)
@@ -37,7 +37,7 @@ public class User extends BaseEntity {
 	@Column(name = "name", length = 10, nullable = false)
 	private String name;
 
-	@Column(name = "email", nullable = false, unique = true)
+	@Column(name = "email", nullable = false)
 	private String email;
 
 	@Column(name = "address", nullable = false)

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
@@ -2,6 +2,7 @@ package com.palja.user_service.presentation.controller;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
@@ -30,5 +31,6 @@ public interface ManagerController {
 
 	ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateMe(UpdateManagerReq requestDto);
 
+	ResponseEntity<ApiResponse<Void>> deleteByLoginId(String loginId);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
@@ -124,4 +124,13 @@ public class ManagerControllerImpl implements ManagerController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "관리자가 수정되었습니다."));
 	}
 
+	@Override
+	@RequiredRole({UserRole.MASTER})
+	@DeleteMapping("/{loginId}")
+	public ResponseEntity<ApiResponse<Void>> deleteByLoginId(@PathVariable String loginId) {
+		managerService.deleteManagerByLoginId(loginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("관리자가 삭제되었습니다."));
+	}
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/ManagerControllerImpl.java
@@ -3,6 +3,7 @@ package com.palja.user_service.presentation.controller.impl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,10 +43,8 @@ public class ManagerControllerImpl implements ManagerController {
 	@RequiredRole({UserRole.MASTER})
 	@PostMapping
 	public ResponseEntity<ApiResponse<CreateUserRes>> create(@Valid @RequestBody CreateManagerReq requestDto) {
-		String currentUserLoginId = CurrentUser.getLoginId();
-
 		CreateManagerCommand command = CreateManagerReq.of(requestDto);
-		CreateUserRes responseDto = managerService.createManager(currentUserLoginId, command);
+		CreateUserRes responseDto = managerService.createManager(command);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(responseDto, "관리자가 생성되었습니다."));
 	}
@@ -107,10 +106,8 @@ public class ManagerControllerImpl implements ManagerController {
 	public ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateByLoginId(
 		@PathVariable String loginId, @Valid @RequestBody UpdateManagerReq requestDto
 	) {
-		String currentUserLoginId = CurrentUser.getLoginId();
-
 		UpdateManagerCommand command = UpdateManagerReq.of(requestDto);
-		UpdateManagerDetailRes responseDto = managerService.updateManagerByLoginId(currentUserLoginId, loginId, command);
+		UpdateManagerDetailRes responseDto = managerService.updateManagerByLoginId(loginId, command);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "관리자가 수정되었습니다."));
 	}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #97

<br>

## 📌 개요
- 관리자 삭제 API를 구현했습니다.

<br>

## 🔁 변경 사항
- loginId로 Manager를 삭제하는 API를 구현했습니다. (Master만 사용 가능하며 Manager는 본인, 및 다른 Manager를 삭제할 수 없습니다.) (Master도 본인을 삭제할 수 없습니다.)
- Master 전용 API는 회원이 존재하는지 확인할 필요가 없기 때문에 검증하는 로직을 삭제했습니다. (Master는 삭제될 일이 없습니다.)

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
회원 삭제 시 다른 MSA 서비스에 그 회원에 관련된 정보들도 함께 삭제하는 로직은 아직 작성 안했고 일반 사용자, 업체 판매자 API 먼저 구현한 후에 추가할 예정입니다!

Master가 최상위 관리자여서 관리자 생성,조회,수정,삭제 API만 사용할 수 있도록 하고 다른 API는 사용할 수 없도록 하는거 어떨까요? 다른 API Master를 빼고 Manager에게만 권한을 주면 될 것 같습니다. 현재 Master 정보를 조회할 수 없게 해놓은 상태입니다!

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
