### PR TITLE
FEAT/ PaymentService 결제 로그 단건 조회 & 목록 조회 API 구현

### DIFF
--- a/payment-service/src/main/java/com/palja/payment_service/application/command/FindPaymentLogListByConditionCommand.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/command/FindPaymentLogListByConditionCommand.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 public record FindPaymentLogListByConditionCommand(
         UUID paymentId,
+        UUID orderId,
         String status,
         LocalDateTime startDate,
         LocalDateTime endDate

--- a/payment-service/src/main/java/com/palja/payment_service/application/command/FindPaymentLogListByConditionCommand.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/command/FindPaymentLogListByConditionCommand.java
@@ -1,0 +1,12 @@
+package com.palja.payment_service.application.command;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record FindPaymentLogListByConditionCommand(
+        UUID paymentId,
+        String status,
+        LocalDateTime startDate,
+        LocalDateTime endDate
+) {
+}

--- a/payment-service/src/main/java/com/palja/payment_service/application/dto/response/PaymentLogDetailRes.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/dto/response/PaymentLogDetailRes.java
@@ -1,0 +1,38 @@
+package com.palja.payment_service.application.dto.response;
+
+import com.palja.payment_service.domain.entity.PaymentLog;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class PaymentLogDetailRes {
+
+    private UUID paymentLogId;
+    private UUID paymentId;
+    private Long userId;
+    private BigDecimal amount;
+    private String status;
+    private String paymentKey;
+    private String pgResponseCode;
+    private String pgResponseMessage;
+    private LocalDateTime processedAt;
+
+    public static PaymentLogDetailRes from(PaymentLog log) {
+        return PaymentLogDetailRes.builder()
+                .paymentLogId(log.getId())
+                .paymentId(log.getPayment().getId())
+                .userId(log.getUserId())
+                .amount(log.getAmount())
+                .status(log.getStatus().name())
+                .paymentKey(log.getPaymentKey())
+                .pgResponseCode(log.getPgResponseCode())
+                .pgResponseMessage(log.getPgResponseMessage())
+                .processedAt(log.getProcessedAt())
+                .build();
+    }
+}

--- a/payment-service/src/main/java/com/palja/payment_service/application/dto/response/PaymentLogDetailRes.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/dto/response/PaymentLogDetailRes.java
@@ -14,6 +14,7 @@ public class PaymentLogDetailRes {
 
     private UUID paymentLogId;
     private UUID paymentId;
+    private UUID orderId;
     private Long userId;
     private BigDecimal amount;
     private String status;
@@ -26,6 +27,7 @@ public class PaymentLogDetailRes {
         return PaymentLogDetailRes.builder()
                 .paymentLogId(log.getId())
                 .paymentId(log.getPayment().getId())
+                .orderId(log.getOrderId())
                 .userId(log.getUserId())
                 .amount(log.getAmount())
                 .status(log.getStatus().name())

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/PaymentLogService.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/PaymentLogService.java
@@ -5,10 +5,11 @@ import com.palja.payment_service.application.dto.response.PaymentLogDetailRes;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface PaymentLogService {
-    PaymentLogDetailRes getLogByPaymentId(UUID paymentId);
+    List<PaymentLogDetailRes> getLogsByPaymentId(UUID paymentId);
 
     Page<PaymentLogDetailRes> searchLogs(FindPaymentLogListByConditionCommand command, PageRequest pageRequest);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/PaymentLogService.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/PaymentLogService.java
@@ -1,0 +1,14 @@
+package com.palja.payment_service.application.service;
+
+import com.palja.payment_service.application.command.FindPaymentLogListByConditionCommand;
+import com.palja.payment_service.application.dto.response.PaymentLogDetailRes;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.UUID;
+
+public interface PaymentLogService {
+    PaymentLogDetailRes getLogByPaymentId(UUID paymentId);
+
+    Page<PaymentLogDetailRes> searchLogs(FindPaymentLogListByConditionCommand command, PageRequest pageRequest);
+}

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImpl.java
@@ -51,6 +51,7 @@ public class PaymentLogServiceImpl implements PaymentLogService {
 
         Page<PaymentLog> logs = paymentLogRepository.findLogs(
                 command.paymentId(),
+                command.orderId(),
                 status,
                 command.startDate(),
                 command.endDate(),

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -24,10 +25,14 @@ public class PaymentLogServiceImpl implements PaymentLogService {
 
     @Override
     @Transactional(readOnly = true)
-    public PaymentLogDetailRes getLogByPaymentId(UUID paymentId) {
-        PaymentLog log = paymentLogRepository.findByPaymentId(paymentId)
-                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_LOG_NOT_FOUND));
-        return PaymentLogDetailRes.from(log);
+    public List<PaymentLogDetailRes> getLogsByPaymentId(UUID paymentId) {
+        List<PaymentLog> logs = paymentLogRepository.findByPaymentId(paymentId);
+        if (logs.isEmpty()) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_LOG_NOT_FOUND);
+        }
+        return logs.stream()
+                .map(PaymentLogDetailRes::from)
+                .toList();
     }
 
     @Override

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImpl.java
@@ -1,0 +1,57 @@
+package com.palja.payment_service.application.service.impl;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.payment_service.application.command.FindPaymentLogListByConditionCommand;
+import com.palja.payment_service.application.dto.response.PaymentLogDetailRes;
+import com.palja.payment_service.application.service.PaymentLogService;
+import com.palja.payment_service.domain.entity.PaymentLog;
+import com.palja.payment_service.domain.repository.PaymentLogRepository;
+import com.palja.payment_service.domain.vo.PaymentStatus;
+import com.palja.payment_service.exception.PaymentErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentLogServiceImpl implements PaymentLogService {
+
+    private final PaymentLogRepository paymentLogRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaymentLogDetailRes getLogByPaymentId(UUID paymentId) {
+        PaymentLog log = paymentLogRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_LOG_NOT_FOUND));
+        return PaymentLogDetailRes.from(log);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PaymentLogDetailRes> searchLogs(FindPaymentLogListByConditionCommand command,
+                                                PageRequest pageRequest) {
+
+        PaymentStatus status = null;
+        if (command.status() != null) {
+            try {
+                status = PaymentStatus.valueOf(command.status());
+            } catch (IllegalArgumentException e) {
+                throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            }
+        }
+
+        Page<PaymentLog> logs = paymentLogRepository.findLogs(
+                command.paymentId(),
+                status,
+                command.startDate(),
+                command.endDate(),
+                pageRequest
+        );
+
+        return logs.map(PaymentLogDetailRes::from);
+    }
+}

--- a/payment-service/src/main/java/com/palja/payment_service/domain/entity/PaymentLog.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/entity/PaymentLog.java
@@ -28,6 +28,9 @@ public class PaymentLog extends BaseEntity {
     @JoinColumn(name = "payment_id", nullable = false)
     private Payment payment;
 
+    @Column(name = "order_id", nullable = false)
+    private UUID orderId;
+
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
@@ -51,11 +54,12 @@ public class PaymentLog extends BaseEntity {
     private LocalDateTime processedAt;
 
     @Builder
-    public PaymentLog(Payment payment, Long userId, BigDecimal amount,
+    public PaymentLog(Payment payment, UUID orderId, Long userId, BigDecimal amount,
                       PaymentStatus status, String paymentKey,
                       String pgResponseCode, String pgResponseMessage,
                       LocalDateTime processedAt) {
         this.payment = payment;
+        this.orderId = orderId;
         this.userId = userId;
         this.amount = amount;
         this.status = status;
@@ -68,6 +72,7 @@ public class PaymentLog extends BaseEntity {
     public static PaymentLog createRequestLog(Payment payment) {
         return PaymentLog.builder()
                 .payment(payment)
+                .orderId(payment.getOrderId())
                 .userId(payment.getUserId())
                 .amount(payment.getAmount())
                 .status(payment.getStatus())
@@ -84,6 +89,7 @@ public class PaymentLog extends BaseEntity {
                                              String pgResponseMessage) {
         return PaymentLog.builder()
                 .payment(payment)
+                .orderId(payment.getOrderId())
                 .userId(payment.getUserId())
                 .amount(payment.getAmount())
                 .status(payment.getStatus())

--- a/payment-service/src/main/java/com/palja/payment_service/domain/repository/PaymentLogRepository.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/repository/PaymentLogRepository.java
@@ -6,13 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface PaymentLogRepository {
     PaymentLog save(PaymentLog paymentLog);
 
-    Optional<PaymentLog> findByPaymentId(UUID paymentId);
+    List<PaymentLog> findByPaymentId(UUID paymentId);
 
-    Page<PaymentLog> findLogs(UUID paymnetId, PaymentStatus status, LocalDateTime startDate, LocalDateTime endDate, PageRequest pageRequest);
+    Page<PaymentLog> findLogs(UUID paymentId, PaymentStatus status, LocalDateTime startDate, LocalDateTime endDate, PageRequest pageRequest);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/domain/repository/PaymentLogRepository.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/repository/PaymentLogRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface PaymentLogRepository {
@@ -15,5 +14,5 @@ public interface PaymentLogRepository {
 
     List<PaymentLog> findByPaymentId(UUID paymentId);
 
-    Page<PaymentLog> findLogs(UUID paymentId, PaymentStatus status, LocalDateTime startDate, LocalDateTime endDate, PageRequest pageRequest);
+    Page<PaymentLog> findLogs(UUID paymentId, UUID orderId, PaymentStatus status, LocalDateTime startDate, LocalDateTime endDate, PageRequest pageRequest);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/domain/repository/PaymentLogRepository.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/repository/PaymentLogRepository.java
@@ -1,7 +1,18 @@
 package com.palja.payment_service.domain.repository;
 
 import com.palja.payment_service.domain.entity.PaymentLog;
+import com.palja.payment_service.domain.vo.PaymentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface PaymentLogRepository {
     PaymentLog save(PaymentLog paymentLog);
+
+    Optional<PaymentLog> findByPaymentId(UUID paymentId);
+
+    Page<PaymentLog> findLogs(UUID paymnetId, PaymentStatus status, LocalDateTime startDate, LocalDateTime endDate, PageRequest pageRequest);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/exception/PaymentErrorCode.java
+++ b/payment-service/src/main/java/com/palja/payment_service/exception/PaymentErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PaymentErrorCode implements ErrorCode {
 
+    PAYMENT_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 로그를 찾을 수 없습니다."),
     PAYMENT_EXCEED_AMOUNT(HttpStatus.BAD_REQUEST, "취소 금액이 결제 금액을 초과할 수 없습니다."),
     PAYMENT_NOT_PARTIAL_REFUND(HttpStatus.BAD_REQUEST, "부분 환불이 불가합니다,"),
     PAYMENT_NOT_APPROVED(HttpStatus.BAD_REQUEST,"승인된 결제만 취소할 수 있습니다."),

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogJpaRepository.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogJpaRepository.java
@@ -3,9 +3,10 @@ package com.palja.payment_service.infrastructure.repository;
 import com.palja.payment_service.domain.entity.PaymentLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface PaymentLogJpaRepository extends JpaRepository<PaymentLog, UUID> {
-    Optional<PaymentLog> findByPayment_InOrderByProcessedAtDesc(UUID paymentId);
+    List<PaymentLog> findAllByPayment_IdOrderByProcessedAtDesc(UUID paymentId);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogJpaRepository.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogJpaRepository.java
@@ -3,7 +3,9 @@ package com.palja.payment_service.infrastructure.repository;
 import com.palja.payment_service.domain.entity.PaymentLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface PaymentLogJpaRepository extends JpaRepository<PaymentLog, UUID> {
+    Optional<PaymentLog> findByPayment_InOrderByProcessedAtDesc(UUID paymentId);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogQueryDSLRepositoryImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogQueryDSLRepositoryImpl.java
@@ -23,6 +23,7 @@ public class PaymentLogQueryDSLRepositoryImpl {
 
     public Page<PaymentLog> findLogs(
             UUID paymentId,
+            UUID orderId,
             PaymentStatus status,
             LocalDateTime startDate,
             LocalDateTime endDate,
@@ -33,6 +34,9 @@ public class PaymentLogQueryDSLRepositoryImpl {
 
         if (paymentId != null) {
             builder.and(paymentLog.payment.id.eq(paymentId));
+        }
+        if (orderId != null) {
+            builder.and(paymentLog.payment.orderId.eq(orderId));
         }
         if (status != null) {
             builder.and(paymentLog.status.eq(status));

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogQueryDSLRepositoryImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogQueryDSLRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.palja.payment_service.infrastructure.repository;
+
+import com.palja.payment_service.domain.entity.PaymentLog;
+import com.palja.payment_service.domain.entity.QPaymentLog;
+import com.palja.payment_service.domain.vo.PaymentStatus;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.QueryResults;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentLogQueryDSLRepositoryImpl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<PaymentLog> findLogs(
+            UUID paymentId,
+            PaymentStatus status,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            PageRequest pageRequest
+    ){
+        QPaymentLog paymentLog = QPaymentLog.paymentLog;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (paymentId != null) {
+            builder.and(paymentLog.payment.id.eq(paymentId));
+        }
+        if (status != null) {
+            builder.and(paymentLog.status.eq(status));
+        }
+        if (startDate != null) {
+            builder.and(paymentLog.processedAt.goe(startDate));
+        }
+        if (endDate != null) {
+            builder.and(paymentLog.processedAt.loe(endDate));
+        }
+
+        QueryResults<PaymentLog> results = queryFactory
+                .selectFrom(paymentLog)
+                .where(builder)
+                .offset(pageRequest.getOffset())
+                .limit(pageRequest.getPageSize())
+                .fetchResults();
+
+        return new PageImpl<>(results.getResults(), pageRequest, results.getTotal());
+    }
+}

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogQueryDSLRepositoryImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogQueryDSLRepositoryImpl.java
@@ -36,7 +36,7 @@ public class PaymentLogQueryDSLRepositoryImpl {
             builder.and(paymentLog.payment.id.eq(paymentId));
         }
         if (orderId != null) {
-            builder.and(paymentLog.payment.orderId.eq(orderId));
+            builder.and(paymentLog.orderId.eq(orderId));
         }
         if (status != null) {
             builder.and(paymentLog.status.eq(status));

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogRepositoryImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,8 +26,8 @@ public class PaymentLogRepositoryImpl implements PaymentLogRepository {
     }
 
     @Override
-    public Optional<PaymentLog> findByPaymentId(UUID paymentId) {
-        return paymentLogJpaRepository.findByPayment_InOrderByProcessedAtDesc(paymentId);
+    public List<PaymentLog> findByPaymentId(UUID paymentId) {
+        return paymentLogJpaRepository.findAllByPayment_IdOrderByProcessedAtDesc(paymentId);
     }
 
     @Override

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogRepositoryImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogRepositoryImpl.java
@@ -33,13 +33,14 @@ public class PaymentLogRepositoryImpl implements PaymentLogRepository {
     @Override
     public Page<PaymentLog> findLogs(
             UUID paymentId,
+            UUID orderId,
             PaymentStatus status,
             LocalDateTime startDate,
             LocalDateTime endDate,
             PageRequest pageRequest
     ){
         return paymentLogQueryDSLRepository.findLogs(
-                paymentId, status, startDate, endDate, pageRequest
+                paymentId, orderId, status, startDate, endDate, pageRequest
         );
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogRepositoryImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentLogRepositoryImpl.java
@@ -2,17 +2,43 @@ package com.palja.payment_service.infrastructure.repository;
 
 import com.palja.payment_service.domain.entity.PaymentLog;
 import com.palja.payment_service.domain.repository.PaymentLogRepository;
+import com.palja.payment_service.domain.vo.PaymentStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
 public class PaymentLogRepositoryImpl implements PaymentLogRepository {
 
     private final PaymentLogJpaRepository paymentLogJpaRepository;
+    private final PaymentLogQueryDSLRepositoryImpl paymentLogQueryDSLRepository;
 
     @Override
     public PaymentLog save(PaymentLog paymentLog) {
         return paymentLogJpaRepository.save(paymentLog);
+    }
+
+    @Override
+    public Optional<PaymentLog> findByPaymentId(UUID paymentId) {
+        return paymentLogJpaRepository.findByPayment_InOrderByProcessedAtDesc(paymentId);
+    }
+
+    @Override
+    public Page<PaymentLog> findLogs(
+            UUID paymentId,
+            PaymentStatus status,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            PageRequest pageRequest
+    ){
+        return paymentLogQueryDSLRepository.findLogs(
+                paymentId, status, startDate, endDate, pageRequest
+        );
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
@@ -1,0 +1,59 @@
+package com.palja.payment_service.presentation.controller;
+
+import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
+import com.palja.payment_service.application.command.FindPaymentLogListByConditionCommand;
+import com.palja.payment_service.application.dto.response.PaymentLogDetailRes;
+import com.palja.payment_service.application.service.PaymentLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PaymentLogController {
+
+    private final PaymentLogService paymentLogService;
+
+    @GetMapping("/payments/{paymentId}/logs")
+    public ResponseEntity<ApiResponse<PaymentLogDetailRes>> getPaymentLog(
+            @PathVariable UUID paymentId
+    ){
+        PaymentLogDetailRes detail = paymentLogService.getLogByPaymentId(paymentId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(detail, "결제 로그 단건 조회에 성공했습니다."));
+    }
+
+    @GetMapping("/payment-logs")
+    public ResponseEntity<ApiResponse<PageResponse<PaymentLogDetailRes>>> getPaymentLogs(
+            @RequestParam(required = false) UUID paymentId,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime startDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endDate,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        FindPaymentLogListByConditionCommand command = new FindPaymentLogListByConditionCommand(
+                paymentId,
+                status,
+                startDate,
+                endDate
+        );
+
+        PageRequest pageRequest = PageRequest.of(page, size);
+        var pageResult = paymentLogService.searchLogs(command, pageRequest);
+
+        PageResponse<PaymentLogDetailRes> detail = PageResponse.from(pageResult);
+
+        return ResponseEntity
+                .ok(ApiResponse.success(detail, "결제 로그 목록 조회에 성공했습니다."));
+    }
+}

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -23,13 +24,13 @@ public class PaymentLogController {
     private final PaymentLogService paymentLogService;
 
     @GetMapping("/payments/{paymentId}/logs")
-    public ResponseEntity<ApiResponse<PaymentLogDetailRes>> getPaymentLog(
+    public ResponseEntity<ApiResponse<List<PaymentLogDetailRes>>> getPaymentLogsByPaymentId(
             @PathVariable UUID paymentId
-    ){
-        PaymentLogDetailRes detail = paymentLogService.getLogByPaymentId(paymentId);
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(ApiResponse.success(detail, "결제 로그 단건 조회에 성공했습니다."));
+    ) {
+        List<PaymentLogDetailRes> res = paymentLogService.getLogsByPaymentId(paymentId);
+        return ResponseEntity.ok(
+                ApiResponse.success(res, "결제 로그 단건 조회에 성공했습니다.")
+        );
     }
 
     @GetMapping("/payment-logs")

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
@@ -28,7 +28,7 @@ public class PaymentLogController {
     ) {
         List<PaymentLogDetailRes> res = paymentLogService.getLogsByPaymentId(paymentId);
         return ResponseEntity.ok(
-                ApiResponse.success(res, "결제 로그 단건 조회에 성공했습니다.")
+                ApiResponse.success(res, "PaymentId에 해당되는 결제 로그 목록 조회에 성공했습니다.")
         );
     }
 
@@ -56,6 +56,6 @@ public class PaymentLogController {
         PageResponse<PaymentLogDetailRes> detail = PageResponse.from(pageResult);
 
         return ResponseEntity
-                .ok(ApiResponse.success(detail, "결제 로그 목록 조회에 성공했습니다."));
+                .ok(ApiResponse.success(detail, "검색 결과에 따른 결제 로그 목록 조회에 성공했습니다."));
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
@@ -8,7 +8,6 @@ import com.palja.payment_service.application.service.PaymentLogService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,6 +35,7 @@ public class PaymentLogController {
     @GetMapping("/payment-logs")
     public ResponseEntity<ApiResponse<PageResponse<PaymentLogDetailRes>>> getPaymentLogs(
             @RequestParam(required = false) UUID paymentId,
+            @RequestParam(required = false) UUID orderId,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime startDate,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endDate,
@@ -44,6 +44,7 @@ public class PaymentLogController {
     ){
         FindPaymentLogListByConditionCommand command = new FindPaymentLogListByConditionCommand(
                 paymentId,
+                orderId,
                 status,
                 startDate,
                 endDate

--- a/payment-service/src/test/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImplTest.java
+++ b/payment-service/src/test/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImplTest.java
@@ -1,0 +1,145 @@
+package com.palja.payment_service.application.service.impl;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.payment_service.application.command.FindPaymentLogListByConditionCommand;
+import com.palja.payment_service.application.dto.response.PaymentLogDetailRes;
+import com.palja.payment_service.domain.entity.Payment;
+import com.palja.payment_service.domain.entity.PaymentLog;
+import com.palja.payment_service.domain.repository.PaymentLogRepository;
+import com.palja.payment_service.domain.vo.PaymentMethod;
+import com.palja.payment_service.domain.vo.PaymentStatus;
+import com.palja.payment_service.exception.PaymentErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentLogServiceImplTest {
+
+    @Mock
+    private PaymentLogRepository paymentLogRepository;
+
+    @InjectMocks
+    private PaymentLogServiceImpl paymentLogService;
+
+    private PaymentLog createLog(UUID paymentId, PaymentStatus status) {
+        Payment payment = Payment.create(
+                UUID.randomUUID(),
+                1L,
+                new BigDecimal("10000"),
+                "KRW",
+                PaymentMethod.CARD,
+                "paymentKey123"
+        );
+
+        ReflectionTestUtils.setField(payment, "id", paymentId);
+
+        return PaymentLog.createResultLog(
+                payment,
+                "paymentKey123",
+                "SUCCESS",
+                "성공"
+        );
+    }
+
+    @Test
+    @DisplayName("paymentId 기준 전체 로그 반환 성공")
+    void getLogsByPaymentId_success() {
+        UUID paymentId = UUID.randomUUID();
+        PaymentLog log1 = createLog(paymentId, PaymentStatus.APPROVED);
+        PaymentLog log2 = createLog(paymentId, PaymentStatus.FAILED);
+
+        given(paymentLogRepository.findByPaymentId(paymentId))
+                .willReturn(List.of(log1, log2));
+
+        List<PaymentLogDetailRes> result = paymentLogService.getLogsByPaymentId(paymentId);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getPaymentId()).isEqualTo(paymentId);
+    }
+
+    @Test
+    @DisplayName("해당 paymentId 로그가 없다면 결제 로그 단건 조회 실패")
+    void getLogsByPaymentId_failure_notFound() {
+        UUID paymentId = UUID.randomUUID();
+
+        given(paymentLogRepository.findByPaymentId(paymentId))
+                .willReturn(List.of());
+
+        assertThatThrownBy(() -> paymentLogService.getLogsByPaymentId(paymentId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", PaymentErrorCode.PAYMENT_LOG_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("검색 조건에 맞는 결제 로그 목록 조회 성공")
+    void searchLogs_success() {
+        UUID paymentId = UUID.randomUUID();
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        LocalDateTime startDate = LocalDateTime.now().minusDays(1);
+        LocalDateTime endDate = LocalDateTime.now();
+
+        PaymentLog log1 = createLog(paymentId, PaymentStatus.APPROVED);
+        PaymentLog log2 = createLog(paymentId, PaymentStatus.FAILED);
+
+        Page<PaymentLog> page = new PageImpl<>(List.of(log1, log2), pageRequest, 2);
+
+        given(paymentLogRepository.findLogs(
+                eq(paymentId),
+                eq(PaymentStatus.APPROVED),
+                eq(startDate),
+                eq(endDate),
+                eq(pageRequest)
+        )).willReturn(page);
+
+        FindPaymentLogListByConditionCommand command =
+                new FindPaymentLogListByConditionCommand(
+                        paymentId,
+                        "APPROVED",
+                        startDate,
+                        endDate
+                );
+
+        Page<PaymentLogDetailRes> result = paymentLogService.searchLogs(command, pageRequest);
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getPaymentId()).isEqualTo(paymentId);
+    }
+
+    @Test
+    @DisplayName("검색 조건에 맞지 않으면 결제 로그 목록 조회 실패")
+    void searchLogs_failure_invalidStatus() {
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        FindPaymentLogListByConditionCommand command =
+                new FindPaymentLogListByConditionCommand(
+                        null,
+                        "NONE",
+                        null,
+                        null
+                );
+
+        assertThatThrownBy(() -> paymentLogService.searchLogs(command, pageRequest))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", PaymentErrorCode.INVALID_PAYMENT_STATUS);
+    }
+}

--- a/payment-service/src/test/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImplTest.java
+++ b/payment-service/src/test/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImplTest.java
@@ -104,6 +104,7 @@ class PaymentLogServiceImplTest {
 
         given(paymentLogRepository.findLogs(
                 eq(paymentId),
+                eq((UUID) null),
                 eq(PaymentStatus.APPROVED),
                 eq(startDate),
                 eq(endDate),
@@ -113,6 +114,7 @@ class PaymentLogServiceImplTest {
         FindPaymentLogListByConditionCommand command =
                 new FindPaymentLogListByConditionCommand(
                         paymentId,
+                        null,
                         "APPROVED",
                         startDate,
                         endDate
@@ -132,6 +134,7 @@ class PaymentLogServiceImplTest {
 
         FindPaymentLogListByConditionCommand command =
                 new FindPaymentLogListByConditionCommand(
+                        null,
                         null,
                         "NONE",
                         null,


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #92 

<br>

## 📌 개요
### 1. 도메인 계층
- FindPaymentLogListByConditionCommand에 paymentId, orderId, status, startDate, endDate를 추가해 검색 command 객체 생성

### 2. 애플리케이션 계층
- PaymentLogServiceImpl에 paymentId를 통해 결제 로그를 조회합니다. (PENDING상태와 그 이후 결제 관련 로그까지 총 2건이 보이도록)
- searchLogs를 통해 검색 조건에 맞춰 결제 로그를 조회합니다.

### 3. 인프라 계층
- PaymentLogRepository에서 결제 로그를 조회하기 위한 메서드 추가 (findByPaymentId, findLogs)
- PaymentLogQueryDSLRepositoryImpl에서 QueryDSL을 사용해 조건에 맞는 결제 로그 조회

### 4. 프레젠테이션 계층
- 결제 로그 단건 조회 API (/api/v1/payments/{paymentId}/logs)
- 결제 로그 목록 조회 API (/api/v1/paymet-logs)

### 5. 테스트
- 결제 ID에 해당하는 결제 로그 목록이 제대로 반환되는지 성공/실패 테스트
- 검색 조건에 맞는 결제 로그 목록이 제대로 반환되는지 성공/실패 테스트

<br>

## 🔁 변경 사항
결제 로그 컬럼에 orderId도 저장되도록 추가했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>결제 로그 단건 조회 성공</summary>
  <img width="1492" height="1062" alt="image" src="https://github.com/user-attachments/assets/3cb932f7-eeb3-44d6-84ed-94d117e314a7" />
</details>

<details>
  <summary>결제 로그 목록 조회 성공(주문ID로 검색)</summary>
  <img width="1476" height="1056" alt="image" src="https://github.com/user-attachments/assets/eb3f814d-5a0c-4030-8d7d-a0069347be8d" />
</details>

<details>
  <summary>결제 로그 목록 조회 성공(시작날짜)</summary>
  <img width="1503" height="1072" alt="image" src="https://github.com/user-attachments/assets/2ddc3a3d-dcdb-48ec-b342-996348392972" />
</details>

<br>

## 👀 기타 더 이야기해볼 점
검색 조건 없이도 결제 로그 목록 조회 가능합니다.

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
