### PR TITLE
FEAT/OrderService 주문 단건 조회 API 구현

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -37,7 +37,7 @@ ext {
 }
 
 dependencies {
-	implementation 'com.palja:common-module:0.5.6'
+	implementation 'com.palja:common-module:0.6.1'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CompanyUserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CompanyUserRes.java
@@ -1,0 +1,43 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.common.vo.UserRole;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CompanyUserRes {
+
+    private final Long userId;
+    private final UUID companyUserId;
+    private final String loginId;
+    private final String companyName;
+    private final String email;
+    private final UserRole role;
+    private final String status;
+
+    public static CompanyUserRes of(
+            Long userId,
+            UUID companyUserId,
+            String loginId,
+            String companyName,
+            String email,
+            UserRole role,
+            String status
+    ) {
+        return CompanyUserRes.builder()
+                .userId(userId)
+                .companyUserId(companyUserId)
+                .loginId(loginId)
+                .companyName(companyName)
+                .email(email)
+                .role(role)
+                .status(status)
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/CustomerUserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/CustomerUserRes.java
@@ -1,0 +1,38 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.common.vo.UserRole;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CustomerUserRes {
+
+    private final Long userId;
+    private final String loginId;
+    private final String name;
+    private final String email;
+    private final UserRole role;
+    private final String status;
+
+    public static CustomerUserRes of(
+            Long userId,
+            String loginId,
+            String name,
+            String email,
+            UserRole role,
+            String status
+    ) {
+        return CustomerUserRes.builder()
+                .userId(userId)
+                .loginId(loginId)
+                .name(name)
+                .email(email)
+                .role(role)
+                .status(status)
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/ManagerUserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/ManagerUserRes.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserRes {
+public class ManagerUserRes {
 
     private final Long userId;
     private final String loginId;
@@ -18,7 +18,7 @@ public class UserRes {
     private final UserRole role;
     private final String status;
 
-    public static UserRes of(
+    public static ManagerUserRes of(
             Long userId,
             String loginId,
             String name,
@@ -26,7 +26,7 @@ public class UserRes {
             UserRole role,
             String status
     ) {
-        return UserRes.builder()
+        return ManagerUserRes.builder()
                 .userId(userId)
                 .loginId(loginId)
                 .name(name)

--- a/order-service/src/main/java/com/palja/order_service/application/dto/OrderCreateRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/OrderCreateRes.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 // 주문 생성 응답 DTO
@@ -21,7 +21,7 @@ public class OrderCreateRes {
     private PricingRes pricing;
     private CouponSnapshotRes coupon;
     private Boolean timeDealOrder;
-    private Instant createdAt;
+    private LocalDateTime createdAt;
 
     // Order 엔티티 → 주문 생성 응답 DTO 변환
     public static OrderCreateRes from(Order order) {

--- a/order-service/src/main/java/com/palja/order_service/application/dto/OrderDetailRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/OrderDetailRes.java
@@ -1,0 +1,48 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.order_service.domain.entity.Order;
+import com.palja.order_service.domain.vo.OrderStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderDetailRes {
+
+    private final UUID orderId;
+    private final Long userId;
+    private final OrderStatus status;
+
+    private final OrderItemRes orderItem;
+    private final DeliveryRes delivery;
+    private final PricingRes pricing;
+    private final CouponSnapshotRes coupon;
+
+    private final UUID paymentId;
+    private final boolean timeDealOrder;
+
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static OrderDetailRes from(Order order) {
+        return OrderDetailRes.builder()
+                .orderId(order.getOrderId())
+                .userId(order.getUserId())
+                .status(order.getStatus())
+                .orderItem(OrderItemRes.from(order.requireOrderItem()))
+                .delivery(DeliveryRes.from(order.requireDelivery()))
+                .pricing(PricingRes.from(order))
+                .coupon(order.getCouponId() != null ? CouponSnapshotRes.of(order.getCouponId(), order.getCouponName()) : null)
+                .paymentId(order.getPaymentId())
+                .timeDealOrder(order.isTimeDealOrder())
+                .createdAt(order.getCreatedAt())
+                .updatedAt(order.getUpdatedAt())
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
@@ -19,15 +19,14 @@ public class ProductRes {
     private int stockQuantity;
 
     public static ProductRes of(
+            UUID companyUserId,
             UUID productId,
             String productName,
             BigDecimal price,
             int stockQuantity
     ) {
-        // TODO: 상품 도메인 조회 시 companyUserId 반환하도록 수정되면
-        //       랜덤 UUID 대신 실제 companyUserId 값을 설정.
         return ProductRes.builder()
-                .companyUserId(UUID.randomUUID())
+                .companyUserId(companyUserId)
                 .productId(productId)
                 .productName(productName)
                 .price(price)

--- a/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/ProductRes.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductRes {
+    private UUID companyUserId;
     private UUID productId;
     private String productName;
     private BigDecimal price;
@@ -23,7 +24,10 @@ public class ProductRes {
             BigDecimal price,
             int stockQuantity
     ) {
+        // TODO: 상품 도메인 조회 시 companyUserId 반환하도록 수정되면
+        //       랜덤 UUID 대신 실제 companyUserId 값을 설정.
         return ProductRes.builder()
+                .companyUserId(UUID.randomUUID())
                 .productId(productId)
                 .productName(productName)
                 .price(price)

--- a/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
@@ -1,8 +1,14 @@
 package com.palja.order_service.application.service;
 
+import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CreateOrderCommand;
 import com.palja.order_service.application.dto.OrderCreateRes;
+import com.palja.order_service.application.dto.OrderDetailRes;
+
+import java.util.UUID;
 
 public interface OrderService {
     OrderCreateRes createOrder(CreateOrderCommand command);
+
+    OrderDetailRes getOrder(UUID orderId, String loginId, UserRole userRole);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/ProductService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/ProductService.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 public interface ProductService {
 
     // 주문 생성 시 상품 정보 조회
-    ProductRes getProduct(UUID productId, int quantity);
+    ProductRes getProduct(UUID productId);
 
     // 주문 확정 시 상품 재고 차감
     void deductStock(UUID productId, int quantity);

--- a/order-service/src/main/java/com/palja/order_service/application/service/UserService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/UserService.java
@@ -1,8 +1,17 @@
 package com.palja.order_service.application.service;
 
-import com.palja.order_service.application.dto.UserRes;
+import com.palja.order_service.application.dto.CompanyUserRes;
+import com.palja.order_service.application.dto.CustomerUserRes;
+import com.palja.order_service.application.dto.ManagerUserRes;
 
 public interface UserService {
 
-    UserRes getUserByLoginId(String loginId);
+    // 고객 사용자 조회
+    CustomerUserRes getCustomerUserByLoginId(String loginId);
+
+    // 매니저 사용자 조회
+    ManagerUserRes getManagerUserByLoginId(String loginId);
+
+    // 판매업체 사용자 조회
+    CompanyUserRes getCompanyUserByLoginId(String loginId);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -1,7 +1,10 @@
 package com.palja.order_service.application.service.impl;
 
+import com.palja.common.exception.BusinessException;
+import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CreateOrderCommand;
 import com.palja.order_service.application.dto.*;
+import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.*;
 import com.palja.order_service.application.service.calculator.OrderCalculator;
 import com.palja.order_service.application.service.validator.OrderValidator;
@@ -40,9 +43,9 @@ public class OrderServiceImpl implements OrderService {
 
         orderValidator.validateCreateOrderCommand(command);
 
-        UserRes user = getValidUser(command);
-        ProductRes product = getValidProduct(command);
-        TimeDealRes timeDeal = getValidTimeDeal(command);
+        CustomerUserRes user = getUserForOrderCreation(command.loginId());
+        ProductRes product = getProductForOrderCreation(command.productId(), command.quantity());
+        TimeDealRes timeDeal = getValidTimeDealForOrderCreation(command);
 
         BigDecimal amountBeforeCoupon = calculateAmountBeforeCoupon(product, timeDeal, command.quantity());
 
@@ -68,6 +71,64 @@ public class OrderServiceImpl implements OrderService {
                 order.getOrderId(), order.getOrderAmount().getFinalAmount());
 
         return OrderCreateRes.from(order);
+    }
+
+    /**
+     * 주문 단건 조회
+     * 권한별로 접근 제어
+     * - MANAGER: 모든 주문 조회 가능
+     * - CUSTOMER: 본인 주문만 조회 가능
+     * - COMPANY_USER: 자신이 판매한 상품의 주문만 조회 가능
+     */
+    public OrderDetailRes getOrder(UUID orderId, String loginId, UserRole userRole) {
+        log.info("주문 조회 시작 - orderId: {}, loginId: {}, userRole: {}", orderId, loginId, userRole);
+
+        Order order = orderRepository.findOrderByIdWithItemAndDelivery(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        validateOrderAccess(order, loginId, userRole);
+
+        log.info("주문 조회 성공 - orderId: {}", orderId);
+        return OrderDetailRes.from(order);
+    }
+
+    // 권한별로 주문 접근 권한 검증
+    private void validateOrderAccess(Order order, String loginId, UserRole userRole) {
+        switch (userRole) {
+            case MANAGER -> {
+                // MANAGER는 모든 주문 조회 가능
+                log.debug("MANAGER 권한으로 주문 조회");
+            }
+            case CUSTOMER -> {
+                // CUSTOMER는 본인 주문만 조회 가능
+                Long currentUserId = getUserIdForCustomer(loginId);
+                orderValidator.validateOrderForRead(order.getUserId(), userRole, currentUserId, null, null);
+            }
+            case COMPANY_USER -> {
+                // COMPANY_USER는 자신이 판매한 상품의 주문만 조회 가능
+                UUID companyUserId = getCompanyUserIdForCompany(loginId);
+                UUID productCompanyUserId = getProductCompanyUserId(order.getOrderItem().getProductId());
+                orderValidator.validateOrderForRead(order.getUserId(), userRole, null, companyUserId, productCompanyUserId);
+            }
+            default -> throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+        }
+    }
+    // CUSTOMER용 userId 조회
+    private Long getUserIdForCustomer(String loginId) {
+        CustomerUserRes customerUser = userService.getCustomerUserByLoginId(loginId);
+        return customerUser.getUserId();
+    }
+
+    // COMPANY_USER용 companyUserId 조회
+    private UUID getCompanyUserIdForCompany(String loginId) {
+        CompanyUserRes companyUser = userService.getCompanyUserByLoginId(loginId);
+        return companyUser.getCompanyUserId();
+    }
+
+    // 상품의 판매자(companyUserId) 조회
+    private UUID getProductCompanyUserId(UUID productId) {
+        ProductRes product = productService.getProduct(productId);
+        return product.getCompanyUserId();
     }
 
     // ===== 도메인 객체 생성 =====
@@ -102,25 +163,25 @@ public class OrderServiceImpl implements OrderService {
 
     // ====== private ======
     // 사용자 검증 및 정보 조회
-    private UserRes getValidUser(CreateOrderCommand command) {
-        UserRes user = userService.getUserByLoginId(command.loginId());
-        orderValidator.validateUserOrderable(user);
+    private CustomerUserRes getUserForOrderCreation(String loginId) {
+        CustomerUserRes user = userService.getCustomerUserByLoginId(loginId);
+        orderValidator.validateUserForOrderCreation(user);
         return user;
     }
 
     // 상품 검증 및 정보 조회
-    private ProductRes getValidProduct(CreateOrderCommand command) {
-        ProductRes product = productService.getProduct(command.productId(), command.quantity());
-        orderValidator.validateProductStock(product, command.quantity());
+    private ProductRes getProductForOrderCreation(UUID productId, int quantity) {
+        ProductRes product = productService.getProduct(productId);
+        orderValidator.validateProductForOrderCreation(product, quantity);
         return product;
     }
 
     // 타임딜 검증 및 정보 조회 (타임딜 주문인 경우)
-    private TimeDealRes getValidTimeDeal(CreateOrderCommand command) {
+    private TimeDealRes getValidTimeDealForOrderCreation(CreateOrderCommand command) {
         if (command.timeDealId() == null) return null;
 
         TimeDealRes timeDeal = timeDealService.getTimeDeal(command.timeDealId(), command.quantity());
-        orderValidator.validateTimeDeal(timeDeal, command.quantity());
+        orderValidator.validateCouponForOrderCreation(timeDeal, command.quantity());
         return timeDeal;
     }
 
@@ -136,7 +197,7 @@ public class OrderServiceImpl implements OrderService {
         }
 
         CouponRes coupon = couponService.getCoupon(couponId);
-        orderValidator.validateCoupon(coupon, amountBeforeCoupon);
+        orderValidator.validateCouponForUsage(coupon, amountBeforeCoupon);
 
         BigDecimal discountAmount = orderCalculator.calculateCouponDiscount(coupon, amountBeforeCoupon);
 
@@ -148,7 +209,7 @@ public class OrderServiceImpl implements OrderService {
     // 주문 엔티티 생성 (CouponResult 사용)
     private Order createOrder(
             CreateOrderCommand command,
-            UserRes user,
+            CustomerUserRes user,
             ProductRes product,
             TimeDealRes timeDeal,
             CouponResult couponResult,

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -106,9 +106,9 @@ public class OrderServiceImpl implements OrderService {
             }
             case COMPANY_USER -> {
                 // COMPANY_USER는 자신이 판매한 상품의 주문만 조회 가능
-                UUID companyUserId = getCompanyUserIdForCompany(loginId);
+                UUID currentCompanyUserId = getCompanyUserIdForCompany(loginId);
                 UUID productCompanyUserId = getProductCompanyUserId(order.getOrderItem().getProductId());
-                orderValidator.validateOrderForRead(order.getUserId(), userRole, null, companyUserId, productCompanyUserId);
+                orderValidator.validateOrderForRead(order.getUserId(), userRole, null, currentCompanyUserId, productCompanyUserId);
             }
             default -> throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
         }
@@ -181,7 +181,7 @@ public class OrderServiceImpl implements OrderService {
         if (command.timeDealId() == null) return null;
 
         TimeDealRes timeDeal = timeDealService.getTimeDeal(command.timeDealId(), command.quantity());
-        orderValidator.validateCouponForOrderCreation(timeDeal, command.quantity());
+        orderValidator.validateTimeDealForOrderCreation(timeDeal, command.quantity());
         return timeDeal;
     }
 

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 // 주문 관련 검증을 담당하는 컴포넌트
 @Slf4j
@@ -83,33 +84,32 @@ public class OrderValidator {
 
     // ===== 사용자 검증 =====
     // 사용자 주문 가능 여부 검증
-    public void validateUserOrderable(UserRes user) {
+    public void validateUserForOrderCreation(CustomerUserRes user) {
         validateUserStatus(user);
-        validateUserRoleForOrder(user);
+        validateUserRoleForOrderCreation(user);
     }
 
-    private void validateUserStatus(UserRes user) {
+    private void validateUserStatus(CustomerUserRes user) {
         if (!"ACTIVE".equals(user.getStatus())) {
             throw new BusinessException(OrderErrorCode.INVALID_USER_ID);
         }
     }
 
-    private void validateUserRoleForOrder(UserRes user) {
+    private void validateUserRoleForOrderCreation(CustomerUserRes user) {
         if (UserRole.COMPANY_USER.equals(user.getRole())) {
             throw new BusinessException(OrderErrorCode.USER_NOT_ALLOWED);
         }
     }
 
     // ===== 상품 검증 =====
-    public void validateProductStock(ProductRes product, int requestedQuantity) {
+    public void validateProductForOrderCreation(ProductRes product, int requestedQuantity) {
         if (product.getStockQuantity() < requestedQuantity) {
             throw new BusinessException(OrderErrorCode.INSUFFICIENT_STOCK);
         }
     }
 
     // ===== 타임딜 검증 =====
-    // 상품 재고 검증
-    public void validateTimeDeal(TimeDealRes timeDeal, int requestedQuantity) {
+    public void validateCouponForOrderCreation(TimeDealRes timeDeal, int requestedQuantity) {
         validateTimeDealPeriod(timeDeal);
         validateTimeDealStatus(timeDeal);
         validateTimeDealStock(timeDeal, requestedQuantity);
@@ -143,7 +143,7 @@ public class OrderValidator {
     }
 
     // ===== 쿠폰 검증 =====
-    public void validateCoupon(CouponRes coupon, BigDecimal orderAmount) {
+    public void validateCouponForUsage(CouponRes coupon, BigDecimal orderAmount) {
         validateCouponStatus(coupon);
         validateCouponDiscountType(coupon);   // ← 추가
         validateCouponIssuePeriod(coupon);
@@ -194,6 +194,27 @@ public class OrderValidator {
 
         if (orderAmount == null || orderAmount.compareTo(coupon.getMinOrderAmount()) < 0) {
             throw new BusinessException(OrderErrorCode.COUPON_MIN_AMOUNT_NOT_MET);
+        }
+    }
+
+    public void validateOrderForRead(Long orderUserId, UserRole userRole, Long currentUserId,
+                                     UUID currentCompanyUserId, UUID productCompanyUserId) {
+        switch (userRole) {
+            case MANAGER -> {
+                // 모든 주문 조회 가능
+            }
+            case CUSTOMER -> {
+                if (currentUserId == null || !currentUserId.equals(orderUserId)) {
+                    throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+                }
+            }
+            case COMPANY_USER -> {
+                if (currentCompanyUserId == null || productCompanyUserId == null
+                        || !currentCompanyUserId.equals(productCompanyUserId)) {
+                    throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+                }
+            }
+            default -> throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
         }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
@@ -83,7 +83,7 @@ public class OrderValidator {
     }
 
     // ===== 사용자 검증 =====
-    // 사용자 주문 가능 여부 검증
+    // 주문 생성 시 사용자 검증
     public void validateUserForOrderCreation(CustomerUserRes user) {
         validateUserStatus(user);
         validateUserRoleForOrderCreation(user);
@@ -102,6 +102,7 @@ public class OrderValidator {
     }
 
     // ===== 상품 검증 =====
+    // 주문 생성 시 상품 검증
     public void validateProductForOrderCreation(ProductRes product, int requestedQuantity) {
         if (product.getStockQuantity() < requestedQuantity) {
             throw new BusinessException(OrderErrorCode.INSUFFICIENT_STOCK);
@@ -109,7 +110,8 @@ public class OrderValidator {
     }
 
     // ===== 타임딜 검증 =====
-    public void validateCouponForOrderCreation(TimeDealRes timeDeal, int requestedQuantity) {
+    // 주문 생성 시 타임딜 검증
+    public void validateTimeDealForOrderCreation(TimeDealRes timeDeal, int requestedQuantity) {
         validateTimeDealPeriod(timeDeal);
         validateTimeDealStatus(timeDeal);
         validateTimeDealStock(timeDeal, requestedQuantity);
@@ -143,9 +145,10 @@ public class OrderValidator {
     }
 
     // ===== 쿠폰 검증 =====
+    // 쿠폰 사용 가능 여부 검증 (상태, 타입, 기간, 최소 주문 금액)
     public void validateCouponForUsage(CouponRes coupon, BigDecimal orderAmount) {
         validateCouponStatus(coupon);
-        validateCouponDiscountType(coupon);   // ← 추가
+        validateCouponDiscountType(coupon);
         validateCouponIssuePeriod(coupon);
         validateCouponMinOrderAmount(coupon, orderAmount);
     }
@@ -197,6 +200,13 @@ public class OrderValidator {
         }
     }
 
+    // ===== 주문 조회 권한 검증 =====
+    /**
+     * 주문 조회 시 권한 검증
+     * - MANAGER: 모든 주문 조회 가능
+     * - CUSTOMER: 본인 주문만 조회 가능
+     * - COMPANY_USER: 자신이 판매한 상품의 주문만 조회 가능
+     */
     public void validateOrderForRead(Long orderUserId, UserRole userRole, Long currentUserId,
                                      UUID currentCompanyUserId, UUID productCompanyUserId) {
         switch (userRole) {

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
@@ -7,6 +7,7 @@ import com.palja.order_service.domain.vo.OrderStatus;
 import com.palja.order_service.domain.vo.Recipient;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Where;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -18,6 +19,7 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
+@Where(clause = "deleted_at IS NULL")
 public class Order extends BaseEntity {
 
     @Id
@@ -145,11 +147,10 @@ public class Order extends BaseEntity {
         order.delivery = OrderDelivery.create(order, recipient);
     }
 
-
     // 주문 취소
     public void cancel(String cancelReason, String canceledBy) {
         // 1. 주문 상태 검증
-        if (!this.status.isCancelableCandidate()) {
+        if (!this.status.isOrderCancellable()) {
             throw new IllegalStateException(
                     String.format("취소할 수 없는 주문 상태입니다: %s", this.status.getDescription())
             );
@@ -241,5 +242,19 @@ public class Order extends BaseEntity {
         if (paymentId == null) {
             throw new IllegalArgumentException("결제 ID는 필수입니다.");
         }
+    }
+
+    public OrderItem requireOrderItem() {
+        if (this.orderItem == null) {
+            throw new IllegalStateException("주문 상품 정보가 없습니다.");
+        }
+        return this.orderItem;
+    }
+
+    public OrderDelivery requireDelivery() {
+        if (this.delivery == null) {
+            throw new IllegalStateException("배송 정보가 없습니다.");
+        }
+        return this.delivery;
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/repository/OrderRepository.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/repository/OrderRepository.java
@@ -2,7 +2,12 @@ package com.palja.order_service.domain.repository;
 
 import com.palja.order_service.domain.entity.Order;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface OrderRepository {
 
     Order save(Order order);
+
+    Optional<Order> findOrderByIdWithItemAndDelivery(UUID orderId);
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
@@ -14,7 +14,7 @@ public enum OrderStatus {
         }
 
         @Override
-        public boolean isCancelableCandidate() {
+        public boolean isOrderCancellable() {
             return true;
         }
     },
@@ -31,7 +31,7 @@ public enum OrderStatus {
         }
 
         @Override
-        public boolean isCancelableCandidate() {
+        public boolean isOrderCancellable() {
             return true;
         }
     },
@@ -48,7 +48,7 @@ public enum OrderStatus {
         }
 
         @Override
-        public boolean isCancelableCandidate() {
+        public boolean isOrderCancellable() {
             return true;
         }
     },
@@ -174,7 +174,7 @@ public enum OrderStatus {
      * - CREATED / PAID / PREPARING
      * - 실제 취소 가능 여부는 배송 상태(READY/REQUESTED 이하)까지 같이 확인
      */
-    public boolean isCancelableCandidate() {
+    public boolean isOrderCancellable() {
         return false;
     }
 

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
@@ -1,6 +1,7 @@
 package com.palja.order_service.infrastructure.external;
 
 import com.palja.common.response.ApiResponse;
+import com.palja.order_service.infrastructure.external.dto.response.CompanyUserDTO;
 import com.palja.order_service.infrastructure.external.dto.response.CustomerUserDTO;
 import com.palja.order_service.infrastructure.external.dto.response.ManagerUserDTO;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -17,4 +18,8 @@ public interface UserClient {
     // manager 사용자 정보 조회
     @GetMapping("/managers/{loginId}")
     ApiResponse<ManagerUserDTO> getManagerUserByLoginId(@PathVariable("loginId") String loginId);
+
+    // company-user 사용자 정보 조회
+    @GetMapping("/company-users/{loginId}")
+    ApiResponse<CompanyUserDTO> getCompanyUserByLoginId(@PathVariable("loginId") String loginId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
@@ -34,6 +34,7 @@ public class ProductAdapter implements ProductService {
 
     private ProductRes toProductRes(ProductDTO dto) {
         return ProductRes.of(
+                UUID.fromString("11111111-1111-1111-1111-111111111111"),
                 dto.getProductId(),
                 dto.getName(),
                 dto.getPrice(),

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
@@ -20,7 +20,7 @@ public class ProductAdapter implements ProductService {
      //private final ProductClient productClient;
 
     @Override
-    public ProductRes getProduct(UUID productId, int quantity) {
+    public ProductRes getProduct(UUID productId) {
         log.debug("상품 정보 조회: productId={}", productId);
 
         // TODO: 실제 상품 API 호출 (Feign)

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -1,8 +1,12 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
-import com.palja.order_service.application.dto.UserRes;
+import com.palja.order_service.application.dto.CompanyUserRes;
+import com.palja.order_service.application.dto.CustomerUserRes;
+import com.palja.order_service.application.dto.ManagerUserRes;
 import com.palja.order_service.application.service.UserService;
+import com.palja.order_service.infrastructure.external.dto.response.CompanyUserDTO;
 import com.palja.order_service.infrastructure.external.dto.response.CustomerUserDTO;
+import com.palja.order_service.infrastructure.external.dto.response.ManagerUserDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -16,21 +20,36 @@ public class UserAdapter implements UserService {
     //private final UserClient userClient;
 
     @Override
-    public UserRes getUserByLoginId(String loginId) {
-        log.debug("사용자 조회 요청: loginId={}", loginId);
-        // TODO: 권한에 따라 다른 엔드포인트 연결하기 (MANAGER, CUSTOMER, COMPANY_USER)
-        // TODO: user-service 연동 시 FeignClient 호출 사용
-        // CustomerUserDTO response = userClient.getCustomerUserByLoginId(loginId).data();
-        // ManagerUserDTO response = userClient.getManagerUserByLoginId(loginId).data();
+    public CustomerUserRes getCustomerUserByLoginId(String loginId) {
+        log.debug("고객 사용자 조회 요청: loginId={}", loginId);
+
+        // TODO: user-service 연동 시 FeignClient 호출
+        // CustomerUserDTO dto = userClient.getCustomerUserByLoginId(loginId).getData();
         // TODO: 실제 유저 서비스 연동 시 위의 코드로 교체
         // 임시 더미 데이터
         CustomerUserDTO response = CustomerUserDTO.dummy(loginId);
 
-        return toUserRes(response);
+        return CustomerUserRes.of(
+                response.getUserId(),
+                response.getLoginId(),
+                response.getName(),
+                response.getEmail(),
+                response.getRole(),
+                response.getStatus()
+        );
     }
 
-    private UserRes toUserRes(CustomerUserDTO dto) {
-        return UserRes.of(
+    @Override
+    public ManagerUserRes getManagerUserByLoginId(String loginId) {
+        log.debug("매니저 사용자 조회 요청: loginId={}", loginId);
+
+        // TODO: user-service 연동 시 FeignClient 호출
+        // ManagerUserDTO dto = userClient.getManagerUserByLoginId(loginId).getData();
+        // TODO: 실제 유저 서비스 연동 시 위의 코드로 교체
+        // 임시 더미 데이터
+        ManagerUserDTO dto = ManagerUserDTO.dummy(loginId);
+
+        return ManagerUserRes.of(
                 dto.getUserId(),
                 dto.getLoginId(),
                 dto.getName(),
@@ -40,4 +59,24 @@ public class UserAdapter implements UserService {
         );
     }
 
+    @Override
+    public CompanyUserRes getCompanyUserByLoginId(String loginId) {
+        log.debug("판매업체 사용자 조회 요청: loginId={}", loginId);
+
+        // TODO: user-service 연동 시 FeignClient 호출
+        // CompanyUserDTO dto = userClient.getCompanyUserByLoginId(loginId).getData();
+        // TODO: 실제 유저 서비스 연동 시 위의 코드로 교체
+        // 임시 더미 데이터
+        CompanyUserDTO dto = CompanyUserDTO.dummy(loginId);
+
+        return CompanyUserRes.of(
+                dto.getUserId(),
+                dto.getCompanyUserId(),
+                dto.getLoginId(),
+                dto.getCompanyName(),
+                dto.getEmail(),
+                dto.getRole(),
+                dto.getStatus()
+        );
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CompanyUserDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CompanyUserDTO.java
@@ -3,12 +3,13 @@ package com.palja.order_service.infrastructure.external.dto.response;
 import com.palja.common.vo.UserRole;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CompanyUserDTO {
@@ -31,8 +32,8 @@ public class CompanyUserDTO {
     // TODO: 사용자 서비스 연동 전까지 사용하는 더미 데이터. user-service 연결 후 삭제.
     public static CompanyUserDTO dummy(String loginId) {
         return new CompanyUserDTO(
-                8L,
-                UUID.randomUUID(),
+                100L,
+                UUID.fromString("11111111-1111-1111-1111-111111111111"),
                 loginId,
                 "company",
                 "업체",

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CompanyUserDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CompanyUserDTO.java
@@ -1,0 +1,50 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import com.palja.common.vo.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyUserDTO {
+
+    private Long userId;
+    private UUID companyUserId;
+    private String loginId;
+    private String name;
+    private String companyName;
+    private String companyNumber;
+    private String email;
+    private String address;
+    private UserRole role;
+    private String status;
+    private LocalDateTime createdAt;
+    private String createdBy;
+    private LocalDateTime updatedAt;
+    private String updatedBy;
+
+    // TODO: 사용자 서비스 연동 전까지 사용하는 더미 데이터. user-service 연결 후 삭제.
+    public static CompanyUserDTO dummy(String loginId) {
+        return new CompanyUserDTO(
+                8L,
+                UUID.randomUUID(),
+                loginId,
+                "company",
+                "업체",
+                "123-45-67890",
+                "company@gmail.com",
+                "서울시 강남구 테헤란로 123",
+                UserRole.COMPANY_USER,
+                "PENDING",
+                LocalDateTime.now(),
+                loginId,
+                LocalDateTime.now(),
+                loginId
+        );
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ManagerUserDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ManagerUserDTO.java
@@ -30,7 +30,7 @@ public class ManagerUserDTO {
                 loginId,
                 loginId,
                 loginId + "@example.com",
-                UserRole.CUSTOMER,
+                UserRole.MANAGER,
                 "ACTIVE",
                 LocalDateTime.now(),
                 loginId,

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductDTO.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductDTO {
-
+    // TODO: 상품 단건 조회 시 companyUserId 반환하도록 수정되면 companyUserId 값 추가.
     private UUID productId;
     private String name;
     private String description;

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/TimeDealDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/TimeDealDTO.java
@@ -28,7 +28,7 @@ public class TimeDealDTO {
     public static TimeDealDTO dummy(UUID timeDealId) {
         return new TimeDealDTO(
                 timeDealId,
-                UUID.randomUUID(),
+                UUID.fromString("22222222-2222-2222-2222-222222222222"),
                 LocalDateTime.of(2025, 12, 1, 0, 0),
                 LocalDateTime.of(2025, 12, 10, 23, 59, 59),
                 BigDecimal.valueOf(9900),

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/repository/JpaOrderRepository.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/repository/JpaOrderRepository.java
@@ -2,8 +2,21 @@ package com.palja.order_service.infrastructure.repository;
 
 import com.palja.order_service.domain.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaOrderRepository extends JpaRepository<Order, UUID> {
+
+    @Query("""
+        SELECT o
+        FROM Order o
+        LEFT JOIN FETCH o.orderItem oi
+        LEFT JOIN FETCH o.delivery d
+        WHERE o.orderId = :orderId
+          AND o.deletedAt IS NULL
+    """)
+    Optional<Order> findOrderByIdWithItemAndDelivery(@Param("orderId") UUID orderId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/repository/impl/OrderRepositoryImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/repository/impl/OrderRepositoryImpl.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+import java.util.UUID;
+
 @Repository
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -18,5 +21,10 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Transactional
     public Order save(Order order) {
         return jpaOrderRepository.save(order);
+    }
+
+    @Override
+    public Optional<Order> findOrderByIdWithItemAndDelivery(UUID orderId) {
+        return jpaOrderRepository.findOrderByIdWithItemAndDelivery(orderId);
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
@@ -5,16 +5,16 @@ import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.dto.OrderCreateRes;
+import com.palja.order_service.application.dto.OrderDetailRes;
 import com.palja.order_service.application.service.OrderService;
 import com.palja.order_service.presentation.dto.request.CreateOrderReq;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/orders")
@@ -36,5 +36,15 @@ public class OrderController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response, "주문이 생성되었습니다."));
+    }
+
+    // 주문 상세 조회
+    @GetMapping("/{orderId}")
+    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER, UserRole.COMPANY_USER})
+    public ResponseEntity<ApiResponse<OrderDetailRes>> getOrder(
+            @PathVariable UUID orderId
+    ) {
+        OrderDetailRes response = orderService.getOrder(orderId, CurrentUser.getLoginId(), CurrentUser.getRole());
+        return ResponseEntity.ok(ApiResponse.success(response, "주문이 조회되었습니다."));
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #113 

<br>

## 📌 개요
- 주문 상세 조회 API(`GET /api/v1/orders/{orderId}`)를 구현했습니다.
- 사용자 권한(Customer, Manager, CompanyUser)에 따라 조회 가능한 주문을 제한하는 접근 제어를 적용했습니다.
- 주문 정보(상품, 배송, 금액, 쿠폰, 결제 등)를 포함한 상세 응답 구조를 제공합니다.

<br>

## 🔁 변경 사항

### **Application 레이어**
- 주문 상세 응답 DTO `OrderDetailRes` 추가
- 주문 상세 조회 서비스 로직 추가
- 권한(Customer/Manager/CompanyUser) 기반 조회 검증 적용

---

### **Domain 레이어**
- 주문 엔티티에 `@Where(clause = "deleted_at IS NULL")` 추가하여 소프트 삭제 적용
- 취소 가능 여부 메서드 네이밍 개선

---

### **Infrastructure 레이어**
- fetch join 기반 단건 조회 쿼리 추가 (`findOrderByIdWithItemAndDelivery`)
- UserAdapter 개선: 권한별 사용자 조회(Customer/Manager/CompanyUser) 적용

---

### **Presentation 레이어**
- 주문 상세 조회 API 추가 (`GET /api/v1/orders/{orderId}`)
- `@RequiredRole` 적용하여 권한별 접근 제어 구현
- 조회 성공 시 `OrderDetailRes` 반환

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
- 상품 조회 API 응답에 업체 판매자(companyUserId) 필드를 포함해야 COMPANY_USER 권한 검증이 가능하므로, 상품 서비스 수정이 필요합니다.

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
