### PR TITLE
FEAT/ UserService 업체 판매자 조회, 수정, 삭제 API 구현

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.palja:common-module:0.6.0'
+    implementation 'com.palja:common-module:0.6.1'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/user-service/src/main/java/com/palja/user_service/application/command/UpdateCompanyUserCommand.java
+++ b/user-service/src/main/java/com/palja/user_service/application/command/UpdateCompanyUserCommand.java
@@ -1,0 +1,12 @@
+package com.palja.user_service.application.command;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateCompanyUserCommand(
+
+	String companyName,
+	String address
+
+) {
+}

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserDetailRes.java
@@ -1,6 +1,7 @@
 package com.palja.user_service.application.dto.response;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import com.palja.user_service.domain.entity.CompanyUser;
 
@@ -13,6 +14,7 @@ import lombok.Getter;
 public class ReadCompanyUserDetailRes {
 
 	private Long userId;
+	private UUID companyUserId;
 	private String loginId;
 	private String name;
 	private String companyName;
@@ -29,6 +31,7 @@ public class ReadCompanyUserDetailRes {
 	public static ReadCompanyUserDetailRes from(CompanyUser companyUser) {
 		return ReadCompanyUserDetailRes.builder()
 			.userId(companyUser.getUser().getId())
+			.companyUserId(companyUser.getId())
 			.loginId(companyUser.getUser().getLoginId())
 			.name(companyUser.getUser().getName())
 			.companyName(companyUser.getCompanyName())

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserDetailRes.java
@@ -1,6 +1,6 @@
 package com.palja.user_service.application.dto.response;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.palja.user_service.domain.entity.CompanyUser;
@@ -23,9 +23,9 @@ public class ReadCompanyUserDetailRes {
 	private String address;
 	private String role;
 	private String status;
-	private Instant createdAt;
+	private LocalDateTime createdAt;
 	private String createdBy;
-	private Instant updatedAt;
+	private LocalDateTime updatedAt;
 	private String updatedBy;
 
 	public static ReadCompanyUserDetailRes from(CompanyUser companyUser) {

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserDetailRes.java
@@ -1,0 +1,47 @@
+package com.palja.user_service.application.dto.response;
+
+import java.time.Instant;
+
+import com.palja.user_service.domain.entity.CompanyUser;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class ReadCompanyUserDetailRes {
+
+	private Long userId;
+	private String loginId;
+	private String name;
+	private String companyName;
+	private String companyNumber;
+	private String email;
+	private String address;
+	private String role;
+	private String status;
+	private Instant createdAt;
+	private String createdBy;
+	private Instant updatedAt;
+	private String updatedBy;
+
+	public static ReadCompanyUserDetailRes from(CompanyUser companyUser) {
+		return ReadCompanyUserDetailRes.builder()
+			.userId(companyUser.getUser().getId())
+			.loginId(companyUser.getUser().getLoginId())
+			.name(companyUser.getUser().getName())
+			.companyName(companyUser.getCompanyName())
+			.companyNumber(companyUser.getCompanyNumber())
+			.email(companyUser.getUser().getEmail())
+			.address(companyUser.getUser().getAddress())
+			.role(companyUser.getUser().getRole().name())
+			.status(companyUser.getUser().getStatus().name())
+			.createdAt(companyUser.getUser().getCreatedAt())
+			.createdBy(companyUser.getUser().getCreatedBy())
+			.updatedAt(companyUser.getUser().getUpdatedAt())
+			.updatedBy(companyUser.getUser().getUpdatedBy())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserSummaryRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserSummaryRes.java
@@ -1,0 +1,27 @@
+package com.palja.user_service.application.dto.response;
+
+import com.palja.user_service.domain.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class ReadCompanyUserSummaryRes {
+
+	private String loginId;
+	private String name;
+	private String email;
+	private String status;
+
+	public static ReadCompanyUserSummaryRes from(User user) {
+		return ReadCompanyUserSummaryRes.builder()
+			.loginId(user.getLoginId())
+			.name(user.getName())
+			.email(user.getEmail())
+			.status(user.getStatus().name())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCustomerDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCustomerDetailRes.java
@@ -1,6 +1,6 @@
 package com.palja.user_service.application.dto.response;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import com.palja.user_service.domain.entity.User;
 
@@ -19,9 +19,9 @@ public class ReadCustomerDetailRes {
 	private String address;
 	private String role;
 	private String status;
-	private Instant createdAt;
+	private LocalDateTime createdAt;
 	private String createdBy;
-	private Instant updatedAt;
+	private LocalDateTime updatedAt;
 	private String updatedBy;
 
 	public static ReadCustomerDetailRes from(User user) {

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadManagerDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadManagerDetailRes.java
@@ -1,6 +1,6 @@
 package com.palja.user_service.application.dto.response;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import com.palja.user_service.domain.entity.User;
 
@@ -19,9 +19,9 @@ public class ReadManagerDetailRes {
 	private String address;
 	private String role;
 	private String status;
-	private Instant createdAt;
+	private LocalDateTime createdAt;
 	private String createdBy;
-	private Instant updatedAt;
+	private LocalDateTime updatedAt;
 	private String updatedBy;
 
 	public static ReadManagerDetailRes from(User user) {

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateCompanyUserDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateCompanyUserDetailRes.java
@@ -1,0 +1,50 @@
+package com.palja.user_service.application.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.palja.user_service.domain.entity.CompanyUser;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class UpdateCompanyUserDetailRes {
+
+	private Long userId;
+	private UUID companyUserId;
+	private String loginId;
+	private String name;
+	private String companyName;
+	private String companyNumber;
+	private String email;
+	private String address;
+	private String role;
+	private String status;
+	private Instant createdAt;
+	private String createdBy;
+	private Instant updatedAt;
+	private String updatedBy;
+
+	public static UpdateCompanyUserDetailRes from(CompanyUser companyUser) {
+		return UpdateCompanyUserDetailRes.builder()
+			.userId(companyUser.getUser().getId())
+			.companyUserId(companyUser.getId())
+			.loginId(companyUser.getUser().getLoginId())
+			.name(companyUser.getUser().getName())
+			.companyName(companyUser.getCompanyName())
+			.companyNumber(companyUser.getCompanyNumber())
+			.email(companyUser.getUser().getEmail())
+			.address(companyUser.getUser().getAddress())
+			.role(companyUser.getUser().getRole().name())
+			.status(companyUser.getUser().getStatus().name())
+			.createdAt(companyUser.getUser().getCreatedAt())
+			.createdBy(companyUser.getUser().getCreatedBy())
+			.updatedAt(companyUser.getUser().getUpdatedAt())
+			.updatedBy(companyUser.getUser().getUpdatedBy())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateCompanyUserDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateCompanyUserDetailRes.java
@@ -1,6 +1,6 @@
 package com.palja.user_service.application.dto.response;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.palja.user_service.domain.entity.CompanyUser;
@@ -23,9 +23,9 @@ public class UpdateCompanyUserDetailRes {
 	private String address;
 	private String role;
 	private String status;
-	private Instant createdAt;
+	private LocalDateTime createdAt;
 	private String createdBy;
-	private Instant updatedAt;
+	private LocalDateTime updatedAt;
 	private String updatedBy;
 
 	public static UpdateCompanyUserDetailRes from(CompanyUser companyUser) {

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateCustomerDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateCustomerDetailRes.java
@@ -1,6 +1,6 @@
 package com.palja.user_service.application.dto.response;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import com.palja.user_service.domain.entity.User;
 
@@ -19,9 +19,9 @@ public class UpdateCustomerDetailRes {
 	private String address;
 	private String role;
 	private String status;
-	private Instant createdAt;
+	private LocalDateTime createdAt;
 	private String createdBy;
-	private Instant updatedAt;
+	private LocalDateTime updatedAt;
 	private String updatedBy;
 
 	public static UpdateCustomerDetailRes from(User user) {

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateManagerDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/UpdateManagerDetailRes.java
@@ -1,6 +1,6 @@
 package com.palja.user_service.application.dto.response;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import com.palja.user_service.domain.entity.User;
 
@@ -19,9 +19,9 @@ public class UpdateManagerDetailRes {
 	private String address;
 	private String role;
 	private String status;
-	private Instant createdAt;
+	private LocalDateTime createdAt;
 	private String createdBy;
-	private Instant updatedAt;
+	private LocalDateTime updatedAt;
 	private String updatedBy;
 
 	public static UpdateManagerDetailRes from(User user) {

--- a/user-service/src/main/java/com/palja/user_service/application/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/palja/user_service/application/exception/UserErrorCode.java
@@ -14,6 +14,7 @@ public enum UserErrorCode implements ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
 	DUPLICATED_LOGIN_ID(HttpStatus.CONFLICT, "이미 존재하는 로그인 아이디입니다."),
 	DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+	USER_STATUS_NOT_FOUND(HttpStatus.BAD_REQUEST, "유효하지 않은 상태 값입니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/user-service/src/main/java/com/palja/user_service/application/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/palja/user_service/application/exception/UserErrorCode.java
@@ -15,6 +15,7 @@ public enum UserErrorCode implements ErrorCode {
 	DUPLICATED_LOGIN_ID(HttpStatus.CONFLICT, "이미 존재하는 로그인 아이디입니다."),
 	DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 	USER_STATUS_NOT_FOUND(HttpStatus.BAD_REQUEST, "유효하지 않은 상태 값입니다."),
+	COMPANY_USER_STATUS_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "이미 승인된 업체 판매자입니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -33,5 +33,7 @@ public interface CompanyUserService {
 
 	UpdateCompanyUserDetailRes updateMe(String currentUserLoginId, UpdateCompanyUserCommand command);
 
+	void deleteCompanyByLoginId(String currentUserLoginId, String loginId);
+
 }
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -6,10 +6,12 @@ import org.springframework.data.domain.Pageable;
 
 import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
+import com.palja.user_service.application.command.UpdateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateCompanyUserDetailRes;
 
 public interface CompanyUserService {
 
@@ -26,6 +28,8 @@ public interface CompanyUserService {
 	ReadCompanyUserDetailRes getCustomerByCompanyUserId(String currentUserLoginId, UUID companyUserId);
 
 	ReadCompanyUserDetailRes getMe(String currentUserLoginId);
+
+	UpdateCompanyUserDetailRes updateCompanyUserByLoginId(String currentUserLoginId, String loginId, UpdateCompanyUserCommand command);
 
 }
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -25,5 +25,7 @@ public interface CompanyUserService {
 
 	ReadCompanyUserDetailRes getCustomerByCompanyUserId(String currentUserLoginId, UUID companyUserId);
 
+	ReadCompanyUserDetailRes getMe(String currentUserLoginId);
+
 }
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -35,5 +35,7 @@ public interface CompanyUserService {
 
 	void deleteCompanyByLoginId(String currentUserLoginId, String loginId);
 
+	void deleteMe(String accessToken, String currentUserLoginId);
+
 }
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -1,5 +1,7 @@
 package com.palja.user_service.application.service;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Pageable;
 
 import com.palja.common.response.PageResponse;
@@ -20,6 +22,8 @@ public interface CompanyUserService {
 	);
 
 	ReadCompanyUserDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId);
+
+	ReadCompanyUserDetailRes getCustomerByCompanyUserId(String currentUserLoginId, UUID companyUserId);
 
 }
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -31,5 +31,7 @@ public interface CompanyUserService {
 
 	UpdateCompanyUserDetailRes updateCompanyUserByLoginId(String currentUserLoginId, String loginId, UpdateCompanyUserCommand command);
 
+	UpdateCompanyUserDetailRes updateMe(String currentUserLoginId, UpdateCompanyUserCommand command);
+
 }
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -37,5 +37,7 @@ public interface CompanyUserService {
 
 	void deleteMe(String accessToken, String currentUserLoginId);
 
+	void rejectCompanyUser(String currentUserLoginId, String loginId);
+
 }
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -1,8 +1,12 @@
 package com.palja.user_service.application.service;
 
+import org.springframework.data.domain.Pageable;
+
+import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
 
 public interface CompanyUserService {
 
@@ -10,4 +14,9 @@ public interface CompanyUserService {
 
 	void updateCompanyUserStatus(String currentUserLoginId, String loginId, UpdateCompanyUserStatusCommand command);
 
+	PageResponse<ReadCompanyUserSummaryRes> getAllCompanyUsers(
+		String currentUserLoginId, String loginId, String email, String name, String status, Pageable pageable
+	);
+
 }
+

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -6,6 +6,7 @@ import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
 
 public interface CompanyUserService {
@@ -17,6 +18,8 @@ public interface CompanyUserService {
 	PageResponse<ReadCompanyUserSummaryRes> getAllCompanyUsers(
 		String currentUserLoginId, String loginId, String email, String name, String status, Pageable pageable
 	);
+
+	ReadCompanyUserDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId);
 
 }
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/CompanyUserService.java
@@ -23,9 +23,9 @@ public interface CompanyUserService {
 		String currentUserLoginId, String loginId, String email, String name, String status, Pageable pageable
 	);
 
-	ReadCompanyUserDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId);
+	ReadCompanyUserDetailRes getCompanyUserByLoginId(String currentUserLoginId, String loginId);
 
-	ReadCompanyUserDetailRes getCustomerByCompanyUserId(String currentUserLoginId, UUID companyUserId);
+	ReadCompanyUserDetailRes getCompanyUserByCompanyUserId(String currentUserLoginId, UUID companyUserId);
 
 	ReadCompanyUserDetailRes getMe(String currentUserLoginId);
 
@@ -33,7 +33,7 @@ public interface CompanyUserService {
 
 	UpdateCompanyUserDetailRes updateMe(String currentUserLoginId, UpdateCompanyUserCommand command);
 
-	void deleteCompanyByLoginId(String currentUserLoginId, String loginId);
+	void deleteCompanyUserByLoginId(String currentUserLoginId, String loginId);
 
 	void deleteMe(String accessToken, String currentUserLoginId);
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -155,6 +155,16 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + currentUserLoginId);
 	}
 
+	@Override
+	@Transactional
+	public void rejectCompanyUser(String currentUserLoginId, String loginId) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
+		validateStatusIsPending(companyUser);
+		companyUser.softDelete();
+	}
+
 	private User getUserByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
@@ -188,6 +198,12 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	private void validateDuplicateEmail(String email) {
 		if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
 			throw new BusinessException(UserErrorCode.DUPLICATED_EMAIL);
+		}
+	}
+
+	private void validateStatusIsPending(CompanyUser companyUser) {
+		if (companyUser.getUser().getStatus().equals(UserStatus.ACTIVE)) {
+			throw new BusinessException(UserErrorCode.COMPANY_USER_STATUS_ALREADY_ACTIVE);
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -14,6 +14,7 @@ import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CompanyUserService;
@@ -81,13 +82,26 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		);
 	}
 
+	@Override
+	public ReadCompanyUserDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		return ReadCompanyUserDetailRes.from(getCompanyUserByLoginId(loginId));
+	}
+
 	private User getUserByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
 		);
 	}
 
-	private CompanyUser getCompanyUserById(UUID companyUserId) {
+	private CompanyUser getCompanyUserByLoginId(String loginId) {
+		return companyUserRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
+			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
+		);
+	}
+
+	private CompanyUser getCompanyUserByCompanyUserId(UUID companyUserId) {
 		return companyUserRepository.findByIdAndDeletedAtIsNull(companyUserId).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
 		);

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -125,6 +125,15 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		return UpdateCompanyUserDetailRes.from(companyUser);
 	}
 
+	@Override
+	@Transactional
+	public void deleteCompanyByLoginId(String currentUserLoginId, String loginId) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
+		companyUser.softDelete();
+	}
+
 	private User getUserByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -2,22 +2,26 @@ package com.palja.user_service.application.service.impl;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.palja.common.auditor.AuditorContext;
 import com.palja.common.exception.BusinessException;
+import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CompanyUserService;
 import com.palja.user_service.domain.entity.CompanyUser;
 import com.palja.user_service.domain.entity.User;
 import com.palja.user_service.domain.repository.CompanyUserRepository;
 import com.palja.user_service.domain.repository.UserRepository;
+import com.palja.user_service.domain.vo.UserStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -59,10 +63,22 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	@Override
 	@Transactional
 	public void updateCompanyUserStatus(String currentUserLoginId, String loginId, UpdateCompanyUserStatusCommand command) {
-		getUserByLoginId(currentUserLoginId);
+		validateUserExistsByLoginId(currentUserLoginId);
 
 		User companyUser = getUserByLoginId(loginId);
 		companyUser.updateStatus(command.status());
+	}
+
+	@Override
+	public PageResponse<ReadCompanyUserSummaryRes> getAllCompanyUsers(
+		String currentUserLoginId, String loginId, String email, String name, String status, Pageable pageable
+	) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		return PageResponse.from(
+			userRepository.searchAllCompanyUsers(loginId, email, name, validateAndGetUserStatus(status), pageable)
+				.map(ReadCompanyUserSummaryRes::from)
+		);
 	}
 
 	private User getUserByLoginId(String loginId) {
@@ -77,6 +93,12 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		);
 	}
 
+	private void validateUserExistsByLoginId(String loginId) {
+		if (!userRepository.existsByLoginIdAndDeletedAtIsNull(loginId)) {
+			throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+		}
+	}
+
 	private void validateDuplicateLoginId(String loginId) {
 		if (userRepository.existsByLoginIdAndDeletedAtIsNull(loginId)) {
 			throw new BusinessException(UserErrorCode.DUPLICATED_LOGIN_ID);
@@ -86,6 +108,16 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	private void validateDuplicateEmail(String email) {
 		if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
 			throw new BusinessException(UserErrorCode.DUPLICATED_EMAIL);
+		}
+	}
+
+	private UserStatus validateAndGetUserStatus(String status) {
+		if (status == null) return null;
+
+		try {
+			return UserStatus.valueOf(status.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new BusinessException(UserErrorCode.USER_STATUS_NOT_FOUND);
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -96,6 +96,11 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		return ReadCompanyUserDetailRes.from(getCompanyUserByCompanyUserId(companyUserId));
 	}
 
+	@Override
+	public ReadCompanyUserDetailRes getMe(String currentUserLoginId) {
+		return ReadCompanyUserDetailRes.from(getCompanyUserByLoginId(currentUserLoginId));
+	}
+
 	private User getUserByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -116,6 +116,15 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		return UpdateCompanyUserDetailRes.from(companyUser);
 	}
 
+	@Override
+	@Transactional
+	public UpdateCompanyUserDetailRes updateMe(String currentUserLoginId, UpdateCompanyUserCommand command) {
+		CompanyUser companyUser = getCompanyUserByLoginId(currentUserLoginId);
+		companyUser.update(command.companyName(), command.address());
+
+		return UpdateCompanyUserDetailRes.from(companyUser);
+	}
+
 	private User getUserByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -89,6 +89,13 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		return ReadCompanyUserDetailRes.from(getCompanyUserByLoginId(loginId));
 	}
 
+	@Override
+	public ReadCompanyUserDetailRes getCustomerByCompanyUserId(String currentUserLoginId, UUID companyUserId) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		return ReadCompanyUserDetailRes.from(getCompanyUserByCompanyUserId(companyUserId));
+	}
+
 	private User getUserByLoginId(String loginId) {
 		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
 			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -91,14 +91,14 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	}
 
 	@Override
-	public ReadCompanyUserDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId) {
+	public ReadCompanyUserDetailRes getCompanyUserByLoginId(String currentUserLoginId, String loginId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
 		return ReadCompanyUserDetailRes.from(getCompanyUserByLoginId(loginId));
 	}
 
 	@Override
-	public ReadCompanyUserDetailRes getCustomerByCompanyUserId(String currentUserLoginId, UUID companyUserId) {
+	public ReadCompanyUserDetailRes getCompanyUserByCompanyUserId(String currentUserLoginId, UUID companyUserId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
 		return ReadCompanyUserDetailRes.from(getCompanyUserByCompanyUserId(companyUserId));
@@ -133,7 +133,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 
 	@Override
 	@Transactional
-	public void deleteCompanyByLoginId(String currentUserLoginId, String loginId) {
+	public void deleteCompanyUserByLoginId(String currentUserLoginId, String loginId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
 		CompanyUser companyUser = getCompanyUserByLoginId(loginId);

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.palja.user_service.application.service.impl;
 
+import static com.palja.user_service.application.util.RedisKeyConstants.*;
+
 import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
@@ -20,9 +22,11 @@ import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes
 import com.palja.user_service.application.dto.response.UpdateCompanyUserDetailRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CompanyUserService;
+import com.palja.user_service.application.util.JwtUtil;
 import com.palja.user_service.domain.entity.CompanyUser;
 import com.palja.user_service.domain.entity.User;
 import com.palja.user_service.domain.repository.CompanyUserRepository;
+import com.palja.user_service.domain.repository.TokenRepository;
 import com.palja.user_service.domain.repository.UserRepository;
 import com.palja.user_service.domain.vo.UserStatus;
 
@@ -35,6 +39,8 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	private final CompanyUserRepository companyUserRepository;
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final JwtUtil jwtUtil;
+	private final TokenRepository tokenRepository;
 
 	@Override
 	@Transactional
@@ -132,6 +138,21 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 
 		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
 		companyUser.softDelete();
+	}
+
+	@Override
+	@Transactional
+	public void deleteMe(String accessToken, String currentUserLoginId) {
+		CompanyUser companyUser = getCompanyUserByLoginId(currentUserLoginId);
+		companyUser.softDelete();
+
+		String substringAccessToken = jwtUtil.substringToken(accessToken);
+		String hashKey = jwtUtil.hashingTokenToSHA256(substringAccessToken);
+
+		tokenRepository.save(
+			ACCESS_TOKEN_BLACKLIST_PREFIX + currentUserLoginId + ":" + hashKey, substringAccessToken, jwtUtil.getAccessKeyExpirationTime()
+		);
+		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + currentUserLoginId);
 	}
 
 	private User getUserByLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -12,10 +12,12 @@ import com.palja.common.exception.BusinessException;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
+import com.palja.user_service.application.command.UpdateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateCompanyUserDetailRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CompanyUserService;
 import com.palja.user_service.domain.entity.CompanyUser;
@@ -99,6 +101,19 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	@Override
 	public ReadCompanyUserDetailRes getMe(String currentUserLoginId) {
 		return ReadCompanyUserDetailRes.from(getCompanyUserByLoginId(currentUserLoginId));
+	}
+
+	@Override
+	@Transactional
+	public UpdateCompanyUserDetailRes updateCompanyUserByLoginId(
+		String currentUserLoginId, String loginId, UpdateCompanyUserCommand command
+	) {
+		validateUserExistsByLoginId(currentUserLoginId);
+
+		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
+		companyUser.update(command.companyName(), command.address());
+
+		return UpdateCompanyUserDetailRes.from(companyUser);
 	}
 
 	private User getUserByLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/CompanyUser.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/CompanyUser.java
@@ -1,6 +1,7 @@
 package com.palja.user_service.domain.entity;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.hibernate.annotations.UuidGenerator;
@@ -42,13 +43,13 @@ public class CompanyUser {
 	private String companyNumber;
 
 	@Column(name = "deletedAt")
-	private Instant deletedAt;
+	private LocalDateTime deletedAt;
 
 	@Column(name = "deletedBy", length = 10)
 	private String deletedBy;
 
 	public void softDelete() {
-		this.deletedAt = Instant.now();
+		this.deletedAt = LocalDateTime.now();
 		this.deletedBy = AuditorContext.get().getLoginId();
 		user.softDelete();
 	}

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/CompanyUser.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/CompanyUser.java
@@ -60,6 +60,13 @@ public class CompanyUser {
 		this.companyNumber = companyNumber;
 	}
 
+	public void update(String companyName, String address) {
+		if (companyName != null && !companyName.isBlank()) {
+			this.companyName = companyName;
+		}
+		this.user.update(address);
+	}
+
 	public void updateStatus(String status) {
 		this.user.updateStatus(status);
 	}

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
@@ -65,7 +65,9 @@ public class User extends BaseEntity {
 	}
 
 	public void update(String address) {
-		this.address = address;
+		if (address != null && !address.isBlank()) {
+			this.address = address;
+		}
 	}
 
 	public void updateStatus(String status) {

--- a/user-service/src/main/java/com/palja/user_service/domain/repository/CompanyUserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/repository/CompanyUserRepository.java
@@ -11,4 +11,6 @@ public interface CompanyUserRepository {
 
 	Optional<CompanyUser> findByIdAndDeletedAtIsNull(UUID companyUserId);
 
+	Optional<CompanyUser> findByLoginIdAndDeletedAtIsNull(String loginId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/repository/UserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.domain.entity.User;
+import com.palja.user_service.domain.vo.UserStatus;
 
 public interface UserRepository {
 
@@ -21,6 +22,8 @@ public interface UserRepository {
 	Page<User> searchAllManagers(String loginId, String email, String name, Pageable pageable);
 
 	Page<User> searchAllCustomers(String loginId, String email, String name, Pageable pageable);
+
+	Page<User> searchAllCompanyUsers(String loginId, String email, String name, UserStatus status, Pageable pageable);
 
 	Optional<User> findByLoginIdAndRoleAndDeletedAtIsNull(String loginId, UserRole role);
 

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/DslUserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/DslUserRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.domain.entity.QUser;
 import com.palja.user_service.domain.entity.User;
+import com.palja.user_service.domain.vo.UserStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -60,6 +61,28 @@ public class DslUserRepository {
 		Long total = getTotal(qUser, UserRole.CUSTOMER, loginId, email, name);
 
 		return new PageImpl<>(customers, pageable, total != null ? total : 0);
+	}
+
+	public Page<User> searchAllCompanyUsers(String loginId, String email, String name, UserStatus status, Pageable pageable) {
+		QUser qUser = QUser.user;
+
+		List<User> managers = jpaQueryFactory
+			.selectFrom(qUser)
+			.where(
+				loginId != null ? qUser.loginId.contains(loginId) : null,
+				email != null ? qUser.email.contains(email) : null,
+				name != null ? qUser.name.contains(name) : null,
+				status != null ? qUser.status.eq(status) : null,
+				qUser.role.eq(UserRole.COMPANY_USER),
+				qUser.deletedAt.isNull()
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = getTotal(qUser, UserRole.COMPANY_USER, loginId, email, name);
+
+		return new PageImpl<>(managers, pageable, total != null ? total : 0);
 	}
 
 	private Long getTotal(QUser qUser, UserRole role, String loginId, String email, String name) {

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/DslUserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/DslUserRepository.java
@@ -66,7 +66,7 @@ public class DslUserRepository {
 	public Page<User> searchAllCompanyUsers(String loginId, String email, String name, UserStatus status, Pageable pageable) {
 		QUser qUser = QUser.user;
 
-		List<User> managers = jpaQueryFactory
+		List<User> companyUsers = jpaQueryFactory
 			.selectFrom(qUser)
 			.where(
 				loginId != null ? qUser.loginId.contains(loginId) : null,
@@ -82,7 +82,7 @@ public class DslUserRepository {
 
 		Long total = getTotal(qUser, UserRole.COMPANY_USER, loginId, email, name);
 
-		return new PageImpl<>(managers, pageable, total != null ? total : 0);
+		return new PageImpl<>(companyUsers, pageable, total != null ? total : 0);
 	}
 
 	private Long getTotal(QUser qUser, UserRole role, String loginId, String email, String name) {

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/JpaCompanyUserRepository.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/JpaCompanyUserRepository.java
@@ -20,4 +20,13 @@ public interface JpaCompanyUserRepository extends JpaRepository<CompanyUser, UUI
 	""")
 	Optional<CompanyUser> findByIdAndDeletedAtIsNull(@Param("companyUserId") UUID companyUserId);
 
+	@Query("""
+		SELECT cu
+		FROM CompanyUser cu
+		JOIN FETCH cu.user
+		WHERE cu.user.loginId = :loginId
+		AND cu.deletedAt IS NULL
+	""")
+	Optional<CompanyUser> findByLoginIdAndDeletedAtIsNull(@Param("loginId") String loginId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/impl/CompanyUserRepositoryImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/impl/CompanyUserRepositoryImpl.java
@@ -27,4 +27,9 @@ public class CompanyUserRepositoryImpl implements CompanyUserRepository {
 		return jpaCompanyUserRepository.findByIdAndDeletedAtIsNull(companyUserId);
 	}
 
+	@Override
+	public Optional<CompanyUser> findByLoginIdAndDeletedAtIsNull(String loginId) {
+		return jpaCompanyUserRepository.findByLoginIdAndDeletedAtIsNull(loginId);
+	}
+
 }

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/repository/impl/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/repository/impl/UserRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.domain.entity.User;
 import com.palja.user_service.domain.repository.UserRepository;
+import com.palja.user_service.domain.vo.UserStatus;
 import com.palja.user_service.infrastructure.repository.DslUserRepository;
 import com.palja.user_service.infrastructure.repository.JpaUserRepository;
 
@@ -49,6 +50,11 @@ public class UserRepositoryImpl implements UserRepository {
 	@Override
 	public Page<User> searchAllCustomers(String loginId, String email, String name, Pageable pageable) {
 		return dslUserRepository.searchAllCustomers(loginId, email, name, pageable);
+	}
+
+	@Override
+	public Page<User> searchAllCompanyUsers(String loginId, String email, String name, UserStatus status, Pageable pageable) {
+		return dslUserRepository.searchAllCompanyUsers(loginId, email, name, status, pageable);
 	}
 
 	@Override

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -27,4 +27,6 @@ public interface CompanyUserController {
 
 	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByCompanyUserId(UUID companyUserId);
 
+	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getMe();
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -15,6 +15,8 @@ import com.palja.user_service.presentation.dto.request.CreateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserStatusReq;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 public interface CompanyUserController {
 
 	ResponseEntity<ApiResponse<CreateUserRes>> create(CreateCompanyUserReq requestDto);
@@ -36,5 +38,7 @@ public interface CompanyUserController {
 	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateMe(UpdateCompanyUserReq requestDto);
 
 	ResponseEntity<ApiResponse<Void>> deleteByLoginId(String loginId);
+
+	ResponseEntity<ApiResponse<Void>> deleteMe(String accessToken, HttpServletResponse response);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
 import com.palja.user_service.presentation.dto.request.CreateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserStatusReq;
@@ -19,5 +20,7 @@ public interface CompanyUserController {
 	ResponseEntity<ApiResponse<PageResponse<ReadCompanyUserSummaryRes>>> getAll(
 		String loginId, String email, String name, String status, Pageable pageable
 	);
+
+	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByLoginId(String loginId);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -35,4 +35,6 @@ public interface CompanyUserController {
 
 	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateMe(UpdateCompanyUserReq requestDto);
 
+	ResponseEntity<ApiResponse<Void>> deleteByLoginId(String loginId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -1,5 +1,7 @@
 package com.palja.user_service.presentation.controller;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
@@ -22,5 +24,7 @@ public interface CompanyUserController {
 	);
 
 	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByLoginId(String loginId);
+
+	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByCompanyUserId(UUID companyUserId);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -10,7 +10,9 @@ import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateCompanyUserDetailRes;
 import com.palja.user_service.presentation.dto.request.CreateCompanyUserReq;
+import com.palja.user_service.presentation.dto.request.UpdateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserStatusReq;
 
 public interface CompanyUserController {
@@ -28,5 +30,7 @@ public interface CompanyUserController {
 	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByCompanyUserId(UUID companyUserId);
 
 	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getMe();
+
+	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateByLoginId(String loginId, UpdateCompanyUserReq requestDto);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -41,4 +41,6 @@ public interface CompanyUserController {
 
 	ResponseEntity<ApiResponse<Void>> deleteMe(String accessToken, HttpServletResponse response);
 
+	ResponseEntity<ApiResponse<Void>> reject(String loginId);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -1,9 +1,12 @@
 package com.palja.user_service.presentation.controller;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
 import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
 import com.palja.user_service.presentation.dto.request.CreateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserStatusReq;
 
@@ -12,5 +15,9 @@ public interface CompanyUserController {
 	ResponseEntity<ApiResponse<CreateUserRes>> create(CreateCompanyUserReq requestDto);
 
 	ResponseEntity<ApiResponse<Void>> updateStatus(String loginId, UpdateCompanyUserStatusReq requestDto);
+
+	ResponseEntity<ApiResponse<PageResponse<ReadCompanyUserSummaryRes>>> getAll(
+		String loginId, String email, String name, String status, Pageable pageable
+	);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -33,4 +33,6 @@ public interface CompanyUserController {
 
 	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateByLoginId(String loginId, UpdateCompanyUserReq requestDto);
 
+	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateMe(UpdateCompanyUserReq requestDto);
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -105,4 +105,15 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자 사용자를 조회했습니다."));
 	}
 
+	@Override
+	@RequiredRole({UserRole.COMPANY_USER})
+	@GetMapping("/me")
+	public ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getMe() {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		ReadCompanyUserDetailRes responseDto = companyUserService.getMe(currentUserLoginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자 사용자를 조회했습니다."));
+	}
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -3,7 +3,9 @@ package com.palja.user_service.presentation.controller.impl;
 import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,6 +37,7 @@ import com.palja.user_service.presentation.dto.request.CreateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserStatusReq;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -153,6 +157,28 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 		String currentUserLoginId = CurrentUser.getLoginId();
 
 		companyUserService.deleteCompanyByLoginId(currentUserLoginId, loginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("업체 판매자가 삭제되었습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.COMPANY_USER})
+	@DeleteMapping("/me")
+	public ResponseEntity<ApiResponse<Void>> deleteMe(
+		@RequestHeader("Authorization") String accessToken, HttpServletResponse response
+	) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		companyUserService.deleteMe(accessToken, currentUserLoginId);
+
+		ResponseCookie cookie = ResponseCookie
+			.from("refresh_token", "")
+			.path("/")
+			.httpOnly(true)
+			.secure(false)
+			.maxAge(0)
+			.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("업체 판매자가 삭제되었습니다."));
 	}

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -21,6 +21,7 @@ import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
 import com.palja.user_service.application.service.CompanyUserService;
 import com.palja.user_service.presentation.controller.CompanyUserController;
@@ -78,6 +79,17 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 		);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(pagedResponseDto, "업체 판매자 목록을 조회했습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@GetMapping("/{loginId}")
+	public ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByLoginId(@PathVariable String loginId) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		ReadCompanyUserDetailRes responseDto = companyUserService.getCustomerByLoginId(currentUserLoginId, loginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체판매자 사용자를 조회했습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -133,4 +133,16 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자가 수정되었습니다."));
 	}
 
+	@Override
+	@RequiredRole({UserRole.COMPANY_USER})
+	@PutMapping("/me")
+	public ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateMe(@Valid @RequestBody UpdateCompanyUserReq requestDto) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		UpdateCompanyUserCommand command = UpdateCompanyUserReq.of(requestDto);
+		UpdateCompanyUserDetailRes responseDto = companyUserService.updateMe(currentUserLoginId, command);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자가 수정되었습니다."));
+	}
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -183,4 +183,15 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("업체 판매자가 삭제되었습니다."));
 	}
 
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@DeleteMapping("/{loginId}/reject")
+	public ResponseEntity<ApiResponse<Void>> reject(@PathVariable String loginId) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		companyUserService.rejectCompanyUser(currentUserLoginId, loginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("업체 판매자 가입이 거절되었습니다."));
+	}
+
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -97,7 +97,7 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 	public ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByLoginId(@PathVariable String loginId) {
 		String currentUserLoginId = CurrentUser.getLoginId();
 
-		ReadCompanyUserDetailRes responseDto = companyUserService.getCustomerByLoginId(currentUserLoginId, loginId);
+		ReadCompanyUserDetailRes responseDto = companyUserService.getCompanyUserByLoginId(currentUserLoginId, loginId);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자 사용자를 조회했습니다."));
 	}
@@ -108,7 +108,7 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 	public ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByCompanyUserId(@PathVariable UUID companyUserId) {
 		String currentUserLoginId = CurrentUser.getLoginId();
 
-		ReadCompanyUserDetailRes responseDto = companyUserService.getCustomerByCompanyUserId(currentUserLoginId, companyUserId);
+		ReadCompanyUserDetailRes responseDto = companyUserService.getCompanyUserByCompanyUserId(currentUserLoginId, companyUserId);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자 사용자를 조회했습니다."));
 	}
@@ -156,7 +156,7 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 	public ResponseEntity<ApiResponse<Void>> deleteByLoginId(@PathVariable String loginId) {
 		String currentUserLoginId = CurrentUser.getLoginId();
 
-		companyUserService.deleteCompanyByLoginId(currentUserLoginId, loginId);
+		companyUserService.deleteCompanyUserByLoginId(currentUserLoginId, loginId);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("업체 판매자가 삭제되었습니다."));
 	}

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -1,5 +1,7 @@
 package com.palja.user_service.presentation.controller.impl;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -89,7 +91,18 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 
 		ReadCompanyUserDetailRes responseDto = companyUserService.getCustomerByLoginId(currentUserLoginId, loginId);
 
-		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체판매자 사용자를 조회했습니다."));
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자 사용자를 조회했습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@GetMapping("/internal/{companyUserId}")
+	public ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByCompanyUserId(@PathVariable UUID companyUserId) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		ReadCompanyUserDetailRes responseDto = companyUserService.getCustomerByCompanyUserId(currentUserLoginId, companyUserId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자 사용자를 조회했습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -143,6 +144,17 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 		UpdateCompanyUserDetailRes responseDto = companyUserService.updateMe(currentUserLoginId, command);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자가 수정되었습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@DeleteMapping("/{loginId}")
+	public ResponseEntity<ApiResponse<Void>> deleteByLoginId(@PathVariable String loginId) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		companyUserService.deleteCompanyByLoginId(currentUserLoginId, loginId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("업체 판매자가 삭제되었습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -21,13 +21,16 @@ import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
+import com.palja.user_service.application.command.UpdateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
 import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
+import com.palja.user_service.application.dto.response.UpdateCompanyUserDetailRes;
 import com.palja.user_service.application.service.CompanyUserService;
 import com.palja.user_service.presentation.controller.CompanyUserController;
 import com.palja.user_service.presentation.dto.request.CreateCompanyUserReq;
+import com.palja.user_service.presentation.dto.request.UpdateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserStatusReq;
 
 import jakarta.validation.Valid;
@@ -114,6 +117,20 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 		ReadCompanyUserDetailRes responseDto = companyUserService.getMe(currentUserLoginId);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자 사용자를 조회했습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@PutMapping("/{loginId}")
+	public ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateByLoginId(
+		@PathVariable String loginId, @Valid @RequestBody UpdateCompanyUserReq requestDto
+	) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		UpdateCompanyUserCommand command = UpdateCompanyUserReq.of(requestDto);
+		UpdateCompanyUserDetailRes responseDto = companyUserService.updateCompanyUserByLoginId(currentUserLoginId, loginId, command);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responseDto, "업체 판매자가 수정되었습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/impl/CompanyUserControllerImpl.java
@@ -1,22 +1,27 @@
 package com.palja.user_service.presentation.controller.impl;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.palja.common.annotation.RequiredAnonymous;
 import com.palja.common.annotation.RequiredRole;
 import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.user_service.application.command.CreateCompanyUserCommand;
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 import com.palja.user_service.application.dto.response.CreateUserRes;
+import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes;
 import com.palja.user_service.application.service.CompanyUserService;
 import com.palja.user_service.presentation.controller.CompanyUserController;
 import com.palja.user_service.presentation.dto.request.CreateCompanyUserReq;
@@ -43,7 +48,7 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 	}
 
 	@Override
-	@RequiredRole({UserRole.MASTER, UserRole.MANAGER})
+	@RequiredRole({UserRole.MANAGER})
 	@PutMapping("/{loginId}/status")
 	public ResponseEntity<ApiResponse<Void>> updateStatus(
 		@PathVariable("loginId") String loginId, @Valid @RequestBody UpdateCompanyUserStatusReq requestDto
@@ -54,6 +59,25 @@ public class CompanyUserControllerImpl implements CompanyUserController {
 		companyUserService.updateCompanyUserStatus(currentUserLoginId, loginId, command);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("업체 판매자의 상태가 수정되었습니다."));
+	}
+
+	@Override
+	@RequiredRole({UserRole.MANAGER})
+	@GetMapping
+	public ResponseEntity<ApiResponse<PageResponse<ReadCompanyUserSummaryRes>>> getAll(
+		@RequestParam(required = false) String loginId,
+		@RequestParam(required = false) String email,
+		@RequestParam(required = false) String name,
+		@RequestParam(required = false) String status,
+		Pageable pageable
+	) {
+		String currentUserLoginId = CurrentUser.getLoginId();
+
+		PageResponse<ReadCompanyUserSummaryRes> pagedResponseDto = companyUserService.getAllCompanyUsers(
+			currentUserLoginId, loginId, email, name, status, pageable
+		);
+
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(pagedResponseDto, "업체 판매자 목록을 조회했습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCompanyUserReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCompanyUserReq.java
@@ -1,0 +1,23 @@
+package com.palja.user_service.presentation.dto.request;
+
+import com.palja.user_service.application.command.UpdateCompanyUserCommand;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateCompanyUserReq {
+
+	private String companyName;
+	private String address;
+
+	public static UpdateCompanyUserCommand of(UpdateCompanyUserReq requestDto) {
+		return UpdateCompanyUserCommand.builder()
+			.companyName(requestDto.getCompanyName())
+			.address(requestDto.getAddress())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCustomerReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCustomerReq.java
@@ -2,7 +2,6 @@ package com.palja.user_service.presentation.dto.request;
 
 import com.palja.user_service.application.command.UpdateCustomerCommand;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UpdateCustomerReq {
 
-	@NotBlank(message = "주소를 입력해주세요.")
 	private String address;
 
 	public static UpdateCustomerCommand of(UpdateCustomerReq requestDto) {

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateManagerReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateManagerReq.java
@@ -2,7 +2,6 @@ package com.palja.user_service.presentation.dto.request;
 
 import com.palja.user_service.application.command.UpdateManagerCommand;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UpdateManagerReq {
 
-	@NotBlank(message = "주소를 입력해주세요.")
 	private String address;
 
 	public static UpdateManagerCommand of(UpdateManagerReq requestDto) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #106 

<br>

## 📌 개요
- 업체 판매자 조회, 수정, 삭제 API를 구현했습니다.

<br>

## 🔁 변경 사항
- 조회
  - 목록 조회 : 검색 및 페이징을 통해 업체 판매자 목록을 조회할 수 있습니다.
  - 단건 조회(loginId) : loginId로 업체 판매자의 상세 정보를 조회할 수 있습니다.
  - 단건 조회(companyUserId) : companyUserId로 업체 판매자의 상세 정보를 조회할 수 있습니다.
  - 단건 조회(me) : 로그인한 업체 판매자가 자신의 상세 정보를 조회할 수 있습니다.
- 수정
  - 수정(loginId) : loginId로 업체 판매자의 정보를 수정할 수 있습니다. (현재 address 필드만 변경할 수 있도록 해놓은 상태입니다.)
  - 수정(me) : 로그인한 업체 판매자가 자신의 정보를 수정할 수 있습니다. (현재 address 필드만 변경할 수 있도록 해놓은 상태입니다.)
- 삭제
  - 삭제(loginId) : loginId로 업체 판매자를 삭제할 수 있습니다.
  - 삭제(me) : 로그인한 업체 판매자가 자신을 삭제할 수 있습니다. (액세스 토큰을 레디스에 블랙리스트에 등록하고 리프레시 토큰을 레디스에서 삭제합니다.)
  - 삭제(가입 거절) : 업체 판매자의 가입을 거절하여 생성된 업체 판매자를 삭제할 수 있습니다.
- createdAt, updatedAt, deletedAt의 타입을 LocalDateTime으로 변경했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
업체 판매자도 마찬가지로 개선할 점은 리팩토링할 때 개선해보겠습니다!

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
