### PR TITLE
FEAT/사용자 쿠폰 조회 기능 구현

### DIFF
--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponUserDetailRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponUserDetailRes.java
@@ -1,0 +1,53 @@
+package com.palja.coupon_service.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.palja.coupon_service.domain.entity.Coupon;
+import com.palja.coupon_service.domain.entity.CouponUser;
+import com.palja.coupon_service.domain.vo.CouponUserStatus;
+import com.palja.coupon_service.domain.vo.DiscountType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CouponUserDetailRes {
+    private UUID couponUserId;
+    private UUID couponId;
+    private String userId;
+    private String couponName;
+    private String couponDescription;
+    private DiscountType discountType;
+    private Integer discountValue;
+    private Integer maxDiscountAmount;
+    private Integer minOrderAmount;
+    private LocalDateTime expireAt;
+    private CouponUserStatus status;
+    private LocalDateTime usedAt;
+    private UUID orderId;
+    private Long discountAmount;
+
+    public static CouponUserDetailRes from(CouponUser couponUser) {
+        Coupon coupon = couponUser.getCoupon();
+
+        return CouponUserDetailRes.builder()
+                .couponUserId(couponUser.getId())
+                .couponId(coupon.getId())
+                .userId(couponUser.getUserId())
+                .couponName(coupon.getName())
+                .couponDescription(coupon.getDescription())
+                .discountType(coupon.getDiscountPolicy().getDiscountType())
+                .discountValue(coupon.getDiscountPolicy().getDiscountValue())
+                .maxDiscountAmount(coupon.getAmountPolicy().getMaxDiscountAmount())
+                .minOrderAmount(coupon.getAmountPolicy().getMinOrderAmount())
+                .expireAt(couponUser.getExpireAt())
+                .status(couponUser.getStatus())
+                .usedAt(couponUser.getUsedAt())
+                .orderId(couponUser.getOrderId())
+                .discountAmount(couponUser.getDiscountAmount())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/CouponUserRes.java
@@ -1,7 +1,9 @@
 package com.palja.coupon_service.application.dto;
 
+import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import com.palja.coupon_service.domain.vo.CouponUserStatus;
+import com.palja.coupon_service.domain.vo.DiscountType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,14 +16,22 @@ public class CouponUserRes {
     private UUID couponUserId;
     private UUID couponId;
     private String userId;
+    private String couponName;
+    private DiscountType discountType;
+    private Integer discountValue;
     private LocalDateTime expireAt;
     private CouponUserStatus status;
 
     public static CouponUserRes from(CouponUser couponUser) {
+        Coupon coupon = couponUser.getCoupon();
+
         return CouponUserRes.builder()
                 .couponUserId(couponUser.getId())
-                .couponId(couponUser.getCouponId())
+                .couponId(coupon.getId())
                 .userId(couponUser.getUserId())
+                .couponName(couponUser.getCoupon().getName())
+                .discountType(coupon.getDiscountPolicy().getDiscountType())
+                .discountValue(coupon.getDiscountPolicy().getDiscountValue())
                 .expireAt(couponUser.getExpireAt())
                 .status(couponUser.getStatus())
                 .build();

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
@@ -1,12 +1,17 @@
 package com.palja.coupon_service.application.service;
 
 import com.palja.coupon_service.application.command.IssueCouponCommand;
+import com.palja.coupon_service.application.dto.CouponUserDetailRes;
 import com.palja.coupon_service.application.dto.CouponUserRes;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
 
 public interface CouponService {
     CouponUserRes issueCoupon(IssueCouponCommand command);
 
     Page<CouponUserRes> getCouponList(String userId, Pageable pageable);
+
+    CouponUserDetailRes getCouponDetail(UUID couponUserId, String userId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
@@ -2,7 +2,11 @@ package com.palja.coupon_service.application.service;
 
 import com.palja.coupon_service.application.command.IssueCouponCommand;
 import com.palja.coupon_service.application.dto.CouponUserRes;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CouponService {
     CouponUserRes issueCoupon(IssueCouponCommand command);
+
+    Page<CouponUserRes> getCouponList(String userId, Pageable pageable);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
@@ -2,6 +2,7 @@ package com.palja.coupon_service.application.service.impl;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.coupon_service.application.command.IssueCouponCommand;
+import com.palja.coupon_service.application.dto.CouponUserDetailRes;
 import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.application.service.CouponService;
 import com.palja.coupon_service.domain.entity.Coupon;
@@ -16,7 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -49,9 +50,20 @@ public class CouponServiceImpl implements CouponService {
     @Override
     @Transactional(readOnly = true)
     public Page<CouponUserRes> getCouponList(String userId, Pageable pageable) {
-        log.info("쿠폰 발급 시작 userId={}", userId);
+        log.info("쿠폰 목록 조회 시작 userId={}", userId);
         return couponUserRepository.findAllByUserIdAndDeletedAtIsNull(userId, pageable)
                 .map(CouponUserRes::from);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CouponUserDetailRes getCouponDetail(UUID couponUserId, String userId) {
+        log.info("쿠폰 상세 조회 시작 couponId={} userId={}", couponUserId, userId);
+
+        CouponUser couponUser = couponUserRepository.findByIdAndUserIdAndDeletedAtIsNull(couponUserId, userId)
+                .orElseThrow(() -> new BusinessException(CouponErrorCode.USER_COUPON_NOT_FOUND));
+
+        return CouponUserDetailRes.from(couponUser);
     }
 
     // 쿠폰 발급 검증

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
@@ -73,7 +73,7 @@ public class CouponServiceImpl implements CouponService {
 
         coupon.validateIssuePeriod();
 
-        if (couponUserRepository.existsByCouponIdAndUserIdAndDeletedAtIsNull(coupon.getId(), userId))
+        if (couponUserRepository.existsByCoupon_IdAndUserIdAndDeletedAtIsNull(coupon.getId(), userId))
             throw new BusinessException(CouponErrorCode.DUPLICATE_COUPON_ISSUE);
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
@@ -11,6 +11,8 @@ import com.palja.coupon_service.domain.repository.CouponUserRepository;
 import com.palja.coupon_service.exception.CouponErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,19 +38,20 @@ public class CouponServiceImpl implements CouponService {
 
         coupon.increaseIssuedQuantity();
 
-        CouponUser couponUser = CouponUser.issue(coupon.getId(), command.userId(), calculateExpireAt(coupon));
+        CouponUser couponUser = CouponUser.issue(coupon, command.userId());
 
         CouponUser issuedCoupon = couponUserRepository.save(couponUser);
 
-        log.info("쿠폰 발급 성공 issuedCouponID={}", issuedCoupon.getCouponId());
+        log.info("쿠폰 발급 성공 issuedCouponID={}", issuedCoupon.getCoupon().getId());
         return CouponUserRes.from(couponUser);
     }
 
-    // 쿠폰 사용 만료일 계산
-    private LocalDateTime calculateExpireAt(Coupon coupon) {
-        LocalDateTime now = LocalDateTime.now();
-
-        return now.plusDays(coupon.getUsageDays());
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CouponUserRes> getCouponList(String userId, Pageable pageable) {
+        log.info("쿠폰 발급 시작 userId={}", userId);
+        return couponUserRepository.findAllByUserIdAndDeletedAtIsNull(userId, pageable)
+                .map(CouponUserRes::from);
     }
 
     // 쿠폰 발급 검증

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/entity/CouponUser.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/entity/CouponUser.java
@@ -22,8 +22,9 @@ public class CouponUser extends BaseEntity {
     @Column(nullable = false)
     private String userId;
 
-    @Column(name = "coupon_id", nullable = false)
-    private UUID couponId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
 
     @Column(nullable = false)
     private LocalDateTime expireAt; // 쿠폰 만료일
@@ -36,11 +37,12 @@ public class CouponUser extends BaseEntity {
 
     private UUID orderId; // 사용한 주문 ID
     
-    private Long discount_amount; // 할인된 금액
+    private Long discountAmount; // 할인된 금액
 
-    public static CouponUser issue(UUID couponId, String userId, LocalDateTime expireAt) {
+    public static CouponUser issue(Coupon coupon, String userId) {
+        LocalDateTime expireAt = LocalDateTime.now().plusDays(coupon.getUsageDays());
         return CouponUser.builder()
-                .couponId(couponId)
+                .coupon(coupon)
                 .userId(userId)
                 .expireAt(expireAt)
                 .status(CouponUserStatus.ISSUED)

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
@@ -1,10 +1,10 @@
 package com.palja.coupon_service.domain.repository;
 
-import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CouponUserRepository {
@@ -14,4 +14,6 @@ public interface CouponUserRepository {
     boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
 
     Page<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId, Pageable pageable);
+
+    Optional<CouponUser> findByIdAndUserIdAndDeletedAtIsNull(UUID couponUserId, String userId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
@@ -11,7 +11,7 @@ public interface CouponUserRepository {
 
     CouponUser save(CouponUser couponUser);
 
-    boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
+    boolean existsByCoupon_IdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
 
     Page<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId, Pageable pageable);
 

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
@@ -1,6 +1,9 @@
 package com.palja.coupon_service.domain.repository;
 
+import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.domain.entity.CouponUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
 
@@ -9,4 +12,6 @@ public interface CouponUserRepository {
     CouponUser save(CouponUser couponUser);
 
     boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
+
+    Page<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId, Pageable pageable);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
@@ -1,8 +1,11 @@
 package com.palja.coupon_service.infrastructure.repository;
 
+import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import com.palja.coupon_service.domain.repository.CouponUserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -21,5 +24,10 @@ public class CouponUserRepositoryAdaptor implements CouponUserRepository {
     @Override
     public boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId) {
         return jpaCouponUserRepository.existsByCouponIdAndUserIdAndDeletedAtIsNull(couponId, userId);
+    }
+
+    @Override
+    public Page<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId, Pageable pageable) {
+        return jpaCouponUserRepository.findAllByUserIdAndDeletedAtIsNull(userId, pageable);
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
@@ -1,6 +1,5 @@
 package com.palja.coupon_service.infrastructure.repository;
 
-import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import com.palja.coupon_service.domain.repository.CouponUserRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Component
@@ -29,5 +29,10 @@ public class CouponUserRepositoryAdaptor implements CouponUserRepository {
     @Override
     public Page<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId, Pageable pageable) {
         return jpaCouponUserRepository.findAllByUserIdAndDeletedAtIsNull(userId, pageable);
+    }
+
+    @Override
+    public Optional<CouponUser> findByIdAndUserIdAndDeletedAtIsNull(UUID couponUserId, String userId) {
+        return jpaCouponUserRepository.findByIdAndUserIdAndDeletedAtIsNull(couponUserId, userId);
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
@@ -22,8 +22,8 @@ public class CouponUserRepositoryAdaptor implements CouponUserRepository {
     }
 
     @Override
-    public boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId) {
-        return jpaCouponUserRepository.existsByCouponIdAndUserIdAndDeletedAtIsNull(couponId, userId);
+    public boolean existsByCoupon_IdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId) {
+        return jpaCouponUserRepository.existsByCoupon_IdAndUserIdAndDeletedAtIsNull(couponId, userId);
     }
 
     @Override

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
@@ -1,6 +1,9 @@
 package com.palja.coupon_service.infrastructure.repository;
 
+import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.domain.entity.CouponUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
@@ -8,4 +11,6 @@ import java.util.UUID;
 public interface JpaCouponUserRepository extends JpaRepository<CouponUser, UUID> {
 
     boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
+
+    Page<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId, Pageable pageable);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
@@ -4,15 +4,27 @@ import com.palja.coupon_service.domain.entity.CouponUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaCouponUserRepository extends JpaRepository<CouponUser, UUID> {
 
-    boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
+    boolean existsByCoupon_IdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
 
+    @Query("SELECT cu FROM CouponUser cu " +
+            "JOIN FETCH cu.coupon c " +
+            "WHERE cu.userId = :userId " +
+            "AND cu.deletedAt IS NULL " +
+            "ORDER BY cu.expireAt")
     Page<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId, Pageable pageable);
 
+    @Query("SELECT cu FROM CouponUser cu " +
+            "JOIN FETCH cu.coupon c " +
+            "WHERE cu.id = :couponUserId " +
+            "AND cu.userId = :userId " +
+            "AND cu.deletedAt IS NULL " +
+            "ORDER BY cu.expireAt")
     Optional<CouponUser> findByIdAndUserIdAndDeletedAtIsNull(UUID couponUserId, String userId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
@@ -1,11 +1,11 @@
 package com.palja.coupon_service.infrastructure.repository;
 
-import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaCouponUserRepository extends JpaRepository<CouponUser, UUID> {
@@ -13,4 +13,6 @@ public interface JpaCouponUserRepository extends JpaRepository<CouponUser, UUID>
     boolean existsByCouponIdAndUserIdAndDeletedAtIsNull(UUID couponId, String userId);
 
     Page<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId, Pageable pageable);
+
+    Optional<CouponUser> findByIdAndUserIdAndDeletedAtIsNull(UUID couponUserId, String userId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
@@ -4,6 +4,7 @@ import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
 import com.palja.coupon_service.application.command.IssueCouponCommand;
+import com.palja.coupon_service.application.dto.CouponUserDetailRes;
 import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.application.service.CouponService;
 import lombok.RequiredArgsConstructor;
@@ -44,5 +45,14 @@ public class CouponController {
         PageResponse<CouponUserRes> response = PageResponse.from(couponUserResPage);
 
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 쿠폰 목록 조회"));
+    }
+
+    @GetMapping("/me/{couponUserId}")
+    public ResponseEntity<ApiResponse<CouponUserDetailRes>> getCouponDetail(@PathVariable UUID couponUserId) {
+        log.info("GET /api/v1/coupons/me/{} - 쿠폰 상세 조회 요청", couponUserId);
+
+        CouponUserDetailRes response = couponService.getCouponDetail(couponUserId, CurrentUser.getLoginId());
+
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 쿠폰 상세 조회"));
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
@@ -2,17 +2,17 @@ package com.palja.coupon_service.presentation.controller;
 
 import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
 import com.palja.coupon_service.application.command.IssueCouponCommand;
 import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.application.service.CouponService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -33,5 +33,16 @@ public class CouponController {
         CouponUserRes response = couponService.issueCoupon(command);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "쿠폰이 발급되었습니다."));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<PageResponse<CouponUserRes>>> getCouponList(Pageable pageable) {
+        log.info("GET /api/v1/coupons/me - 사용자 쿠폰 목록 조회 요청 userId={}", CurrentUser.getLoginId());
+
+        Page<CouponUserRes> couponUserResPage = couponService.getCouponList(CurrentUser.getLoginId(), pageable);
+
+        PageResponse<CouponUserRes> response = PageResponse.from(couponUserResPage);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 쿠폰 목록 조회"));
     }
 }

--- a/coupon-service/src/main/resources/application-datasource.yml
+++ b/coupon-service/src/main/resources/application-datasource.yml
@@ -12,5 +12,6 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
+        highlight_sql: true
         show_sql: true
         default_schema: palja_coupon


### PR DESCRIPTION
# ✨ [Feature] 사용자 쿠폰 조회 기능 구현

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #120 

<br>

## 📌 개요
사용자가 자신이 발급받은 쿠폰 목록을 조회하고 상세 정보를 확인할 수 있는 기능을 구현했습니다.

<br>

## 🔁 변경 사항

### 1. 도메인 계층
- **CouponUser 엔티티**: 
  - Coupon과의 연관관계 복원 (`couponId` → `@ManyToOne Coupon`)
  - 필드명 수정 (`discount_amount` → `discountAmount`)
- **CouponUserRepository**: 사용자별 쿠폰 목록 및 상세 조회 메서드 추가

### 2. 애플리케이션 계층
- **CouponUserDetailRes 추가**: 쿠폰 상세 정보를 포함한 사용자 쿠폰 응답 DTO (`@JsonInclude` 적용)
- **CouponUserRes 개선**: 쿠폰 기본 정보 추가 (쿠폰명, 할인 타입, 할인값)
- **CouponService**: 사용자 쿠폰 목록 및 상세 조회 메서드 추가
- **CouponServiceImpl**: 만료일 계산 로직을 도메인 엔티티로 이동

### 3. 프레젠테이션 계층
- **CouponController**: 
  - `GET /api/v1/coupons/me` - 사용자 쿠폰 목록 조회
  - `GET /api/v1/coupons/me/{couponUserId}` - 사용자 쿠폰 상세 조회

### 4. 인프라 계층
- **JpaCouponUserRepository**: 
  - Fetch Join을 활용한 쿼리 메서드 구현
  - N+1 문제 해결을 위한 `@Query` with `JOIN FETCH` 적용
- **CouponUserRepositoryAdaptor**: 리포지토리 인터페이스 구현체 업데이트

### 5. 기타
- **Hibernate 설정**: SQL 하이라이트 옵션 활성화 (`highlight_sql: true`)
- **메서드명 수정**: `existsByCouponIdAndUserIdAndDeletedAtIsNull` → `existsByCoupon_IdAndUserIdAndDeletedAtIsNull` (연관관계 반영)

<br>

## 📸 스크린샷

<details>
  <summary>사용자 쿠폰 목록 조회 API</summary>
  
<img width="1061" height="782" alt="image" src="https://github.com/user-attachments/assets/887e80dd-0237-47d9-aafb-2b7058a6b680" />

</details>

<details>
  <summary>사용자 쿠폰 상세 조회 AP</summary>

<img width="1068" height="721" alt="image" src="https://github.com/user-attachments/assets/b641c89c-8afc-461c-8233-f2bcede132e4" />


</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.