### PR TITLE
FEAT/CouponService 쿠폰 발급 기능 구현

### DIFF
--- a/coupon-service/src/main/java/com/palja/coupon_service/application/command/CreateCouponCommand.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/command/CreateCouponCommand.java
@@ -1,6 +1,5 @@
 package com.palja.coupon_service.application.command;
 
-import com.palja.coupon_service.domain.vo.DiscountType;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -15,6 +14,7 @@ public record CreateCouponCommand(
         Integer maxDiscountAmount,
         Integer minOrderAmount,
         LocalDateTime issueStartAt,
-        LocalDateTime issueEndAt
+        LocalDateTime issueEndAt,
+        Integer usageDays
 ) {
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/command/IssueCouponCommand.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/command/IssueCouponCommand.java
@@ -1,0 +1,9 @@
+package com.palja.coupon_service.application.command;
+
+import java.util.UUID;
+
+public record IssueCouponCommand(
+        UUID couponId,
+        String userId
+) {
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/command/UpdateCouponCommand.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/command/UpdateCouponCommand.java
@@ -14,6 +14,7 @@ public record UpdateCouponCommand(
         Integer maxDiscountAmount,
         Integer minOrderAmount,
         LocalDateTime issueStartAt,
-        LocalDateTime issueEndAt
+        LocalDateTime issueEndAt,
+        Integer usageDays
 ) {
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponDetailRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponDetailRes.java
@@ -24,6 +24,7 @@ public class CouponDetailRes {
     private Integer minOrderAmount;
     private LocalDateTime issueStartAt;
     private LocalDateTime issueEndAt;
+    private Integer usageDays;
     private CouponStatus status;
     private Instant createdAt;
     private String createdBy;
@@ -43,6 +44,7 @@ public class CouponDetailRes {
                 .minOrderAmount(coupon.getAmountPolicy().getMinOrderAmount())
                 .issueStartAt(coupon.getIssuePeriod().getIssueStartAt())
                 .issueEndAt(coupon.getIssuePeriod().getIssueEndAt())
+                .usageDays(coupon.getUsageDays())
                 .status(coupon.getStatus())
                 .createdAt(coupon.getCreatedAt())
                 .createdBy(coupon.getCreatedBy())

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponRes.java
@@ -23,6 +23,7 @@ public class CouponRes {
     private Integer minOrderAmount;
     private LocalDateTime issueStartAt;
     private LocalDateTime issueEndAt;
+    private Integer usageDays;
     private CouponStatus status;
 
     public static CouponRes from(Coupon coupon) {
@@ -37,6 +38,7 @@ public class CouponRes {
                 .minOrderAmount(coupon.getAmountPolicy().getMinOrderAmount())
                 .issueStartAt(coupon.getIssuePeriod().getIssueStartAt())
                 .issueEndAt(coupon.getIssuePeriod().getIssueEndAt())
+                .usageDays(coupon.getUsageDays())
                 .status(coupon.getStatus())
                 .build();
     }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponUserRes.java
@@ -1,0 +1,29 @@
+package com.palja.coupon_service.application.dto;
+
+import com.palja.coupon_service.domain.entity.CouponUser;
+import com.palja.coupon_service.domain.vo.CouponUserStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CouponUserRes {
+    private UUID couponUserId;
+    private UUID couponId;
+    private String userId;
+    private LocalDateTime expireAt;
+    private CouponUserStatus status;
+
+    public static CouponUserRes from(CouponUser couponUser) {
+        return CouponUserRes.builder()
+                .couponUserId(couponUser.getId())
+                .couponId(couponUser.getCouponId())
+                .userId(couponUser.getUserId())
+                .expireAt(couponUser.getExpireAt())
+                .status(couponUser.getStatus())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
@@ -1,0 +1,8 @@
+package com.palja.coupon_service.application.service;
+
+import com.palja.coupon_service.application.command.IssueCouponCommand;
+import com.palja.coupon_service.application.dto.CouponUserRes;
+
+public interface CouponService {
+    CouponUserRes issueCoupon(IssueCouponCommand command);
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
@@ -40,7 +40,8 @@ public class CouponManagerServiceImpl implements CouponManagerService {
                 DiscountPolicy.of(DiscountType.valueOf(command.discountType().toUpperCase()), command.discountValue()),
                 command.totalQuantity(),
                 AmountPolicy.of(command.maxDiscountAmount(), command.minOrderAmount()),
-                IssuePeriod.of(command.issueStartAt(), command.issueEndAt())
+                IssuePeriod.of(command.issueStartAt(), command.issueEndAt()),
+                command.usageDays()
         );
 
         Coupon savedCoupon = couponRepository.save(coupon);
@@ -57,7 +58,8 @@ public class CouponManagerServiceImpl implements CouponManagerService {
         Coupon coupon = couponRepository.findByIdAndDeletedAtIsNull(command.couponId())
                 .orElseThrow(() -> new BusinessException(CouponErrorCode.COUPON_NOT_FOUND));
 
-        validateCouponNameDuplicate(command.couponName());
+        if (command.couponName() != null && !coupon.getName().equals(command.couponName()))
+            validateCouponNameDuplicate(command.couponName());
 
         coupon.update(
                 command.couponName(),
@@ -66,7 +68,8 @@ public class CouponManagerServiceImpl implements CouponManagerService {
                 command.maxDiscountAmount(),
                 command.minOrderAmount(),
                 command.issueStartAt(),
-                command.issueEndAt()
+                command.issueEndAt(),
+                command.usageDays()
         );
 
         log.info("쿠폰 수정 완료 - couponId={}", command.couponId());

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
@@ -1,0 +1,64 @@
+package com.palja.coupon_service.application.service.impl;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.coupon_service.application.command.IssueCouponCommand;
+import com.palja.coupon_service.application.dto.CouponUserRes;
+import com.palja.coupon_service.application.service.CouponService;
+import com.palja.coupon_service.domain.entity.Coupon;
+import com.palja.coupon_service.domain.entity.CouponUser;
+import com.palja.coupon_service.domain.repository.CouponRepository;
+import com.palja.coupon_service.domain.repository.CouponUserRepository;
+import com.palja.coupon_service.exception.CouponErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponServiceImpl implements CouponService {
+
+    private final CouponRepository couponRepository;
+    private final CouponUserRepository couponUserRepository;
+
+    @Override
+    @Transactional
+    public CouponUserRes issueCoupon(IssueCouponCommand command) {
+        log.info("쿠폰 발급 시작 userId={} couponId={}", command.userId(), command.couponId());
+
+        Coupon coupon = couponRepository.findByIdAndDeletedAtIsNull(command.couponId())
+                .orElseThrow(() -> new BusinessException(CouponErrorCode.COUPON_NOT_FOUND));
+
+        validateCouponIssue(coupon, command.userId());
+
+        coupon.increaseIssuedQuantity();
+
+        CouponUser couponUser = CouponUser.issue(coupon.getId(), command.userId(), calculateExpireAt(coupon));
+
+        CouponUser issuedCoupon = couponUserRepository.save(couponUser);
+
+        log.info("쿠폰 발급 성공 issuedCouponID={}", issuedCoupon.getCouponId());
+        return CouponUserRes.from(couponUser);
+    }
+
+    // 쿠폰 사용 만료일 계산
+    private LocalDateTime calculateExpireAt(Coupon coupon) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return now.plusDays(coupon.getUsageDays());
+    }
+
+    // 쿠폰 발급 검증
+    private void validateCouponIssue(Coupon coupon, String userId) {
+
+        coupon.validateIssuable();
+
+        coupon.validateIssuePeriod();
+
+        if (couponUserRepository.existsByCouponIdAndUserId(coupon.getId(), userId))
+            throw new BusinessException(CouponErrorCode.DUPLICATE_COUPON_ISSUE);
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
@@ -58,7 +58,7 @@ public class CouponServiceImpl implements CouponService {
 
         coupon.validateIssuePeriod();
 
-        if (couponUserRepository.existsByCouponIdAndUserId(coupon.getId(), userId))
+        if (couponUserRepository.existsByCouponIdAndUserIdAndDeletedAtIsNull(coupon.getId(), userId))
             throw new BusinessException(CouponErrorCode.DUPLICATE_COUPON_ISSUE);
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/entity/Coupon.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/entity/Coupon.java
@@ -41,6 +41,9 @@ public class Coupon extends BaseEntity {
     @Embedded
     private IssuePeriod issuePeriod; // 발급 시작일, 종료일
 
+    @Column(nullable = false)
+    private Integer usageDays; // 사용 기간 (발행일로부터 N일)
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private CouponStatus status;
@@ -51,9 +54,10 @@ public class Coupon extends BaseEntity {
             DiscountPolicy discountPolicy,
             Integer totalQuantity,
             AmountPolicy amountPolicy,
-            IssuePeriod issuePeriod
+            IssuePeriod issuePeriod,
+            Integer usageDays
     ) {
-        validateRequiredFields(name);
+        validateRequiredFields(name, usageDays);
         validateQuantity(totalQuantity);
 
         return Coupon.builder()
@@ -63,45 +67,57 @@ public class Coupon extends BaseEntity {
                 .totalQuantity(totalQuantity)
                 .amountPolicy(amountPolicy)
                 .issuePeriod(issuePeriod)
+                .usageDays(usageDays)
                 .status(CouponStatus.ACTIVE)
                 .build();
     }
 
     public void update(
-            String name,
-            String description,
+            String newName,
+            String newDescription,
             Integer newTotalQuantity,
-            Integer maxDiscountAmount,
-            Integer minOrderAmount,
-            LocalDateTime issueStartAt,
-            LocalDateTime issueEndAt
+            Integer newMaxDiscountAmount,
+            Integer newMinOrderAmount,
+            LocalDateTime newIssueStartAt,
+            LocalDateTime newIssueEndAt,
+            Integer newUsageDays
     ) {
         validateModifiable();
 
-        if (name != null) {
+        if (newName != null) {
             if (hasIssued())
                 throw new BusinessException(CouponErrorCode.CANNOT_MODIFY_ISSUED_COUPON);
-            this.name = name;
+            this.name = newName;
         }
 
-        if (description != null)
-            this.description = description;
+        if (newDescription != null)
+            this.description = newDescription;
 
-        if (totalQuantity != null) {
+        if (newTotalQuantity != null) {
             validateTotalQuantityUpdate(totalQuantity);
             this.totalQuantity = newTotalQuantity;
         }
 
-        if (maxDiscountAmount != null || minOrderAmount != null) {
+        if (newMaxDiscountAmount != null || newMinOrderAmount != null) {
             if (hasIssued())
                 throw new BusinessException(CouponErrorCode.CANNOT_MODIFY_ISSUED_COUPON);
-            this.amountPolicy = this.amountPolicy.update(maxDiscountAmount, minOrderAmount);
+            this.amountPolicy = this.amountPolicy.update(newMaxDiscountAmount, newMinOrderAmount);
         }
 
-        if (issueStartAt != null || issueEndAt != null) {
+        if (newIssueStartAt != null || newIssueEndAt != null) {
             if (hasIssued())
                 throw new BusinessException(CouponErrorCode.CANNOT_MODIFY_ISSUED_COUPON);
-            this.issuePeriod = this.issuePeriod.update(issueStartAt, issueEndAt);
+            this.issuePeriod = this.issuePeriod.update(newIssueStartAt, newIssueEndAt);
+        }
+
+        if (newUsageDays != null) {
+            if (hasIssued())
+                throw new BusinessException(CouponErrorCode.CANNOT_MODIFY_ISSUED_COUPON);
+
+            if (newUsageDays < 1)
+                throw new BusinessException(CouponErrorCode.INVALID_VALIDITY_DAYS);
+
+            this.usageDays = newUsageDays;
         }
     }
 
@@ -114,10 +130,20 @@ public class Coupon extends BaseEntity {
         this.status = newStatus;
     }
 
+    public void increaseIssuedQuantity() {
+        if (totalQuantity != null && issuedQuantity >= totalQuantity)
+            throw new BusinessException(CouponErrorCode.COUPON_EXHAUSTED);
+
+        this.issuedQuantity++;
+    }
+
     // 필수 필드 검증
-    private static void validateRequiredFields(String name) {
+    private static void validateRequiredFields(String name, Integer usageDays) {
         if (name == null || name.isBlank())
             throw new BusinessException(CouponErrorCode.INVALID_COUPON_NAME);
+
+        if (usageDays == null || usageDays < 1)
+            throw new BusinessException(CouponErrorCode.INVALID_VALIDITY_DAYS);
     }
 
     // 수량 정책 검증
@@ -130,7 +156,7 @@ public class Coupon extends BaseEntity {
             throw new BusinessException(CouponErrorCode.INVALID_QUANTITY);
     }
 
-    // 발행 여부 검증
+    // 발행된 쿠폰인지 검증
     public boolean hasIssued() {
         return this.issuedQuantity != null && this.issuedQuantity > 0;
     }
@@ -152,5 +178,17 @@ public class Coupon extends BaseEntity {
         if (!this.status.canTransitionTo(newStatus)) {
             throw new BusinessException(CouponErrorCode.INVALID_STATUS_TRANSITION);
         }
+    }
+
+    // 쿠폰 발급 가능 상태 검증
+    public void validateIssuable() {
+        if (this.status != CouponStatus.ACTIVE)
+            throw new BusinessException(CouponErrorCode.COUPON_NOT_AVAILABLE);
+    }
+
+    // 쿠폰 발행 기간 검증
+    public void validateIssuePeriod() {
+        LocalDateTime now = LocalDateTime.now();
+        issuePeriod.validateIssuePeriod(now);
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/entity/CouponUser.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/entity/CouponUser.java
@@ -1,7 +1,7 @@
 package com.palja.coupon_service.domain.entity;
 
 import com.palja.common.entity.BaseEntity;
-import com.palja.coupon_service.domain.vo.UserCouponStatus;
+import com.palja.coupon_service.domain.vo.CouponUserStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,22 +20,30 @@ public class CouponUser extends BaseEntity {
     private UUID id;
 
     @Column(nullable = false)
-    private Long userId;
+    private String userId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "coupon_id", nullable = false)
-    private Coupon coupon;
+    @Column(name = "coupon_id", nullable = false)
+    private UUID couponId;
 
     @Column(nullable = false)
     private LocalDateTime expireAt; // 쿠폰 만료일
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private UserCouponStatus status;
+    private CouponUserStatus status;
 
     private LocalDateTime usedAt; // 사용일시
 
     private UUID orderId; // 사용한 주문 ID
     
     private Long discount_amount; // 할인된 금액
+
+    public static CouponUser issue(UUID couponId, String userId, LocalDateTime expireAt) {
+        return CouponUser.builder()
+                .couponId(couponId)
+                .userId(userId)
+                .expireAt(expireAt)
+                .status(CouponUserStatus.ISSUED)
+                .build();
+    }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
@@ -8,5 +8,5 @@ public interface CouponUserRepository {
 
     CouponUser save(CouponUser couponUser);
 
-    boolean existsByCouponIdAndUserId(UUID couponId, String userId);
+    boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
@@ -1,0 +1,12 @@
+package com.palja.coupon_service.domain.repository;
+
+import com.palja.coupon_service.domain.entity.CouponUser;
+
+import java.util.UUID;
+
+public interface CouponUserRepository {
+
+    CouponUser save(CouponUser couponUser);
+
+    boolean existsByCouponIdAndUserId(UUID couponId, String userId);
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/vo/CouponUserStatus.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/vo/CouponUserStatus.java
@@ -1,0 +1,15 @@
+package com.palja.coupon_service.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouponUserStatus {
+    ISSUED("발행됨"),
+    USED("사용완료"),
+    EXPIRED("만료됨"),
+    ;
+
+    private final String description;
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/vo/IssuePeriod.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/vo/IssuePeriod.java
@@ -39,6 +39,16 @@ public class IssuePeriod {
         return IssuePeriod.of(updateIssueStartAt, updateIssueEndAt);
     }
 
+    public void validateIssuePeriod(LocalDateTime now) {
+        if (issueStartAt == null && issueEndAt == null) return;
+
+        if (issueStartAt != null && now.isBefore(issueStartAt))
+            throw new BusinessException(CouponErrorCode.COUPON_NOT_STARTED);
+
+        if (issueEndAt != null && now.isAfter(issueEndAt))
+            throw new BusinessException(CouponErrorCode.COUPON_EXPIRED);
+    }
+
     private void validate(LocalDateTime issueStartAt, LocalDateTime issueEndAt) {
         if (issueStartAt == null || issueEndAt == null) return;
 

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/vo/UserCouponStatus.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/vo/UserCouponStatus.java
@@ -1,7 +1,0 @@
-package com.palja.coupon_service.domain.vo;
-
-public enum UserCouponStatus {
-    ISSUED,
-    USED,
-    EXPIRED
-}

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
@@ -1,0 +1,25 @@
+package com.palja.coupon_service.infrastructure.repository;
+
+import com.palja.coupon_service.domain.entity.CouponUser;
+import com.palja.coupon_service.domain.repository.CouponUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class CouponUserRepositoryAdaptor implements CouponUserRepository {
+
+    private final JpaCouponUserRepository jpaCouponUserRepository;
+
+    @Override
+    public CouponUser save(CouponUser couponUser) {
+        return jpaCouponUserRepository.save(couponUser);
+    }
+
+    @Override
+    public boolean existsByCouponIdAndUserId(UUID couponId, String userId) {
+        return jpaCouponUserRepository.existsByCouponIdAndUserId(couponId, userId);
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
@@ -19,7 +19,7 @@ public class CouponUserRepositoryAdaptor implements CouponUserRepository {
     }
 
     @Override
-    public boolean existsByCouponIdAndUserId(UUID couponId, String userId) {
-        return jpaCouponUserRepository.existsByCouponIdAndUserId(couponId, userId);
+    public boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId) {
+        return jpaCouponUserRepository.existsByCouponIdAndUserIdAndDeletedAtIsNull(couponId, userId);
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
@@ -1,0 +1,11 @@
+package com.palja.coupon_service.infrastructure.repository;
+
+import com.palja.coupon_service.domain.entity.CouponUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface JpaCouponUserRepository extends JpaRepository<CouponUser, UUID> {
+
+    boolean existsByCouponIdAndUserId(UUID couponId, String userId);
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
@@ -7,5 +7,5 @@ import java.util.UUID;
 
 public interface JpaCouponUserRepository extends JpaRepository<CouponUser, UUID> {
 
-    boolean existsByCouponIdAndUserId(UUID couponId, String userId);
+    boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
@@ -1,7 +1,37 @@
 package com.palja.coupon_service.presentation.controller;
 
+import com.palja.common.auditor.CurrentUser;
+import com.palja.common.response.ApiResponse;
+import com.palja.coupon_service.application.command.IssueCouponCommand;
+import com.palja.coupon_service.application.dto.CouponUserRes;
+import com.palja.coupon_service.application.service.CouponService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
+@Slf4j
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/coupons")
 public class CouponController {
+
+    private final CouponService couponService;
+
+    @PostMapping("/{couponId}")
+    public ResponseEntity<ApiResponse<CouponUserRes>> issueCoupon(@PathVariable UUID couponId) {
+        log.info("POST /api/v1/coupons/{} - 쿠폰 발급 요청 userId={}", couponId, CurrentUser.getLoginId());
+
+        IssueCouponCommand command = new IssueCouponCommand(couponId, CurrentUser.getLoginId());
+
+        CouponUserRes response = couponService.issueCoupon(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "쿠폰이 발급되었습니다."));
+    }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
@@ -36,6 +36,9 @@ public class CreateCouponReq {
     @Future(message = "발급 종료일은 현재 시간 이후여야 합니다")
     private LocalDateTime issueEndAt;
 
+    @Positive(message = "사용 기간은 0보다 커야합니다.")
+    private Integer usageDays;
+
     public static CreateCouponCommand of(CreateCouponReq request) {
         return CreateCouponCommand.builder()
                 .couponName(request.getCouponName())
@@ -47,6 +50,7 @@ public class CreateCouponReq {
                 .minOrderAmount(request.getMinOrderAmount())
                 .issueStartAt(request.getIssueStartAt())
                 .issueEndAt(request.getIssueEndAt())
+                .usageDays(request.getUsageDays())
                 .build();
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/UpdateCouponReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/UpdateCouponReq.java
@@ -31,6 +31,9 @@ public class UpdateCouponReq {
     @Future(message = "발급 종료일은 현재 시간 이후여야 합니다")
     private LocalDateTime issueEndAt;
 
+    @Positive(message = "사용 기간은 0보다 커야합니다.")
+    private Integer usageDays;
+
     public static UpdateCouponCommand of(UUID couponId, UpdateCouponReq request) {
         return UpdateCouponCommand.builder()
                 .couponId(couponId)
@@ -41,6 +44,7 @@ public class UpdateCouponReq {
                 .minOrderAmount(request.getMinOrderAmount())
                 .issueStartAt(request.getIssueStartAt())
                 .issueEndAt(request.getIssueEndAt())
+                .usageDays(request.getUsageDays())
                 .build();
     }
 }

--- a/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
+++ b/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
@@ -62,6 +62,7 @@ class CouponManagerServiceImplTest {
                     .minOrderAmount(10000)
                     .issueStartAt(LocalDateTime.of(2025, 12, 1, 0, 0))
                     .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .usageDays(7)
                     .build();
 
             Coupon savedCoupon = Coupon.create(
@@ -70,7 +71,8 @@ class CouponManagerServiceImplTest {
                     DiscountPolicy.of(DiscountType.valueOf(command.discountType()), command.discountValue()),
                     command.totalQuantity(),
                     AmountPolicy.of(command.maxDiscountAmount(), command.minOrderAmount()),
-                    IssuePeriod.of(command.issueStartAt(), command.issueEndAt())
+                    IssuePeriod.of(command.issueStartAt(), command.issueEndAt()),
+                    command.usageDays()
             );
 
             given(couponRepository.save(any(Coupon.class))).willReturn(savedCoupon);
@@ -108,6 +110,7 @@ class CouponManagerServiceImplTest {
                     .minOrderAmount(10000)
                     .issueStartAt(LocalDateTime.of(2025, 12, 1, 0, 0))
                     .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .usageDays(7)
                     .build();
 
             assertThatThrownBy(() -> couponManagerService.createCoupon(command))
@@ -129,6 +132,7 @@ class CouponManagerServiceImplTest {
                     .minOrderAmount(10000)
                     .issueStartAt(LocalDateTime.of(2025, 12, 1, 0, 0))
                     .issueEndAt(LocalDateTime.of(2025, 12, 31, 23, 59))
+                    .usageDays(7)
                     .build();
 
             assertThatThrownBy(() -> couponManagerService.createCoupon(command))
@@ -218,7 +222,8 @@ class CouponManagerServiceImplTest {
                     command.maxDiscountAmount(),
                     command.minOrderAmount(),
                     command.issueStartAt(),
-                    command.issueEndAt()
+                    command.issueEndAt(),
+                    command.usageDays()
             );
         }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #98 
<br>

## 📌 개요
사용자가 쿠폰을 발급받을 수 있는 기능을 구현했습니다. 

<br>

## 🔁 변경 사항

### 1. 도메인 계층
- **Coupon 엔티티**: 
  - `usageDays` 필드 추가 (쿠폰 사용 기간)
  - 발급 수량 증가 메서드 추가 (`increaseIssuedQuantity()`)
  - 발급 가능 상태 및 발급 기간 검증 메서드 추가
- **CouponUser 엔티티**: 
  - 쿠폰과 연관관계 변경 (`@ManyToOne` → `couponId` 직접 참조)
  - `userId` 타입 변경 (`Long` → `String`)
  - 정적 팩토리 메서드 추가 (`issue()`)
- **IssuePeriod VO**: 발급 기간 검증 메서드 추가 (`validateIssuePeriod()`)
- **CouponUserStatus Enum**: 사용자 쿠폰 상태 정의 (`ISSUED`, `USED`, `EXPIRED`)
- **CouponUserRepository**: 사용자 쿠폰 저장 및 중복 발급 체크 인터페이스

### 2. 애플리케이션 계층
- **IssueCouponCommand 추가**: 쿠폰 발급 요청 데이터 전달용 커맨드 객체
- **CouponUserRes 추가**: 발급된 쿠폰 정보 응답 DTO
- **CouponService 추가**: 쿠폰 발급 비즈니스 로직 처리 서비스
- **CouponServiceImpl 구현**: 발급 검증, 수량 증가, 만료일 계산 로직 포함
- **Command 객체 수정**: `CreateCouponCommand`, `UpdateCouponCommand`에 `usageDays` 필드 추가

### 3. 프레젠테이션 계층
- **CouponController**: `POST /api/v1/coupons/{couponId}` 쿠폰 발급 엔드포인트 추가
- **Request DTO 수정**: `CreateCouponReq`, `UpdateCouponReq`에 `usageDays` 필드 및 검증 추가

### 4. 인프라 계층
- **CouponUserRepositoryAdaptor**: 도메인 리포지토리 구현체
- **JpaCouponUserRepository**: Spring Data JPA 리포지토리

### 5. 비즈니스 로직
- **발급 검증**: 쿠폰 상태(ACTIVE만 가능), 발급 기간, 수량 제한, 중복 발급 체크
- **수량 관리**: 발급 시 `issuedQuantity` 자동 증가 및 최대 수량 체크
- **만료일 계산**: 발급 시점 + `usageDays`로 쿠폰 사용 만료일 자동 계산
- **쿠폰명 중복 체크 개선**: 수정 시 동일한 이름으로 변경하는 경우 중복 체크 스킵

### 6. 테스트
- **CouponManagerServiceImplTest 수정**: 모든 테스트에 `usageDays` 필드 추가

<br>

## 📸 스크린샷

<details>
  <summary>쿠폰 발급 API 요청/응답 예시</summary>

  <img width="1066" height="623" alt="image" src="https://github.com/user-attachments/assets/022110d2-cfac-4116-93a5-cfe4e73a4b67" />

</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.