### PR TITLE
FEAT/ UserService 일반 사용자 조회, 수정, 삭제 API 구현

### DIFF
--- a/user-service/src/main/java/com/palja/user_service/application/command/UpdateCustomerCommand.java
+++ b/user-service/src/main/java/com/palja/user_service/application/command/UpdateCustomerCommand.java
@@ -1,0 +1,11 @@
+package com.palja.user_service.application.command;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateCustomerCommand(
+
+	String address
+
+) {
+}

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCustomerDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCustomerDetailRes.java
@@ -1,0 +1,43 @@
+package com.palja.user_service.application.dto.response;
+
+import java.time.Instant;
+
+import com.palja.user_service.domain.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class ReadCustomerDetailRes {
+
+	private Long userId;
+	private String loginId;
+	private String name;
+	private String email;
+	private String address;
+	private String role;
+	private String status;
+	private Instant createdAt;
+	private String createdBy;
+	private Instant updatedAt;
+	private String updatedBy;
+
+	public static ReadCustomerDetailRes from(User user) {
+		return ReadCustomerDetailRes.builder()
+			.userId(user.getId())
+			.loginId(user.getLoginId())
+			.name(user.getName())
+			.email(user.getEmail())
+			.address(user.getAddress())
+			.role(user.getRole().name())
+			.status(user.getStatus().name())
+			.createdAt(user.getCreatedAt())
+			.createdBy(user.getCreatedBy())
+			.updatedAt(user.getUpdatedAt())
+			.updatedBy(user.getUpdatedBy())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCustomerSummaryRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCustomerSummaryRes.java
@@ -1,0 +1,27 @@
+package com.palja.user_service.application.dto.response;
+
+import com.palja.user_service.domain.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class ReadCustomerSummaryRes {
+
+	private String loginId;
+	private String name;
+	private String email;
+	private String status;
+
+	public static ReadCustomerSummaryRes from(User user) {
+		return ReadCustomerSummaryRes.builder()
+			.loginId(user.getLoginId())
+			.name(user.getName())
+			.email(user.getEmail())
+			.status(user.getStatus().name())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateCustomerDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateCustomerDetailRes.java
@@ -1,0 +1,43 @@
+package com.palja.user_service.application.dto.response;
+
+import java.time.Instant;
+
+import com.palja.user_service.domain.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class UpdateCustomerDetailRes {
+
+	private Long userId;
+	private String loginId;
+	private String name;
+	private String email;
+	private String address;
+	private String role;
+	private String status;
+	private Instant createdAt;
+	private String createdBy;
+	private Instant updatedAt;
+	private String updatedBy;
+
+	public static UpdateCustomerDetailRes from(User user) {
+		return UpdateCustomerDetailRes.builder()
+			.userId(user.getId())
+			.loginId(user.getLoginId())
+			.name(user.getName())
+			.email(user.getEmail())
+			.address(user.getAddress())
+			.role(user.getRole().name())
+			.status(user.getStatus().name())
+			.createdAt(user.getCreatedAt())
+			.createdBy(user.getCreatedBy())
+			.updatedAt(user.getUpdatedAt())
+			.updatedBy(user.getUpdatedBy())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
@@ -1,10 +1,16 @@
 package com.palja.user_service.application.service;
 
+import org.springframework.data.domain.Pageable;
+
+import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.command.CreateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 
 public interface CustomerService {
 
 	CreateUserRes createCustomer(CreateCustomerCommand command);
+
+	PageResponse<ReadCustomerSummaryRes> getAllCustomers(String currentUserLoginId, String loginId, String email, String name, Pageable pageable);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
@@ -16,4 +16,6 @@ public interface CustomerService {
 
 	ReadCustomerDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId);
 
+	ReadCustomerDetailRes getCustomerByUserId(String currentUserLoginId, Long userId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
@@ -26,4 +26,6 @@ public interface CustomerService {
 
 	UpdateCustomerDetailRes updateMe(String currentUserLoginId, UpdateCustomerCommand command);
 
+	void deleteCustomerByLoginId(String currentUserLoginId, String loginId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
@@ -24,4 +24,6 @@ public interface CustomerService {
 
 	UpdateCustomerDetailRes updateCustomerByLoginId(String currentUserLoginId, String loginId, UpdateCustomerCommand command);
 
+	UpdateCustomerDetailRes updateMe(String currentUserLoginId, UpdateCustomerCommand command);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
@@ -18,4 +18,6 @@ public interface CustomerService {
 
 	ReadCustomerDetailRes getCustomerByUserId(String currentUserLoginId, Long userId);
 
+	ReadCustomerDetailRes getMe(String currentUserLoginId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
@@ -28,4 +28,6 @@ public interface CustomerService {
 
 	void deleteCustomerByLoginId(String currentUserLoginId, String loginId);
 
+	void deleteMe(String accessToken, String currentUserLoginId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.command.CreateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
 import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 
 public interface CustomerService {
@@ -12,5 +13,7 @@ public interface CustomerService {
 	CreateUserRes createCustomer(CreateCustomerCommand command);
 
 	PageResponse<ReadCustomerSummaryRes> getAllCustomers(String currentUserLoginId, String loginId, String email, String name, Pageable pageable);
+
+	ReadCustomerDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CustomerService.java
@@ -4,9 +4,11 @@ import org.springframework.data.domain.Pageable;
 
 import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.command.CreateCustomerCommand;
+import com.palja.user_service.application.command.UpdateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
 import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateCustomerDetailRes;
 
 public interface CustomerService {
 
@@ -19,5 +21,7 @@ public interface CustomerService {
 	ReadCustomerDetailRes getCustomerByUserId(String currentUserLoginId, Long userId);
 
 	ReadCustomerDetailRes getMe(String currentUserLoginId);
+
+	UpdateCustomerDetailRes updateCustomerByLoginId(String currentUserLoginId, String loginId, UpdateCustomerCommand command);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -1,14 +1,17 @@
 package com.palja.user_service.application.service.impl;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.palja.common.auditor.AuditorContext;
 import com.palja.common.exception.BusinessException;
+import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CustomerService;
 import com.palja.user_service.domain.entity.User;
@@ -42,6 +45,24 @@ public class CustomerServiceImpl implements CustomerService {
 		userRepository.save(user);
 
 		return CreateUserRes.from(user);
+	}
+
+	@Override
+	public PageResponse<ReadCustomerSummaryRes> getAllCustomers(
+		String currentUserLoginId, String loginId, String email, String name, Pageable pageable
+	) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		return PageResponse.from(
+			userRepository.searchAllCustomers(loginId, email, name, pageable)
+				.map(ReadCustomerSummaryRes::from)
+		);
+	}
+
+	private void validateUserExistsByLoginId(String loginId) {
+		if (!userRepository.existsByLoginIdAndDeletedAtIsNull(loginId)) {
+			throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+		}
 	}
 
 	private void validateDuplicateLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -94,6 +94,15 @@ public class CustomerServiceImpl implements CustomerService {
 		return UpdateCustomerDetailRes.from(user);
 	}
 
+	@Override
+	@Transactional
+	public UpdateCustomerDetailRes updateMe(String currentUserLoginId, UpdateCustomerCommand command) {
+		User user = getCustomerByLoginId(currentUserLoginId);
+		user.update(command.address());
+
+		return UpdateCustomerDetailRes.from(user);
+	}
+
 	private User getCustomerByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndRoleAndDeletedAtIsNull(loginId, UserRole.CUSTOMER).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -10,9 +10,11 @@ import com.palja.common.exception.BusinessException;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCustomerCommand;
+import com.palja.user_service.application.command.UpdateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
 import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateCustomerDetailRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CustomerService;
 import com.palja.user_service.domain.entity.User;
@@ -77,6 +79,19 @@ public class CustomerServiceImpl implements CustomerService {
 	@Override
 	public ReadCustomerDetailRes getMe(String currentUserLoginId) {
 		return ReadCustomerDetailRes.from(getCustomerByLoginId(currentUserLoginId));
+	}
+
+	@Override
+	@Transactional
+	public UpdateCustomerDetailRes updateCustomerByLoginId(
+		String currentUserLoginId, String loginId, UpdateCustomerCommand command
+	) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		User user = getCustomerByLoginId(loginId);
+		user.update(command.address());
+
+		return UpdateCustomerDetailRes.from(user);
 	}
 
 	private User getCustomerByLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -103,6 +103,15 @@ public class CustomerServiceImpl implements CustomerService {
 		return UpdateCustomerDetailRes.from(user);
 	}
 
+	@Override
+	@Transactional
+	public void deleteCustomerByLoginId(String currentUserLoginId, String loginId) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		User user = getCustomerByLoginId(loginId);
+		user.softDelete();
+	}
+
 	private User getCustomerByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndRoleAndDeletedAtIsNull(loginId, UserRole.CUSTOMER).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -67,8 +67,21 @@ public class CustomerServiceImpl implements CustomerService {
 		return ReadCustomerDetailRes.from(getCustomerByLoginId(loginId));
 	}
 
+	@Override
+	public ReadCustomerDetailRes getCustomerByUserId(String currentUserLoginId, Long userId) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		return ReadCustomerDetailRes.from(getCustomerByUserId(userId));
+	}
+
 	private User getCustomerByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndRoleAndDeletedAtIsNull(loginId, UserRole.CUSTOMER).orElseThrow(
+			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
+		);
+	}
+
+	private User getCustomerByUserId(Long userId) {
+		return userRepository.findByIdAndRoleAndDeletedAtIsNull(userId, UserRole.CUSTOMER).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
 		);
 	}

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -1,5 +1,7 @@
 package com.palja.user_service.application.service.impl;
 
+import static com.palja.user_service.application.util.RedisKeyConstants.*;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,7 +19,9 @@ import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 import com.palja.user_service.application.dto.response.UpdateCustomerDetailRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CustomerService;
+import com.palja.user_service.application.util.JwtUtil;
 import com.palja.user_service.domain.entity.User;
+import com.palja.user_service.domain.repository.TokenRepository;
 import com.palja.user_service.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -28,6 +32,8 @@ public class CustomerServiceImpl implements CustomerService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final JwtUtil jwtUtil;
+	private final TokenRepository tokenRepository;
 
 	@Override
 	@Transactional
@@ -110,6 +116,21 @@ public class CustomerServiceImpl implements CustomerService {
 
 		User user = getCustomerByLoginId(loginId);
 		user.softDelete();
+	}
+
+	@Override
+	@Transactional
+	public void deleteMe(String accessToken, String currentUserLoginId) {
+		User user = getCustomerByLoginId(currentUserLoginId);
+		user.softDelete();
+
+		String substringAccessToken = jwtUtil.substringToken(accessToken);
+		String hashKey = jwtUtil.hashingTokenToSHA256(substringAccessToken);
+
+		tokenRepository.save(
+			ACCESS_TOKEN_BLACKLIST_PREFIX + currentUserLoginId + ":" + hashKey, substringAccessToken, jwtUtil.getAccessKeyExpirationTime()
+		);
+		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + currentUserLoginId);
 	}
 
 	private User getCustomerByLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -74,6 +74,11 @@ public class CustomerServiceImpl implements CustomerService {
 		return ReadCustomerDetailRes.from(getCustomerByUserId(userId));
 	}
 
+	@Override
+	public ReadCustomerDetailRes getMe(String currentUserLoginId) {
+		return ReadCustomerDetailRes.from(getCustomerByLoginId(currentUserLoginId));
+	}
+
 	private User getCustomerByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndRoleAndDeletedAtIsNull(loginId, UserRole.CUSTOMER).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -11,6 +11,7 @@ import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
 import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CustomerService;
@@ -56,6 +57,19 @@ public class CustomerServiceImpl implements CustomerService {
 		return PageResponse.from(
 			userRepository.searchAllCustomers(loginId, email, name, pageable)
 				.map(ReadCustomerSummaryRes::from)
+		);
+	}
+
+	@Override
+	public ReadCustomerDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		return ReadCustomerDetailRes.from(getCustomerByLoginId(loginId));
+	}
+
+	private User getCustomerByLoginId(String loginId) {
+		return userRepository.findByLoginIdAndRoleAndDeletedAtIsNull(loginId, UserRole.CUSTOMER).orElseThrow(
+			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
 		);
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -1,5 +1,6 @@
 package com.palja.user_service.application.service.impl;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -57,7 +58,7 @@ public class ManagerServiceImpl implements ManagerService {
 		String currentUserLoginId, String loginId, String email, String name, Pageable pageable
 	) {
 		validateUserExistsByLoginId(currentUserLoginId);
-
+		Page<User> users = userRepository.searchAllManagers(loginId, email, name, pageable);
 		return PageResponse.from(
 			userRepository.searchAllManagers(loginId, email, name, pageable)
 				.map(ReadManagerSummaryRes::from)

--- a/user-service/src/main/java/com/palja/user_service/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/repository/UserRepository.java
@@ -20,6 +20,8 @@ public interface UserRepository {
 
 	Page<User> searchAllManagers(String loginId, String email, String name, Pageable pageable);
 
+	Page<User> searchAllCustomers(String loginId, String email, String name, Pageable pageable);
+
 	Optional<User> findByLoginIdAndRoleAndDeletedAtIsNull(String loginId, UserRole role);
 
 	Optional<User> findByIdAndRoleAndDeletedAtIsNull(Long userId, UserRole role);

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/DslUserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/DslUserRepository.java
@@ -44,7 +44,7 @@ public class DslUserRepository {
 	public Page<User> searchAllCustomers(String loginId, String email, String name, Pageable pageable) {
 		QUser qUser = QUser.user;
 
-		List<User> managers = jpaQueryFactory
+		List<User> customers = jpaQueryFactory
 			.selectFrom(qUser)
 			.where(
 				loginId != null ? qUser.loginId.contains(loginId) : null,
@@ -59,7 +59,7 @@ public class DslUserRepository {
 
 		Long total = getTotal(qUser, UserRole.CUSTOMER, loginId, email, name);
 
-		return new PageImpl<>(managers, pageable, total != null ? total : 0);
+		return new PageImpl<>(customers, pageable, total != null ? total : 0);
 	}
 
 	private Long getTotal(QUser qUser, UserRole role, String loginId, String email, String name) {

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/DslUserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/DslUserRepository.java
@@ -41,6 +41,27 @@ public class DslUserRepository {
 		return new PageImpl<>(managers, pageable, total != null ? total : 0);
 	}
 
+	public Page<User> searchAllCustomers(String loginId, String email, String name, Pageable pageable) {
+		QUser qUser = QUser.user;
+
+		List<User> managers = jpaQueryFactory
+			.selectFrom(qUser)
+			.where(
+				loginId != null ? qUser.loginId.contains(loginId) : null,
+				email != null ? qUser.email.contains(email) : null,
+				name != null ? qUser.name.contains(name) : null,
+				qUser.role.eq(UserRole.CUSTOMER),
+				qUser.deletedAt.isNull()
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = getTotal(qUser, UserRole.CUSTOMER, loginId, email, name);
+
+		return new PageImpl<>(managers, pageable, total != null ? total : 0);
+	}
+
 	private Long getTotal(QUser qUser, UserRole role, String loginId, String email, String name) {
 		return jpaQueryFactory
 			.select(qUser.count())

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/impl/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/impl/UserRepositoryImpl.java
@@ -47,6 +47,11 @@ public class UserRepositoryImpl implements UserRepository {
 	}
 
 	@Override
+	public Page<User> searchAllCustomers(String loginId, String email, String name, Pageable pageable) {
+		return dslUserRepository.searchAllCustomers(loginId, email, name, pageable);
+	}
+
+	@Override
 	public Optional<User> findByLoginIdAndRoleAndDeletedAtIsNull(String loginId, UserRole role) {
 		return jpaUserRepository.findByLoginIdAndRoleAndDeletedAtIsNull(loginId, role);
 	}

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -8,7 +8,9 @@ import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
 import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateCustomerDetailRes;
 import com.palja.user_service.presentation.dto.request.CreateCustomerReq;
+import com.palja.user_service.presentation.dto.request.UpdateCustomerReq;
 
 public interface CustomerController {
 
@@ -23,5 +25,7 @@ public interface CustomerController {
 	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByUserId(Long userId);
 
 	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getMe();
+
+	ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateByLoginId(String loginId, UpdateCustomerReq requestDto);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -30,4 +30,6 @@ public interface CustomerController {
 
 	ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateMe(UpdateCustomerReq requestDto);
 
+	ResponseEntity<ApiResponse<Void>> deleteByLoginId(String loginId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -20,4 +20,6 @@ public interface CustomerController {
 
 	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByLoginId(String loginId);
 
+	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByUserId(Long userId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -12,6 +12,8 @@ import com.palja.user_service.application.dto.response.UpdateCustomerDetailRes;
 import com.palja.user_service.presentation.dto.request.CreateCustomerReq;
 import com.palja.user_service.presentation.dto.request.UpdateCustomerReq;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 public interface CustomerController {
 
 	ResponseEntity<ApiResponse<CreateUserRes>> create(CreateCustomerReq requestDto);
@@ -31,5 +33,7 @@ public interface CustomerController {
 	ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateMe(UpdateCustomerReq requestDto);
 
 	ResponseEntity<ApiResponse<Void>> deleteByLoginId(String loginId);
+
+	ResponseEntity<ApiResponse<Void>> deleteMe(String accessToken, HttpServletResponse response);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
 import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 import com.palja.user_service.presentation.dto.request.CreateCustomerReq;
 
@@ -16,5 +17,7 @@ public interface CustomerController {
 	ResponseEntity<ApiResponse<PageResponse<ReadCustomerSummaryRes>>> getAll(
 		String loginId, String email, String name, Pageable pageable
 	);
+
+	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByLoginId(String loginId);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -22,4 +22,6 @@ public interface CustomerController {
 
 	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByUserId(Long userId);
 
+	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getMe();
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -1,13 +1,20 @@
 package com.palja.user_service.presentation.controller;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
 import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 import com.palja.user_service.presentation.dto.request.CreateCustomerReq;
 
 public interface CustomerController {
 
 	ResponseEntity<ApiResponse<CreateUserRes>> create(CreateCustomerReq requestDto);
+
+	ResponseEntity<ApiResponse<PageResponse<ReadCustomerSummaryRes>>> getAll(
+		String loginId, String email, String name, Pageable pageable
+	);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -28,4 +28,6 @@ public interface CustomerController {
 
 	ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateByLoginId(String loginId, UpdateCustomerReq requestDto);
 
+	ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateMe(UpdateCustomerReq requestDto);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
@@ -1,7 +1,9 @@
 package com.palja.user_service.presentation.controller.impl;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,6 +33,7 @@ import com.palja.user_service.presentation.controller.CustomerController;
 import com.palja.user_service.presentation.dto.request.CreateCustomerReq;
 import com.palja.user_service.presentation.dto.request.UpdateCustomerReq;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -134,6 +138,28 @@ public class CustomerControllerImpl implements CustomerController {
 		String currentUserLoginId = CurrentUser.getLoginId();
 
 		customerService.deleteCustomerByLoginId(currentUserLoginId, loginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("일반 사용자가 삭제되었습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.CUSTOMER})
+	@DeleteMapping("/me")
+	public ResponseEntity<ApiResponse<Void>> deleteMe(
+		@RequestHeader("Authorization") String accessToken, HttpServletResponse response
+	) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		customerService.deleteMe(accessToken, currentUserLoginId);
+
+		ResponseCookie cookie = ResponseCookie
+			.from("refresh_token", "")
+			.path("/")
+			.httpOnly(true)
+			.secure(false)
+			.maxAge(0)
+			.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("일반 사용자가 삭제되었습니다."));
 	}

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
@@ -1,16 +1,24 @@
 package com.palja.user_service.presentation.controller.impl;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.palja.common.annotation.RequiredAnonymous;
+import com.palja.common.annotation.RequiredRole;
+import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
+import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 import com.palja.user_service.application.service.CustomerService;
 import com.palja.user_service.presentation.controller.CustomerController;
 import com.palja.user_service.presentation.dto.request.CreateCustomerReq;
@@ -33,6 +41,24 @@ public class CustomerControllerImpl implements CustomerController {
 		CreateUserRes responseDto = customerService.createCustomer(command);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(responseDto, "일반 사용자가 생성되었습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@GetMapping
+	public ResponseEntity<ApiResponse<PageResponse<ReadCustomerSummaryRes>>> getAll(
+		@RequestParam(required = false) String loginId,
+		@RequestParam(required = false) String email,
+		@RequestParam(required = false) String name,
+		Pageable pageable
+	) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		PageResponse<ReadCustomerSummaryRes> pagedResponseDto = customerService.getAllCustomers(
+			currentUserLoginId, loginId, email, name, pageable
+		);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(pagedResponseDto, "일반 사용자 목록을 조회했습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
@@ -114,4 +114,16 @@ public class CustomerControllerImpl implements CustomerController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자가 수정되었습니다."));
 	}
 
+	@Override
+	@RequiredRole({UserRole.CUSTOMER})
+	@PutMapping("/me")
+	public ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateMe(@Valid @RequestBody UpdateCustomerReq requestDto) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		UpdateCustomerCommand command = UpdateCustomerReq.of(requestDto);
+		UpdateCustomerDetailRes responseDto = customerService.updateMe(currentUserLoginId, command);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자가 수정되었습니다."));
+	}
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
@@ -74,4 +74,15 @@ public class CustomerControllerImpl implements CustomerController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자를 조회했습니다."));
 	}
 
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@GetMapping("/internal/{userId}")
+	public ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByUserId(@PathVariable Long userId) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		ReadCustomerDetailRes responseDto = customerService.getCustomerByUserId(currentUserLoginId, userId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자를 조회했습니다."));
+	}
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
@@ -3,6 +3,7 @@ package com.palja.user_service.presentation.controller.impl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -124,6 +125,17 @@ public class CustomerControllerImpl implements CustomerController {
 		UpdateCustomerDetailRes responseDto = customerService.updateMe(currentUserLoginId, command);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자가 수정되었습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@DeleteMapping("/{loginId}")
+	public ResponseEntity<ApiResponse<Void>> deleteByLoginId(@PathVariable String loginId) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		customerService.deleteCustomerByLoginId(currentUserLoginId, loginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("일반 사용자가 삭제되었습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,12 +19,15 @@ import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCustomerCommand;
+import com.palja.user_service.application.command.UpdateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
 import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateCustomerDetailRes;
 import com.palja.user_service.application.service.CustomerService;
 import com.palja.user_service.presentation.controller.CustomerController;
 import com.palja.user_service.presentation.dto.request.CreateCustomerReq;
+import com.palja.user_service.presentation.dto.request.UpdateCustomerReq;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -94,6 +98,20 @@ public class CustomerControllerImpl implements CustomerController {
 		ReadCustomerDetailRes responseDto = customerService.getMe(currentUserLoginId);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자를 조회했습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@PutMapping("/{loginId}")
+	public ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateByLoginId(
+		@PathVariable String loginId, @Valid @RequestBody UpdateCustomerReq requestDto
+	) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		UpdateCustomerCommand command = UpdateCustomerReq.of(requestDto);
+		UpdateCustomerDetailRes responseDto = customerService.updateCustomerByLoginId(currentUserLoginId, loginId, command);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자가 수정되었습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
@@ -85,4 +85,15 @@ public class CustomerControllerImpl implements CustomerController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자를 조회했습니다."));
 	}
 
+	@Override
+	@RequiredRole({UserRole.CUSTOMER})
+	@GetMapping("/me")
+	public ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getMe() {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		ReadCustomerDetailRes responseDto = customerService.getMe(currentUserLoginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자를 조회했습니다."));
+	}
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CustomerControllerImpl.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +19,7 @@ import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCustomerCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
 import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 import com.palja.user_service.application.service.CustomerService;
 import com.palja.user_service.presentation.controller.CustomerController;
@@ -59,6 +61,17 @@ public class CustomerControllerImpl implements CustomerController {
 		);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(pagedResponseDto, "일반 사용자 목록을 조회했습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@GetMapping("/{loginId}")
+	public ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByLoginId(@PathVariable String loginId) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		ReadCustomerDetailRes responseDto = customerService.getCustomerByLoginId(currentUserLoginId, loginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "일반 사용자를 조회했습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCustomerReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCustomerReq.java
@@ -1,0 +1,23 @@
+package com.palja.user_service.presentation.dto.request;
+
+import com.palja.user_service.application.command.UpdateCustomerCommand;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateCustomerReq {
+
+	@NotBlank(message = "주소를 입력해주세요.")
+	private String address;
+
+	public static UpdateCustomerCommand of(UpdateCustomerReq requestDto) {
+		return UpdateCustomerCommand.builder()
+			.address(requestDto.getAddress())
+			.build();
+	}
+
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #100 

<br>

## 📌 개요
- customer 조회, 수정, 삭제 API를 구현했습니다.

<br>

## 🔁 변경 사항
- 조회
  - 목록 조회 : 검색 및 페이징을 통해 일반 사용자 목록을 조회할 수 있습니다.
  - 단건 조회(loginId) : loginId로 일반 사용자의 상세 정보를 조회할 수 있습니다.
  - 단건 조회(userId) : userId로 일반 사용자의 상세 정보를 조회할 수 있습니다.
  - 단건 조회(me) : 로그인한 일반 사용자가 자신의 상세 정보를 조회할 수 있습니다.
- 수정
  - 수정(loginId) : loginId로 일반 사용자의 정보를 수정할 수 있습니다. (현재 address 필드만 변경할 수 있도록 해놓은 상태입니다.)
  - 수정(me) : 로그인한 일반 사용자가 자신의 정보를 수정할 수 있습니다. (현재 address 필드만 변경할 수 있도록 해놓은 상태입니다.)
- 삭제
  - 삭제(loginId) : loginId로 일반 사용자를 삭제할 수 있습니다.
  - 삭제(me) : 로그인한 일반 사용자가 자신을 삭제할 수 있습니다. (액세스 토큰을 레디스에 블랙리스트에 등록하고 리프레시 토큰을 레디스에서 삭제합니다.)

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
회원 삭제 시 해당 회원의 주문, 댓글 등을 삭제하는 기능은 이후에 추가할 예정입니다!
회원 API가 다른 서비스를 테스트할 때 필요해서 일단 기능이 정상 동작하도록 개발하고 이후에 전체적으로 리팩토링할 예정입니다!

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
