### PR TITLE
FEAT/타임딜 상태 변경 API 구현

### DIFF
--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/ChangeTimeDealStatusCommand.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/ChangeTimeDealStatusCommand.java
@@ -1,0 +1,15 @@
+package com.palja.timedeal_service.application.command;
+
+import com.palja.common.vo.UserRole;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record ChangeTimeDealStatusCommand(
+        UUID timeDealId,
+        String newStatus,
+        String reason,
+        String loginId,
+        UserRole role
+) {}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/UpdateTimeDealCommand.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/UpdateTimeDealCommand.java
@@ -17,4 +17,4 @@ public record UpdateTimeDealCommand(
         Long totalQuantity,
         String loginId,
         UserRole role
-) { }
+) {}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
@@ -1,5 +1,6 @@
 package com.palja.timedeal_service.application.service;
 
+import com.palja.timedeal_service.application.command.ChangeTimeDealStatusCommand;
 import com.palja.timedeal_service.application.command.CreateTimeDealCommand;
 import com.palja.timedeal_service.application.command.UpdateTimeDealCommand;
 import com.palja.timedeal_service.application.dto.TimeDealDetailRes;
@@ -10,4 +11,5 @@ public interface TimeDealService {
     TimeDealDetailRes createTimeDeal(CreateTimeDealCommand command);
     TimeDealDetailRes getTimeDeal(UUID timeDealId);
     TimeDealDetailRes updateTimeDeal(UpdateTimeDealCommand command);
+    TimeDealDetailRes changeTimeDealStatus(ChangeTimeDealStatusCommand command);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -2,7 +2,9 @@ package com.palja.timedeal_service.application.service.impl;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
+import com.palja.common.exception.ErrorCode;
 import com.palja.common.vo.UserRole;
+import com.palja.timedeal_service.application.command.ChangeTimeDealStatusCommand;
 import com.palja.timedeal_service.application.command.CreateTimeDealCommand;
 import com.palja.timedeal_service.application.command.UpdateTimeDealCommand;
 import com.palja.timedeal_service.application.dto.TimeDealDetailRes;
@@ -11,6 +13,7 @@ import com.palja.timedeal_service.application.port.ProductClient;
 import com.palja.timedeal_service.application.service.TimeDealService;
 import com.palja.timedeal_service.application.validator.TimeDealValidator;
 import com.palja.timedeal_service.common.TimeDealEditableField;
+import com.palja.timedeal_service.common.TimeDealErrorCode;
 import com.palja.timedeal_service.domain.entity.TimeDeal;
 import com.palja.timedeal_service.domain.repository.TimeDealRepository;
 import com.palja.timedeal_service.domain.vo.Amount;
@@ -94,6 +97,25 @@ public class TimeDealServiceImpl implements TimeDealService {
         return TimeDealDetailRes.from(timeDeal);
     }
 
+    @Override
+    @Transactional
+    public TimeDealDetailRes changeTimeDealStatus(ChangeTimeDealStatusCommand command) {
+        log.info("타임딜 상태 수정 시작");
+
+        TimeDeal timeDeal = getActiveTimeDeal(command.timeDealId());
+
+        if (command.role().equals(UserRole.COMPANY_USER)) {
+            timeDealValidator.validateCompanyUserId(command.loginId(), timeDeal.getCompanyUserId());
+        }
+
+        TimeDealStatus newStatus = parseTimeDealStatus(command.newStatus());
+
+        timeDeal.changeStatus(newStatus, command.reason());
+
+        log.info("타임딜 상태 수정 완료");
+        return TimeDealDetailRes.from(timeDeal);
+    }
+
     private void updateTimeDealFields(TimeDeal timeDeal, UpdateTimeDealCommand command) {
         TimeDealStatus timeDealStatus = timeDeal.getTimeDealStatus();
 
@@ -131,5 +153,13 @@ public class TimeDealServiceImpl implements TimeDealService {
     private TimeDeal getActiveTimeDeal(UUID timeDealId) {
         return timeDealRepository.findDetailByTimeDealId(timeDealId)
                 .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
+    }
+
+    private TimeDealStatus parseTimeDealStatus(String status) {
+        try {
+            return TimeDealStatus.valueOf(status.toUpperCase());
+        } catch (Exception e) {
+            throw new BusinessException(TimeDealErrorCode.INVALID_TIME_DEAL_STATUS);
+        }
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -2,7 +2,6 @@ package com.palja.timedeal_service.application.service.impl;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
-import com.palja.common.exception.ErrorCode;
 import com.palja.common.vo.UserRole;
 import com.palja.timedeal_service.application.command.ChangeTimeDealStatusCommand;
 import com.palja.timedeal_service.application.command.CreateTimeDealCommand;
@@ -44,9 +43,7 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         ProductInfo product = productClient.getProduct(command.productId());
 
-        if (command.role().equals(UserRole.COMPANY_USER)) {
-            timeDealValidator.validateCompanyUserId(command.loginId(), product.companyUserId());
-        }
+        ValidateCompanyUser(command.role(), command.loginId(), product.companyUserId());
 
         timeDealValidator.validateStock(command.totalQuantity(), product.stock());
 
@@ -87,9 +84,7 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         TimeDeal timeDeal = getActiveTimeDeal(command.timeDealId());
 
-        if (command.role().equals(UserRole.COMPANY_USER)) {
-            timeDealValidator.validateCompanyUserId(command.loginId(), timeDeal.getCompanyUserId());
-        }
+        ValidateCompanyUser(command.role(), command.loginId(), timeDeal.getCompanyUserId());
 
         updateTimeDealFields(timeDeal, command);
 
@@ -104,9 +99,7 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         TimeDeal timeDeal = getActiveTimeDeal(command.timeDealId());
 
-        if (command.role().equals(UserRole.COMPANY_USER)) {
-            timeDealValidator.validateCompanyUserId(command.loginId(), timeDeal.getCompanyUserId());
-        }
+        ValidateCompanyUser(command.role(), command.loginId(), timeDeal.getCompanyUserId());
 
         TimeDealStatus newStatus = parseTimeDealStatus(command.newStatus());
 
@@ -153,6 +146,12 @@ public class TimeDealServiceImpl implements TimeDealService {
     private TimeDeal getActiveTimeDeal(UUID timeDealId) {
         return timeDealRepository.findDetailByTimeDealId(timeDealId)
                 .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
+    }
+
+    private void ValidateCompanyUser(UserRole role, String loginId, UUID ownerCompanyUserId) {
+        if (role.equals(UserRole.COMPANY_USER)) {
+            timeDealValidator.validateCompanyUserId(loginId, ownerCompanyUserId);
+        }
     }
 
     private TimeDealStatus parseTimeDealStatus(String status) {

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/common/TimeDealErrorCode.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/common/TimeDealErrorCode.java
@@ -31,6 +31,11 @@ public enum TimeDealErrorCode implements ErrorCode {
 
     // 수정 관련
     TIME_DEAL_NOT_EDITABLE(HttpStatus.BAD_REQUEST, "타임딜을 수정할 수 없는 상태입니다."),
+    INVALID_TIME_DEAL_STATUS(HttpStatus.BAD_REQUEST, "알맞지 않은 타임딜 상태입니다."),
+    TIME_DEAL_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "변경할 타임딜 상태는 필수입니다."),
+    TIME_DEAL_STATUS_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "현재 상태와 동일한 상태로는 변경할 수 없습니다."),
+    TIME_DEAL_INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "허용되지 않은 상태 변경입니다."),
+    TIME_DEAL_STATUS_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "상태 변경 사유는 필수입니다."),
 
     // 외부 관련
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
@@ -94,16 +94,12 @@ public class TimeDeal extends BaseEntity {
     }
 
     public void changeTitle(String newTitle) {
-        if (newTitle == null || newTitle.isBlank()) {
-            throw new BusinessException(TimeDealErrorCode.TITLE_REQUIRED);
-        }
+        validateTitle(title);
         this.title = newTitle;
     }
 
     public void changeDescription(String newDescription) {
-        if (newDescription == null || newDescription.isBlank()) {
-            throw new BusinessException(TimeDealErrorCode.DESCRIPTION_REQUIRED);
-        }
+        validateDescription(description);
         this.description = newDescription;
     }
 
@@ -123,6 +119,15 @@ public class TimeDeal extends BaseEntity {
         this.timeDealStock.changeTotalQuantity(newTotalQuantity);
     }
 
+    public void changeStatus(TimeDealStatus newStatus, String reason) {
+        validateTimeDealStatusChange(newStatus, reason);
+
+        TimeDealStatusHistory history = TimeDealStatusHistory.create(this, this.timeDealStatus, newStatus, reason);
+
+        this.statusHistories.add(history);
+        this.timeDealStatus = newStatus;
+    }
+
     private static void validate(
             UUID productId,
             UUID companyUserId,
@@ -137,12 +142,37 @@ public class TimeDeal extends BaseEntity {
             throw new BusinessException(TimeDealErrorCode.COMPANY_USER_ID_REQUIRED);
         }
 
+        validateTitle(title);
+        validateDescription(description);
+    }
+
+    private static void validateTitle(String title) {
         if (title == null || title.isBlank()) {
             throw new BusinessException(TimeDealErrorCode.TITLE_REQUIRED);
         }
+    }
 
+    private static void validateDescription(String description) {
         if (description == null || description.isBlank()) {
             throw new BusinessException(TimeDealErrorCode.DESCRIPTION_REQUIRED);
+        }
+    }
+
+    private void validateTimeDealStatusChange(TimeDealStatus newStatus, String reason) {
+        if (newStatus == null) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_STATUS_REQUIRED);
+        }
+
+        if (this.timeDealStatus == newStatus) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_STATUS_ALREADY_APPLIED);
+        }
+
+        if (!this.timeDealStatus.canTransitTo(newStatus)) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_INVALID_STATUS_TRANSITION);
+        }
+
+        if (reason == null || reason.isBlank()) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_STATUS_REASON_REQUIRED);
         }
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
@@ -11,6 +11,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -56,6 +58,15 @@ public class TimeDeal extends BaseEntity {
             fetch = FetchType.LAZY
     )
     private TimeDealStock timeDealStock;
+
+    @OneToMany(
+            mappedBy = "timeDeal",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @Builder.Default
+    private List<TimeDealStatusHistory> statusHistories = new ArrayList<>();
 
     public static TimeDeal create(
             UUID productId,

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDealStatusHistory.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDealStatusHistory.java
@@ -34,4 +34,18 @@ public class TimeDealStatusHistory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "time_deal_id", nullable = false)
     private TimeDeal timeDeal;
+
+    public static TimeDealStatusHistory create(
+            TimeDeal timeDeal,
+            TimeDealStatus previousStatus,
+            TimeDealStatus newStatus,
+            String reason
+    ) {
+        return TimeDealStatusHistory.builder()
+                .timeDeal(timeDeal)
+                .previousStatus(previousStatus)
+                .newStatus(newStatus)
+                .reason(reason)
+                .build();
+    }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDealStatusHistory.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDealStatusHistory.java
@@ -1,0 +1,37 @@
+package com.palja.timedeal_service.domain.entity;
+
+import com.palja.common.entity.BaseEntity;
+import com.palja.timedeal_service.domain.vo.TimeDealStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_time_deal_status_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+public class TimeDealStatusHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "time_deal_status_history_id")
+    private UUID timeDealStatusHistoryId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "previous_status", nullable = false)
+    private TimeDealStatus previousStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "new_status", nullable = false)
+    private TimeDealStatus newStatus;
+
+    @Column(name = "reason", nullable = false, length = 100)
+    private String reason;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "time_deal_id", nullable = false)
+    private TimeDeal timeDeal;
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDealStock.java
@@ -34,7 +34,6 @@ public class TimeDealStock extends BaseEntity {
                 .build();
 
         return timeDealStock;
-
     }
 
     public void changeTotalQuantity(long newTotalQuantity) {

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/TimeDealStatus.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/TimeDealStatus.java
@@ -8,12 +8,22 @@ public enum TimeDealStatus {
         public boolean canEditField(TimeDealEditableField field) {
             return true;
         }
+
+        @Override
+        public boolean canTransitTo(TimeDealStatus newStatus) {
+            return newStatus == OPEN || newStatus == CLOSED;
+        }
     },
 
     OPEN("진행중") {
         @Override
         public boolean canEditField(TimeDealEditableField field) {
             return field == TimeDealEditableField.END_AT;
+        }
+
+        @Override
+        public boolean canTransitTo(TimeDealStatus newStatus) {
+            return newStatus == CLOSED;
         }
     },
 
@@ -22,11 +32,21 @@ public enum TimeDealStatus {
         public boolean canEditField(TimeDealEditableField field) {
             return false;
         }
+
+        @Override
+        public boolean canTransitTo(TimeDealStatus newStatus) {
+            return false;
+        }
     },
 
     CLOSED("종료") {
         @Override
         public boolean canEditField(TimeDealEditableField field) {
+            return false;
+        }
+
+        @Override
+        public boolean canTransitTo(TimeDealStatus newStatus) {
             return false;
         }
     };
@@ -42,4 +62,6 @@ public enum TimeDealStatus {
     }
 
     public abstract boolean canEditField(TimeDealEditableField field);
+
+    public abstract boolean canTransitTo(TimeDealStatus newStatus);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
@@ -4,10 +4,12 @@ import com.palja.common.annotation.RequiredRole;
 import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.vo.UserRole;
+import com.palja.timedeal_service.application.command.ChangeTimeDealStatusCommand;
 import com.palja.timedeal_service.application.command.CreateTimeDealCommand;
 import com.palja.timedeal_service.application.command.UpdateTimeDealCommand;
 import com.palja.timedeal_service.application.dto.TimeDealDetailRes;
 import com.palja.timedeal_service.application.service.TimeDealService;
+import com.palja.timedeal_service.presentation.dto.request.ChangeTimeDealStatusReq;
 import com.palja.timedeal_service.presentation.dto.request.CreateTimeDealReq;
 import com.palja.timedeal_service.presentation.dto.request.UpdateTimeDealReq;
 import jakarta.validation.Valid;
@@ -76,5 +78,24 @@ public class TimeDealController {
 
         log.info("타임딜 수정 성공: timeDealId = {}", res.getTimeDealId());
         return ResponseEntity.ok(ApiResponse.success(res, "타임딜 수정에 성공했습니다."));
+    }
+
+    @PutMapping("/{timeDealId}/status")
+    @RequiredRole({UserRole.MANAGER, UserRole.COMPANY_USER})
+    public ResponseEntity<ApiResponse<TimeDealDetailRes>> changeTimeDealStatus(
+            @PathVariable UUID timeDealId,
+            @RequestBody @Valid ChangeTimeDealStatusReq req
+    ) {
+        log.info("PUT api/v1/time-deals/{}/status 타임딜 상태 변경 요청", timeDealId);
+
+        String loginId = CurrentUser.getLoginId();
+        UserRole role = CurrentUser.getRole();
+
+        ChangeTimeDealStatusCommand command = req.toCommand(timeDealId, loginId, role);
+
+        TimeDealDetailRes res = timeDealService.changeTimeDealStatus(command);
+
+        log.info("타임딜 상태 변경 성공: timeDealId = {}", res.getTimeDealId());
+        return ResponseEntity.ok(ApiResponse.success(res, "타임딜 상태 변경에 성공했습니다."));
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
@@ -40,10 +40,7 @@ public class TimeDealController {
     ) {
         log.info("POST api/v1/time-deals 타임딜 생성 요청");
 
-        String loginId = CurrentUser.getLoginId();
-        UserRole role = CurrentUser.getRole();
-
-        CreateTimeDealCommand command = req.toCommand(loginId, role);
+        CreateTimeDealCommand command = req.toCommand(CurrentUser.getLoginId(), CurrentUser.getRole());
 
         TimeDealDetailRes res = timeDealService.createTimeDeal(command);
 
@@ -69,10 +66,7 @@ public class TimeDealController {
     ) {
         log.info("PUT /api/v1/time-deals/{} 타임딜 수정 요청", timeDealId);
 
-        String loginId = CurrentUser.getLoginId();
-        UserRole role = CurrentUser.getRole();
-
-        UpdateTimeDealCommand command = req.toCommand(timeDealId, loginId, role);
+        UpdateTimeDealCommand command = req.toCommand(timeDealId, CurrentUser.getLoginId(), CurrentUser.getRole());
 
         TimeDealDetailRes res = timeDealService.updateTimeDeal(command);
 
@@ -88,10 +82,7 @@ public class TimeDealController {
     ) {
         log.info("PUT api/v1/time-deals/{}/status 타임딜 상태 변경 요청", timeDealId);
 
-        String loginId = CurrentUser.getLoginId();
-        UserRole role = CurrentUser.getRole();
-
-        ChangeTimeDealStatusCommand command = req.toCommand(timeDealId, loginId, role);
+        ChangeTimeDealStatusCommand command = req.toCommand(timeDealId, CurrentUser.getLoginId(), CurrentUser.getRole());
 
         TimeDealDetailRes res = timeDealService.changeTimeDealStatus(command);
 

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
@@ -31,7 +31,6 @@ import java.util.UUID;
 public class TimeDealController {
 
     private final TimeDealService timeDealService;
-    private final ResourceLoader resourceLoader;
 
     @PostMapping
     @RequiredRole({UserRole.MANAGER, UserRole.COMPANY_USER})

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/dto/request/ChangeTimeDealStatusReq.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/dto/request/ChangeTimeDealStatusReq.java
@@ -1,0 +1,31 @@
+package com.palja.timedeal_service.presentation.dto.request;
+
+import com.palja.common.vo.UserRole;
+import com.palja.timedeal_service.application.command.ChangeTimeDealStatusCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class ChangeTimeDealStatusReq {
+    @NotBlank(message = "새로운 상태 값은 필수입니다.")
+    String newStatus;
+
+    @NotBlank(message = "상태 변경 이유는 필수입니다.")
+    @Size(max = 100, message = "상태 변경 이유는 최대 100자까지 입력 가능합니다.")
+    String reason;
+
+    public ChangeTimeDealStatusCommand toCommand(UUID timeDealId, String longinId, UserRole role) {
+        return ChangeTimeDealStatusCommand.builder()
+                .timeDealId(timeDealId)
+                .newStatus(newStatus)
+                .reason(reason)
+                .loginId(longinId)
+                .role(role)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #114 

<br>

## 📌 개요
- 타임딜 상태 변경 API 구현

<br>

## 🔁 변경 사항
- serviceImpl 에서 반복적으로 사용되던 업체 사용자 권한 검증 로직 validateCompanyUser()로 통합
- controller 코드 중복 제거
- 타임딜 상태 변경 이력 테이블 추가
- PENDING -> OPEN, PENDING -> CLOSED, OPEN -> CLOSED 의 변경만 허용 -> 도메인에 규칙 작성
- 권한 인증 로직 작성 (타임딜 담당 업체 판매자, 관리자만 가능)

<br>

## 📸 스크린샷

<details>
  <summary>타임딜 상태 변경 성공</summary>
<img width="753" height="768" alt="화면 캡처 2025-12-07 004905" src="https://github.com/user-attachments/assets/7a775ca5-0061-4b72-afb6-3b7e3cda10af" /></details>

<br>

## 👀 기타 더 이야기해볼 점


<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
