### PR TITLE
FEAT/내부용 타임딜 재고 차감 API 구현

### DIFF
--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/DecreaseRemainingQuantityCommand.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/DecreaseRemainingQuantityCommand.java
@@ -1,0 +1,12 @@
+package com.palja.timedeal_service.application.command;
+
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record DecreaseRemainingQuantityCommand(
+        UUID timeDealId,
+        long deltaQuantity
+) {
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
@@ -2,6 +2,7 @@ package com.palja.timedeal_service.application.service;
 
 import com.palja.timedeal_service.application.command.ChangeTimeDealStatusCommand;
 import com.palja.timedeal_service.application.command.CreateTimeDealCommand;
+import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
 import com.palja.timedeal_service.application.command.UpdateTimeDealCommand;
 import com.palja.timedeal_service.application.dto.TimeDealDetailRes;
 
@@ -12,4 +13,5 @@ public interface TimeDealService {
     TimeDealDetailRes getTimeDeal(UUID timeDealId);
     TimeDealDetailRes updateTimeDeal(UpdateTimeDealCommand command);
     TimeDealDetailRes changeTimeDealStatus(ChangeTimeDealStatusCommand command);
+    void decreaseRemainingQuantity(DecreaseRemainingQuantityCommand command);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -5,6 +5,7 @@ import com.palja.common.exception.CommonErrorCode;
 import com.palja.common.vo.UserRole;
 import com.palja.timedeal_service.application.command.ChangeTimeDealStatusCommand;
 import com.palja.timedeal_service.application.command.CreateTimeDealCommand;
+import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
 import com.palja.timedeal_service.application.command.UpdateTimeDealCommand;
 import com.palja.timedeal_service.application.dto.TimeDealDetailRes;
 import com.palja.timedeal_service.application.dto.external.ProductInfo;
@@ -103,10 +104,28 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         TimeDealStatus newStatus = parseTimeDealStatus(command.newStatus());
 
-        timeDeal.changeStatus(newStatus, command.reason());
+        if (newStatus == TimeDealStatus.OPEN) {
+            timeDeal.openNow(command.reason());
+        }
+        else if (newStatus == TimeDealStatus.CLOSED) {
+            timeDeal.closeNow(command.reason());
+        }
+        else {
+            timeDeal.changeStatus(newStatus, command.reason());
+        }
 
         log.info("타임딜 상태 수정 완료");
         return TimeDealDetailRes.from(timeDeal);
+    }
+
+    @Override
+    @Transactional
+    public void decreaseRemainingQuantity(DecreaseRemainingQuantityCommand command) {
+        log.info("타임딜 남은 수량 차감 시작");
+
+        TimeDeal timeDeal = getActiveTimeDeal(command.timeDealId());
+
+        timeDeal.decreaseRemainingQuantity(command.deltaQuantity());
     }
 
     private void updateTimeDealFields(TimeDeal timeDeal, UpdateTimeDealCommand command) {

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -44,7 +44,7 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         ProductInfo product = productClient.getProduct(command.productId());
 
-        ValidateCompanyUser(command.role(), command.loginId(), product.companyUserId());
+        validateCompanyUser(command.role(), command.loginId(), product.companyUserId());
 
         timeDealValidator.validateStock(command.totalQuantity(), product.stock());
 
@@ -85,7 +85,7 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         TimeDeal timeDeal = getActiveTimeDeal(command.timeDealId());
 
-        ValidateCompanyUser(command.role(), command.loginId(), timeDeal.getCompanyUserId());
+        validateCompanyUser(command.role(), command.loginId(), timeDeal.getCompanyUserId());
 
         updateTimeDealFields(timeDeal, command);
 
@@ -100,7 +100,7 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         TimeDeal timeDeal = getActiveTimeDeal(command.timeDealId());
 
-        ValidateCompanyUser(command.role(), command.loginId(), timeDeal.getCompanyUserId());
+        validateCompanyUser(command.role(), command.loginId(), timeDeal.getCompanyUserId());
 
         TimeDealStatus newStatus = parseTimeDealStatus(command.newStatus());
 
@@ -167,7 +167,7 @@ public class TimeDealServiceImpl implements TimeDealService {
                 .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
     }
 
-    private void ValidateCompanyUser(UserRole role, String loginId, UUID ownerCompanyUserId) {
+    private void validateCompanyUser(UserRole role, String loginId, UUID ownerCompanyUserId) {
         if (role.equals(UserRole.COMPANY_USER)) {
             timeDealValidator.validateCompanyUserId(loginId, ownerCompanyUserId);
         }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/common/TimeDealErrorCode.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/common/TimeDealErrorCode.java
@@ -28,6 +28,10 @@ public enum TimeDealErrorCode implements ErrorCode {
     // 재고 관련
     INVALID_TOTAL_QUANTITY(HttpStatus.BAD_REQUEST, "타임딜 재고는 0보다 커야 합니다."),
     INVALID_STOCK_QUANTITY(HttpStatus.BAD_REQUEST, "타임딜 재고는 상품의 실제 재고를 초과할 수 없습니다."),
+    INVALID_TOTAL_QUANTITY_UPDATE(HttpStatus.BAD_REQUEST, "이미 판매된 수량보다 적은 총 수량으로 변경할 수 없습니다."),
+    INVALID_REMAINING_QUANTITY(HttpStatus.BAD_REQUEST, "남은 수량이 총 수량 범위를 벗어났습니다."),
+    TIME_DEAL_INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "잘못된 차감 수량이 요청되었습니다."),
+    TIME_DEAL_OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "요청 수량만큼 재고가 남아있지 않습니다."),
 
     // 수정 관련
     TIME_DEAL_NOT_EDITABLE(HttpStatus.BAD_REQUEST, "타임딜을 수정할 수 없는 상태입니다."),
@@ -39,7 +43,9 @@ public enum TimeDealErrorCode implements ErrorCode {
 
     // 외부 관련
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
-    COMPANY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "업체 판매자를 찾을 수 없습니다.");
+    COMPANY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "업체 판매자를 찾을 수 없습니다."),
+    TIME_DEAL_NOT_OPEN(HttpStatus.BAD_REQUEST, "OPEN 상태의 타임딜만 재고 차감이 가능합니다."),
+    TIME_DEAL_NOT_IN_PERIOD(HttpStatus.BAD_REQUEST, "현재 시간에 재고 차감을 수행할 수 없는 타임딜입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
@@ -77,7 +77,7 @@ public class TimeDeal extends BaseEntity {
             Amount amount,
             Quantity quantity
     ) {
-        validate(productId, companyUserId, title, description);
+        validate(productId, companyUserId, title, description, period);
 
         TimeDeal timeDeal = TimeDeal.builder()
                 .productId(productId)
@@ -128,11 +128,40 @@ public class TimeDeal extends BaseEntity {
         this.timeDealStatus = newStatus;
     }
 
+    public void openNow(String reason) {
+        this.period = this.period.updateStartAt(LocalDateTime.now());
+
+        changeStatus(TimeDealStatus.OPEN, reason);
+    }
+
+    public void closeNow(String reason) {
+        this.period = this.period.updateEndAt(LocalDateTime.now());
+
+        changeStatus(TimeDealStatus.CLOSED, reason);
+    }
+
+    public void decreaseRemainingQuantity(long deltaQuantity) {
+        if (this.timeDealStatus != TimeDealStatus.OPEN) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_NOT_OPEN);
+        }
+
+        if (!period.isNowWithin(LocalDateTime.now())) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_NOT_IN_PERIOD);
+        }
+
+        this.timeDealStock.decreaseRemainingQuantity(deltaQuantity);
+
+        if (this.timeDealStock.getQuantity().isSoldOut()) {
+            this.timeDealStatus = TimeDealStatus.SOLD_OUT;
+        }
+    }
+
     private static void validate(
             UUID productId,
             UUID companyUserId,
             String title,
-            String description
+            String description,
+            Period period
     ) {
         if (productId == null) {
             throw new BusinessException(TimeDealErrorCode.PRODUCT_ID_REQUIRED);
@@ -144,6 +173,7 @@ public class TimeDeal extends BaseEntity {
 
         validateTitle(title);
         validateDescription(description);
+        validatePeriodForCreate(period);
     }
 
     private static void validateTitle(String title) {
@@ -155,6 +185,16 @@ public class TimeDeal extends BaseEntity {
     private static void validateDescription(String description) {
         if (description == null || description.isBlank()) {
             throw new BusinessException(TimeDealErrorCode.DESCRIPTION_REQUIRED);
+        }
+    }
+
+    private static void validatePeriodForCreate(Period period) {
+        if (period == null) {
+            throw new BusinessException(TimeDealErrorCode.PERIOD_REQUIRED);
+        }
+
+        if (!period.getStartAt().isAfter(LocalDateTime.now())) {
+            throw new BusinessException(TimeDealErrorCode.PERIOD_START_TIME_INVALID);
         }
     }
 

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDealStock.java
@@ -1,6 +1,8 @@
 package com.palja.timedeal_service.domain.entity;
 
 import com.palja.common.entity.BaseEntity;
+import com.palja.common.exception.BusinessException;
+import com.palja.timedeal_service.common.TimeDealErrorCode;
 import com.palja.timedeal_service.domain.vo.Quantity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -38,5 +40,9 @@ public class TimeDealStock extends BaseEntity {
 
     public void changeTotalQuantity(long newTotalQuantity) {
         this.quantity = this.quantity.updateTotalQuantity(newTotalQuantity);
+    }
+
+    public void decreaseRemainingQuantity(long deltaQuantity) {
+        this.quantity = this.quantity.decreaseRemainingQuantity(deltaQuantity);
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/Period.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/Period.java
@@ -40,13 +40,14 @@ public class Period {
         return new Period(this.startAt, newEndAt);
     }
 
+    public boolean isNowWithin(LocalDateTime now) {
+        return (now.isEqual(startAt) || now.isAfter(startAt))
+                && (now.isEqual(endAt) || now.isBefore(endAt));
+    }
+
     private void validate(LocalDateTime startAt, LocalDateTime endAt) {
         if (startAt == null || endAt == null) {
             throw new BusinessException(TimeDealErrorCode.PERIOD_REQUIRED);
-        }
-
-        if(!startAt.isAfter(LocalDateTime.now())) {
-            throw new BusinessException(TimeDealErrorCode.PERIOD_START_TIME_INVALID);
         }
 
         if (endAt.isBefore(startAt)) {

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/Quantity.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/Quantity.java
@@ -21,10 +21,18 @@ public class Quantity {
 
 
     private Quantity(long totalQuantity) {
-        validate(totalQuantity);
+        validateTotalQuantity(totalQuantity);
 
         this.totalQuantity = totalQuantity;
         this.remainingQuantity = totalQuantity;
+    }
+
+    private Quantity(long totalQuantity, long remainingQuantity) {
+        validateTotalQuantity(totalQuantity);
+        validateRemainingQuantity(totalQuantity, remainingQuantity);
+
+        this.totalQuantity = totalQuantity;
+        this.remainingQuantity = remainingQuantity;
     }
 
     public static Quantity of(long totalQuantity) {
@@ -32,12 +40,46 @@ public class Quantity {
     }
 
     public Quantity updateTotalQuantity(long newTotalQuantity) {
-        return new Quantity(newTotalQuantity);
+        long soldQuantity = this.totalQuantity - this.remainingQuantity;
+
+        if (newTotalQuantity < soldQuantity) {
+            throw new BusinessException(TimeDealErrorCode.INVALID_TOTAL_QUANTITY_UPDATE);
+        }
+
+        long newRemaining = newTotalQuantity - soldQuantity;
+
+        return new Quantity(newTotalQuantity, newRemaining);
     }
 
-    private void validate(long totalQuantity) {
+    public Quantity decreaseRemainingQuantity(long deltaQuantity) {
+        validateDecreaseRemainingQuantity(deltaQuantity);
+
+        return new Quantity(this.totalQuantity, this.remainingQuantity - deltaQuantity);
+    }
+
+    public boolean isSoldOut() {
+        return this.remainingQuantity == 0;
+    }
+
+    private void validateTotalQuantity(long totalQuantity) {
         if (totalQuantity <= 0) {
             throw new BusinessException(TimeDealErrorCode.INVALID_TOTAL_QUANTITY);
+        }
+    }
+
+    private void validateRemainingQuantity(long totalQuantity, long remainingQuantity) {
+        if (remainingQuantity < 0 || remainingQuantity > totalQuantity) {
+            throw new BusinessException(TimeDealErrorCode.INVALID_REMAINING_QUANTITY);
+        }
+    }
+
+    private void validateDecreaseRemainingQuantity(long deltaQuantity) {
+        if (deltaQuantity <= 0) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_INVALID_QUANTITY);
+        }
+
+        if (this.remainingQuantity < deltaQuantity) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_OUT_OF_STOCK);
         }
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
@@ -6,16 +6,17 @@ import com.palja.common.response.ApiResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.timedeal_service.application.command.ChangeTimeDealStatusCommand;
 import com.palja.timedeal_service.application.command.CreateTimeDealCommand;
+import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
 import com.palja.timedeal_service.application.command.UpdateTimeDealCommand;
 import com.palja.timedeal_service.application.dto.TimeDealDetailRes;
 import com.palja.timedeal_service.application.service.TimeDealService;
 import com.palja.timedeal_service.presentation.dto.request.ChangeTimeDealStatusReq;
 import com.palja.timedeal_service.presentation.dto.request.CreateTimeDealReq;
+import com.palja.timedeal_service.presentation.dto.request.DecreaseRemainingQuantityReq;
 import com.palja.timedeal_service.presentation.dto.request.UpdateTimeDealReq;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -87,5 +88,20 @@ public class TimeDealController {
 
         log.info("타임딜 상태 변경 성공: timeDealId = {}", res.getTimeDealId());
         return ResponseEntity.ok(ApiResponse.success(res, "타임딜 상태 변경에 성공했습니다."));
+    }
+
+    @PutMapping("/{timeDealId}/stock/decrease")
+    public ResponseEntity<Void> decreaseRemainingQuantity(
+            @PathVariable UUID timeDealId,
+            @RequestBody @Valid DecreaseRemainingQuantityReq req
+    ) {
+        log.info("PUT api/v1/time-deals/{}/stock/decrease 타임딜 남은 재고 차감 요청", timeDealId);
+
+        DecreaseRemainingQuantityCommand command = req.toCommand(timeDealId);
+
+        timeDealService.decreaseRemainingQuantity(command);
+
+        log.info("타임딜 남은 재고 차감 성공");
+        return ResponseEntity.noContent().build();
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/dto/request/DecreaseRemainingQuantityReq.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/dto/request/DecreaseRemainingQuantityReq.java
@@ -1,0 +1,24 @@
+package com.palja.timedeal_service.presentation.dto.request;
+
+import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class DecreaseRemainingQuantityReq {
+    @NotNull
+    @Positive(message = "타임딜 재고의 감소 수량은 0보다 커야 합니다.")
+    long deltaQuantity;
+
+    public DecreaseRemainingQuantityCommand toCommand(UUID timeDealId) {
+        return DecreaseRemainingQuantityCommand.builder()
+                .timeDealId(timeDealId)
+                .deltaQuantity(deltaQuantity)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #116

<br>

## 📌 개요
- 내부용 타임딜 재고 차감 API 구현

<br>

## 🔁 변경 사항
- 타임딜 재고 차감 로직 작성
    - 타임딜 존재 여부 검증
    - 타임딜 상태 검증 (OPEN 일 때만 허용)
    - 타임딜 기간 검증 (startAt ~ endAt 사이만 허용)
    - 남은 재고 검증 (remainingQuantity >= 요청 수량)
    - 남은 재고가 0일 때 타임딜 상태 자동 전환 (SOLD_OUT)

- Quantity 생성 객체 개선
- Period 객체 검증 개선
- TimeDeal 생성, 상태 변경 관련 로직 개선


<br>

## 📸 스크린샷

<details>
  <summary>타임딜 재고 차감 성공</summary>
<img width="947" height="443" alt="image" src="https://github.com/user-attachments/assets/4f592ea3-076d-4b72-9c9a-8a87223b0f12" />
</details>

<br>

## 👀 기타 더 이야기해볼 점


<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
