### PR TITLE
Feat/ProductService 상품 판매나 취소등에 의한 재고 증감 & 타임딜의 요청에 따른 재고의 증감 구현 & 주문 서비스의 요청에 판매자 ID 추가

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -39,6 +39,8 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson:3.52.0'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
@@ -53,6 +55,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.testcontainers:testcontainers-bom:2.0.2'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:testcontainers'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation "org.mockito:mockito-core:5.+"

--- a/product-service/src/main/java/com/palja/product_service/ProductServiceApplication.java
+++ b/product-service/src/main/java/com/palja/product_service/ProductServiceApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 @ComponentScan(basePackages = {"com.palja.product_service", "com.palja.common"})
 public class ProductServiceApplication {
 

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/DecreaseStockForTimeDealRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/DecreaseStockForTimeDealRes.java
@@ -3,16 +3,12 @@ package com.palja.product_service.application.dto.res;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
 @AllArgsConstructor
-public class ProductInfoForOrderRes {
+public class DecreaseStockForTimeDealRes {
 
     private UUID productId;
-    private UUID companyUserId;
-    private String productName;
-    private BigDecimal price;
-    private int stockQuantity;
+    private Boolean status;
 }

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/IncreaseStockForTimeDealRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/IncreaseStockForTimeDealRes.java
@@ -3,16 +3,12 @@ package com.palja.product_service.application.dto.res;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
 @AllArgsConstructor
-public class ProductInfoForOrderRes {
+public class IncreaseStockForTimeDealRes {
 
     private UUID productId;
-    private UUID companyUserId;
-    private String productName;
-    private BigDecimal price;
-    private int stockQuantity;
+    private Boolean status;
 }

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/RestoreStockRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/RestoreStockRes.java
@@ -1,0 +1,14 @@
+package com.palja.product_service.application.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class RestoreStockRes {
+
+    private UUID productId;
+    private boolean status;
+}

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/SaleProductRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/SaleProductRes.java
@@ -1,0 +1,14 @@
+package com.palja.product_service.application.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class SaleProductRes {
+
+    private UUID productId;
+    private Boolean status;
+}

--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -28,4 +28,8 @@ public interface ProductService {
     SaleProductRes saleProduct(UUID productId, Integer quantity);
 
     RestoreStockRes stockRestore(UUID productId, Integer quantity);
+
+    DecreaseStockForTimeDealRes decreaseStockForTimeDeal(UUID productId, Integer quantity);
+
+    IncreaseStockForTimeDealRes increaseStockForTimeDeal(UUID productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -26,4 +26,6 @@ public interface ProductService {
     UpdateStockRes updateStock(UUID productId, Integer stock);
 
     SaleProductRes saleProduct(UUID productId, Integer quantity);
+
+    RestoreStockRes stockRestore(UUID productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -24,4 +24,6 @@ public interface ProductService {
     UpdateProductInfoRes updateProductInfo(UUID productId, UpdateProductInfoCommand updateCommand);
 
     UpdateStockRes updateStock(UUID productId, Integer stock);
+
+    SaleProductRes saleProduct(UUID productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -14,6 +14,7 @@ import com.palja.product_service.domain.vo.Category;
 import com.palja.product_service.exception.ProductErrorCode;
 import com.palja.product_service.infrastructure.repository.DslProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -32,6 +33,13 @@ public class ProductServiceImpl implements ProductService {
     private final ProductRepository repository;
     private final DslProductRepository dslProductRepository;
     private final RedisRepository redisRepository;
+
+    @Value("${redis-key.map0}")
+    private String map0Key;
+
+    @Value("${redis-key.map1}")
+    private String map1Key;
+
 
     @Override
     @Transactional
@@ -192,7 +200,7 @@ public class ProductServiceImpl implements ProductService {
         String substring = productId.toString().substring(0, 8);
         int hash = substring.hashCode();
         if(hash % 2 == 0)
-            return "productStock0";
-        else return "productStock1";
+            return map0Key;
+        else return map1Key;
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -9,6 +9,7 @@ import com.palja.product_service.application.service.ProductService;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
 import com.palja.product_service.domain.entity.Product;
 import com.palja.product_service.domain.repository.ProductRepository;
+import com.palja.product_service.domain.repository.RedisRepository;
 import com.palja.product_service.domain.vo.Category;
 import com.palja.product_service.exception.ProductErrorCode;
 import com.palja.product_service.infrastructure.repository.DslProductRepository;
@@ -30,6 +31,7 @@ public class ProductServiceImpl implements ProductService {
 
     private final ProductRepository repository;
     private final DslProductRepository dslProductRepository;
+    private final RedisRepository redisRepository;
 
     @Override
     @Transactional
@@ -150,19 +152,27 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
-    @Transactional
-    public UpdateStockRes updateStock(UUID productId, Integer stock) {
+    public SaleProductRes saleProduct(UUID productId, Integer quantity) {
 
+        String hashKey;
+        String stringKey = productId.toString();
+        String substring = stringKey.substring(0, 8);
+        int hash = substring.hashCode();
+        if(hash % 2 == 0)
+            hashKey = "productStock0";
+        else hashKey = "productStock1";
+
+        //찾아오는 이유는 레디스에 저장되어있지 않은 상품이라면 해당 상품의 재고가 필요.
+        //재고만 찾아오게 리팩터링 필요.
         Product product = repository.findProduct(productId);
-        /*
-            String loginId = CurrentUser.getLoginId();
-            이 정보로, 해당 로그인 아이디를 사용하는 유저의 UUID를 가져와서 상품의 UUID와 비교해야함.
-            UUID companyUserId = userClient.요청(loginId);
-            if(product.getCompanyUserId().equals(companyUserID)) 가 True여야만 다음 로직 진행.
-         */
+        Integer stock = product.getProductStock().getQuantity();
 
-        Product updateProduct = product.updateStock(stock);
+        boolean finish = redisRepository.decreaseStockBySale(hashKey, stringKey, stock, quantity);
 
-        return UpdateStockRes.fromEntity(updateProduct);
+        if (!finish) {
+            throw new BusinessException(ProductErrorCode.CONNECTION_ERROR_REDIS);
+        }
+
+        return new SaleProductRes(productId, Boolean.TRUE);
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -175,4 +175,11 @@ public class ProductServiceImpl implements ProductService {
 
         return new SaleProductRes(productId, Boolean.TRUE);
     }
+
+    @Override
+    @Transactional
+    public RestoreStockRes stockRestore(UUID productId, Integer quantity) {
+        repository.restoreStock(productId, quantity);
+        return new RestoreStockRes(productId, Boolean.TRUE);
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -154,20 +154,14 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public SaleProductRes saleProduct(UUID productId, Integer quantity) {
 
-        String hashKey;
-        String stringKey = productId.toString();
-        String substring = stringKey.substring(0, 8);
-        int hash = substring.hashCode();
-        if(hash % 2 == 0)
-            hashKey = "productStock0";
-        else hashKey = "productStock1";
+        String hashKey = createRedisHashKey(productId);
 
         //찾아오는 이유는 레디스에 저장되어있지 않은 상품이라면 해당 상품의 재고가 필요.
         //재고만 찾아오게 리팩터링 필요.
         Product product = repository.findProduct(productId);
         Integer stock = product.getProductStock().getQuantity();
 
-        boolean finish = redisRepository.decreaseStockBySale(hashKey, stringKey, stock, quantity);
+        boolean finish = redisRepository.decreaseStockBySale(hashKey, productId.toString(), stock, quantity);
 
         if (!finish) {
             throw new BusinessException(ProductErrorCode.CONNECTION_ERROR_REDIS);
@@ -179,7 +173,26 @@ public class ProductServiceImpl implements ProductService {
     @Override
     @Transactional
     public RestoreStockRes stockRestore(UUID productId, Integer quantity) {
+
         repository.restoreStock(productId, quantity);
+
+        String hashKey = createRedisHashKey(productId);
+        boolean finish = redisRepository.restoreStock(hashKey, productId.toString(), quantity);
+        if (!finish) {
+            throw new BusinessException(ProductErrorCode.CONNECTION_ERROR_REDIS);
+        }
+
         return new RestoreStockRes(productId, Boolean.TRUE);
+    }
+
+    private String createRedisHashKey(UUID productId) {
+
+        //상품 아이디의 앞 7자리를 해시해, 짝수냐 아니냐로 키를 나눔
+        //레디스의 한 컬렉션에 많은 데이터가 저장되면 좋지 않다고 함
+        String substring = productId.toString().substring(0, 8);
+        int hash = substring.hashCode();
+        if(hash % 2 == 0)
+            return "productStock0";
+        else return "productStock1";
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -148,4 +148,21 @@ public class ProductServiceImpl implements ProductService {
 
         return UpdateStockRes.fromEntity(updateProduct);
     }
+
+    @Override
+    @Transactional
+    public UpdateStockRes updateStock(UUID productId, Integer stock) {
+
+        Product product = repository.findProduct(productId);
+        /*
+            String loginId = CurrentUser.getLoginId();
+            이 정보로, 해당 로그인 아이디를 사용하는 유저의 UUID를 가져와서 상품의 UUID와 비교해야함.
+            UUID companyUserId = userClient.요청(loginId);
+            if(product.getCompanyUserId().equals(companyUserID)) 가 True여야만 다음 로직 진행.
+         */
+
+        Product updateProduct = product.updateStock(stock);
+
+        return UpdateStockRes.fromEntity(updateProduct);
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -8,6 +8,7 @@ import com.palja.product_service.application.dto.res.*;
 import com.palja.product_service.application.service.ProductService;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
 import com.palja.product_service.domain.entity.Product;
+import com.palja.product_service.domain.entity.ProductStock;
 import com.palja.product_service.domain.repository.ProductRepository;
 import com.palja.product_service.domain.repository.RedisRepository;
 import com.palja.product_service.domain.vo.Category;
@@ -169,11 +170,8 @@ public class ProductServiceImpl implements ProductService {
         Product product = repository.findProduct(productId);
         Integer stock = product.getProductStock().getQuantity();
 
-        boolean finish = redisRepository.decreaseStockBySale(hashKey, productId.toString(), stock, quantity);
-
-        if (!finish) {
-            throw new BusinessException(ProductErrorCode.CONNECTION_ERROR_REDIS);
-        }
+        boolean result = redisRepository.decreaseStockBySale(hashKey, productId.toString(), stock, quantity);
+        validateRedisOperation(result);
 
         return new SaleProductRes(productId, Boolean.TRUE);
     }
@@ -182,15 +180,42 @@ public class ProductServiceImpl implements ProductService {
     @Transactional
     public RestoreStockRes stockRestore(UUID productId, Integer quantity) {
 
-        repository.restoreStock(productId, quantity);
+        ProductStock restoredStock = repository.findProduct(productId).increaseStock(quantity);
 
         String hashKey = createRedisHashKey(productId);
-        boolean finish = redisRepository.restoreStock(hashKey, productId.toString(), quantity);
-        if (!finish) {
-            throw new BusinessException(ProductErrorCode.CONNECTION_ERROR_REDIS);
-        }
+        boolean result = redisRepository.adjustStock(
+                hashKey, productId.toString(), restoredStock.getQuantity());
+        validateRedisOperation(result);
 
         return new RestoreStockRes(productId, Boolean.TRUE);
+    }
+
+    @Override
+    @Transactional
+    public DecreaseStockForTimeDealRes decreaseStockForTimeDeal(UUID productId, Integer quantity) {
+
+        ProductStock decreasedStock = repository.findProduct(productId).decreaseStock(quantity);
+
+        String hashKey = createRedisHashKey(productId);
+        boolean result = redisRepository.adjustStock(
+                hashKey, productId.toString(), decreasedStock.getQuantity());
+        validateRedisOperation(result);
+
+        return new DecreaseStockForTimeDealRes(productId, Boolean.TRUE);
+    }
+
+    @Override
+    @Transactional
+    public IncreaseStockForTimeDealRes increaseStockForTimeDeal(UUID productId, Integer quantity) {
+
+        ProductStock increasedStock = repository.findProduct(productId).increaseStock(quantity);
+
+        String hashKey = createRedisHashKey(productId);
+        boolean result = redisRepository.adjustStock(
+                hashKey, productId.toString(), increasedStock.getQuantity());
+        validateRedisOperation(result);
+
+        return new IncreaseStockForTimeDealRes(productId, Boolean.TRUE);
     }
 
     private String createRedisHashKey(UUID productId) {
@@ -202,5 +227,11 @@ public class ProductServiceImpl implements ProductService {
         if(hash % 2 == 0)
             return map0Key;
         else return map1Key;
+    }
+
+    private void validateRedisOperation(boolean redisResult) {
+        if (!redisResult) {
+            throw new BusinessException(ProductErrorCode.CONNECTION_ERROR_REDIS);
+        }
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/dto/req/StockScheduleDto.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/dto/req/StockScheduleDto.java
@@ -1,0 +1,14 @@
+package com.palja.product_service.domain.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class StockScheduleDto {
+
+    private UUID productId;
+    private int quantity;
+}

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
@@ -21,4 +21,6 @@ public interface ProductRepository {
     List<Product> findProductsToCondition(FindListByConditionReq condition, Pageable pageable);
 
     void stockBulkUpdateForSchedule(Collection<StockScheduleDto> dtos);
+
+    void restoreStock(UUID productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
@@ -21,6 +21,4 @@ public interface ProductRepository {
     List<Product> findProductsToCondition(FindListByConditionReq condition, Pageable pageable);
 
     void stockBulkUpdateForSchedule(Collection<StockScheduleDto> dtos);
-
-    void restoreStock(UUID productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
@@ -1,10 +1,12 @@
 package com.palja.product_service.domain.repository;
 
+import com.palja.product_service.domain.dto.req.StockScheduleDto;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
 import com.palja.product_service.domain.entity.Product;
 import com.palja.product_service.domain.vo.Category;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -17,4 +19,6 @@ public interface ProductRepository {
     Product findProduct(UUID productId);
 
     List<Product> findProductsToCondition(FindListByConditionReq condition, Pageable pageable);
+
+    void stockBulkUpdateForSchedule(Collection<StockScheduleDto> dtos);
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
@@ -3,4 +3,6 @@ package com.palja.product_service.domain.repository;
 public interface RedisRepository {
 
     boolean decreaseStockBySale(String key, String productId, Integer stock, Integer quantity);
+
+    boolean restoreStock(String hashKey, String productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
@@ -1,0 +1,6 @@
+package com.palja.product_service.domain.repository;
+
+public interface RedisRepository {
+
+    boolean decreaseStockBySale(String key, String productId, Integer stock, Integer quantity);
+}

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
@@ -4,5 +4,5 @@ public interface RedisRepository {
 
     boolean decreaseStockBySale(String key, String productId, Integer stock, Integer quantity);
 
-    boolean restoreStock(String hashKey, String productId, Integer quantity);
+    boolean adjustStock(String hashKey, String productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/exception/ProductErrorCode.java
+++ b/product-service/src/main/java/com/palja/product_service/exception/ProductErrorCode.java
@@ -15,7 +15,9 @@ public enum ProductErrorCode implements ErrorCode {
     NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "상품의 이름은 최대 30자까지 입니다."),
 
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
-    DUPLICATE_PRODUCT(HttpStatus.BAD_REQUEST, "중복된 상품을 등록할 수 없습니다.");
+    DUPLICATE_PRODUCT(HttpStatus.BAD_REQUEST, "중복된 상품을 등록할 수 없습니다."),
+
+    CONNECTION_ERROR_REDIS(HttpStatus.SERVICE_UNAVAILABLE, "요청이 많아 혼잡하니 다시 시도해주세요");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/config/RedisConfig.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/config/RedisConfig.java
@@ -1,0 +1,54 @@
+package com.palja.product_service.infrastructure.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.IntegerCodec;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.codec.CompositeCodec;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String hostName;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory lettuceConnectionFactory() {
+
+        LettuceClientConfiguration config = LettuceClientConfiguration.builder()
+                .commandTimeout(Duration.ofSeconds(3))
+                .shutdownTimeout(Duration.ofSeconds(5))
+                .build();
+
+        return new LettuceConnectionFactory(
+                new RedisStandaloneConfiguration(hostName, port), config);
+    }
+
+    @Bean
+    public RedissonClient redisson(RedisConnectionFactory factory) {
+
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + hostName + ":" + port);
+        //기본값. 락을 획득한 채로 스프링 서버가 죽으면, 30초후에 락이 자동으로 해제됨
+        config.setLockWatchdogTimeout(30000);
+        config.setCodec(new CompositeCodec(
+                StringCodec.INSTANCE,
+                IntegerCodec.INSTANCE,
+                StringCodec.INSTANCE
+        ));
+
+        return Redisson.create(config);
+    }
+}

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/event/RedisTimeSetCleanListener.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/event/RedisTimeSetCleanListener.java
@@ -1,0 +1,31 @@
+package com.palja.product_service.infrastructure.event;
+
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class RedisTimeSetCleanListener {
+
+    private final RedissonClient redissonClient;
+
+    @Value("${redis-key.map0}")
+    private String map0Key;
+
+    @Value("${redis-key.map1}")
+    private String map1Key;
+
+    @Value("${redis-key.time-suffix}")
+    private String timeSuffix;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void afterScheduleDbUpdate(RedisTimeSetClearEvent event) {
+
+        redissonClient.getScoredSortedSet(map0Key +  timeSuffix).clear();
+        redissonClient.getScoredSortedSet(map1Key +  timeSuffix).clear();
+    }
+}

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/event/RedisTimeSetClearEvent.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/event/RedisTimeSetClearEvent.java
@@ -1,0 +1,8 @@
+package com.palja.product_service.infrastructure.event;
+
+import lombok.Getter;
+
+@Getter
+public class RedisTimeSetClearEvent {
+
+}

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
@@ -37,6 +37,13 @@ public class DslProductRepository {
                 .fetchOne();
     }
 
+//    public boolean stockBulkUpdate(Collection<StockScheduleDto> dtos) {
+//
+//        queryFactory.update(product)
+//                .set(product.productStock.quantity)
+//                .where(product.productStock.id.in(dtos))
+//    }
+
     public ProductInfoForOrderRes findProductForOrder(UUID productId) {
 
         return queryFactory.select(Projections.constructor(

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
@@ -37,13 +37,6 @@ public class DslProductRepository {
                 .fetchOne();
     }
 
-//    public boolean stockBulkUpdate(Collection<StockScheduleDto> dtos) {
-//
-//        queryFactory.update(product)
-//                .set(product.productStock.quantity)
-//                .where(product.productStock.id.in(dtos))
-//    }
-
     public ProductInfoForOrderRes findProductForOrder(UUID productId) {
 
         return queryFactory.select(Projections.constructor(

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
@@ -42,6 +42,7 @@ public class DslProductRepository {
         return queryFactory.select(Projections.constructor(
                         ProductInfoForOrderRes.class,
                         product.id,
+                        product.companyUserId,
                         product.name,
                         product.price.amount,
                         product.productStock.quantity))

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JdbcProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JdbcProductRepository.java
@@ -1,0 +1,41 @@
+package com.palja.product_service.infrastructure.repository;
+
+import com.palja.product_service.domain.dto.req.StockScheduleDto;
+import com.palja.product_service.infrastructure.event.RedisTimeSetClearEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class JdbcProductRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void stockBulkUpdateForSchedule(Collection<StockScheduleDto> dtos) {
+
+        String sql = """
+                UPDATE palja_product.p_product_stock ps 
+                SET quantity = ? 
+                FROM palja_product.p_product p 
+                WHERE ps.product_id = p.product_id AND ps.product_id = ?
+                """;
+        jdbcTemplate.batchUpdate(
+                sql, dtos, dtos.size(),
+                (ps, dto) -> {
+                    ps.setInt(1, dto.getQuantity());
+                    ps.setObject(2, dto.getProductId());
+                }
+        );
+
+        eventPublisher.publishEvent(new RedisTimeSetClearEvent());
+    }
+}

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
@@ -16,8 +16,4 @@ public interface JpaProductRepository extends JpaRepository<Product, UUID> {
     Optional<Product> findByIdFetchStock(@Param("productId") UUID productId);
 
     Boolean existsByCompanyNameAndCategoryAndNameAndDeletedAtIsNull(String companyName, Category category, String name);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE ProductStock ps Set ps.quantity = ps.quantity + :quantity WHERE ps.product.id = :productId")
-    void restoreStock(@Param("productId")UUID productId, @Param("quantity") Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
@@ -3,6 +3,7 @@ package com.palja.product_service.infrastructure.repository;
 import com.palja.product_service.domain.entity.Product;
 import com.palja.product_service.domain.vo.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +16,8 @@ public interface JpaProductRepository extends JpaRepository<Product, UUID> {
     Optional<Product> findByIdFetchStock(@Param("productId") UUID productId);
 
     Boolean existsByCompanyNameAndCategoryAndNameAndDeletedAtIsNull(String companyName, Category category, String name);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ProductStock ps Set ps.quantity = ps.quantity + :quantity WHERE ps.product.id = :productId")
+    void restoreStock(@Param("productId")UUID productId, @Param("quantity") Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.palja.product_service.infrastructure.repository.impl;
 
 import com.palja.common.exception.BusinessException;
+import com.palja.product_service.domain.dto.req.StockScheduleDto;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
 import com.palja.product_service.domain.entity.Product;
 import com.palja.product_service.domain.repository.ProductRepository;
@@ -10,8 +11,10 @@ import com.palja.product_service.infrastructure.repository.DslProductRepository;
 import com.palja.product_service.infrastructure.repository.JpaProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -21,6 +24,7 @@ public class ProductRepositoryImpl implements ProductRepository {
 
     private final JpaProductRepository jpaProductRepository;
     private final DslProductRepository dslProductRepository;
+    private final JdbcTemplate jdbcTemplate;
 
     @Override
     public Product save(Product product) {
@@ -43,5 +47,23 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public List<Product> findProductsToCondition(FindListByConditionReq condition, Pageable pageable) {
         return dslProductRepository.findProductByCondition(condition, pageable);
+    }
+
+    @Override
+    public void stockBulkUpdateForSchedule(Collection<StockScheduleDto> dtos) {
+
+        String sql = """
+                UPDATE palja_product.p_product_stock ps 
+                SET quantity = ? 
+                FROM palja_product.p_product p 
+                WHERE ps.product_id = p.product_id AND ps.product_id = ?
+                """;
+        jdbcTemplate.batchUpdate(
+                sql, dtos, dtos.size(),
+                (ps, dto) -> {
+                    ps.setInt(1, dto.getQuantity());
+                    ps.setObject(2, dto.getProductId());
+                }
+        );
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -56,9 +56,4 @@ public class ProductRepositoryImpl implements ProductRepository {
 
         jdbcProductRepository.stockBulkUpdateForSchedule(dtos);
     }
-
-    @Override
-    public void restoreStock(UUID productId, Integer quantity) {
-        jpaProductRepository.restoreStock(productId, quantity);
-    }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -66,4 +66,9 @@ public class ProductRepositoryImpl implements ProductRepository {
                 }
         );
     }
+
+    @Override
+    public void restoreStock(UUID productId, Integer quantity) {
+        jpaProductRepository.restoreStock(productId, quantity);
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -1,18 +1,19 @@
 package com.palja.product_service.infrastructure.repository.impl;
 
 import com.palja.common.exception.BusinessException;
-import com.palja.product_service.domain.dto.req.StockScheduleDto;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
+import com.palja.product_service.domain.dto.req.StockScheduleDto;
 import com.palja.product_service.domain.entity.Product;
 import com.palja.product_service.domain.repository.ProductRepository;
 import com.palja.product_service.domain.vo.Category;
 import com.palja.product_service.exception.ProductErrorCode;
 import com.palja.product_service.infrastructure.repository.DslProductRepository;
+import com.palja.product_service.infrastructure.repository.JdbcProductRepository;
 import com.palja.product_service.infrastructure.repository.JpaProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
@@ -24,7 +25,7 @@ public class ProductRepositoryImpl implements ProductRepository {
 
     private final JpaProductRepository jpaProductRepository;
     private final DslProductRepository dslProductRepository;
-    private final JdbcTemplate jdbcTemplate;
+    private final JdbcProductRepository jdbcProductRepository;
 
     @Override
     public Product save(Product product) {
@@ -50,21 +51,10 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
+    @Transactional
     public void stockBulkUpdateForSchedule(Collection<StockScheduleDto> dtos) {
 
-        String sql = """
-                UPDATE palja_product.p_product_stock ps 
-                SET quantity = ? 
-                FROM palja_product.p_product p 
-                WHERE ps.product_id = p.product_id AND ps.product_id = ?
-                """;
-        jdbcTemplate.batchUpdate(
-                sql, dtos, dtos.size(),
-                (ps, dto) -> {
-                    ps.setInt(1, dto.getQuantity());
-                    ps.setObject(2, dto.getProductId());
-                }
-        );
+        jdbcProductRepository.stockBulkUpdateForSchedule(dtos);
     }
 
     @Override

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
@@ -4,7 +4,9 @@ import com.palja.common.exception.BusinessException;
 import com.palja.product_service.domain.repository.RedisRepository;
 import com.palja.product_service.exception.ProductErrorCode;
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.redisson.api.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -13,10 +15,13 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class RedisRepositoryImpl implements RedisRepository {
 
     private final RedissonClient redissonClient;
+
+    @Value("${redis-key.time-suffix}")
+    private String timeSuffix;
 
     @Override
     public boolean decreaseStockBySale(String key, String productId, Integer stock, Integer quantity) {
@@ -50,7 +55,7 @@ public class RedisRepositoryImpl implements RedisRepository {
 
             //레디스에 새로운 재고를 넣고, DB 재고차감 스케줄링에 사용할 값을 넣는다.
             map.fastPut(productId, resultStock);
-            setTime(key+"Time", productId);
+            setTime(key+timeSuffix, productId);
 
             //예외 없이 모든 작업이 끝난다면 커밋해 레디스에 적용시킨다
             transaction.commit();

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
@@ -1,0 +1,75 @@
+package com.palja.product_service.infrastructure.repository.impl;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.product_service.domain.repository.RedisRepository;
+import com.palja.product_service.exception.ProductErrorCode;
+import lombok.AllArgsConstructor;
+import org.redisson.api.*;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@AllArgsConstructor
+public class RedisRepositoryImpl implements RedisRepository {
+
+    private final RedissonClient redissonClient;
+
+    @Override
+    public boolean decreaseStockBySale(String key, String productId, Integer stock, Integer quantity) {
+
+        //상품의 아이디의 이름으로 락을 건다.
+        RLock lock = redissonClient.getLock(productId);
+
+        RTransaction transaction = null;
+        try {
+            //락을 10초동안 얻지 못한다면 실패 반환
+            if (!lock.tryLock(10, 10, TimeUnit.SECONDS)) {
+                return false;
+            }
+
+            //Redisson에서 지원하는 트랜잭션
+            transaction = redissonClient.createTransaction(
+                    TransactionOptions.defaults().timeout(10, TimeUnit.SECONDS)
+            );
+
+            // 레디스에 key로 매핑된 Hash(자바의 Map)을 가져온다.
+            RMap<String, Integer> map = redissonClient.getMap(key);
+
+            //값이 있으면 가져오고 없으면 DB의 재고로 잡는다
+            Integer remainStock = map.getOrDefault(productId, stock);
+
+            //남아있는 재고보다 판매수량이 많다면 예외
+            Integer resultStock = remainStock - quantity;
+            if (resultStock < 0) {
+                throw new InterruptedException();
+            }
+
+            //레디스에 새로운 재고를 넣고, DB 재고차감 스케줄링에 사용할 값을 넣는다.
+            map.fastPut(productId, resultStock);
+            setTime(key+"Time", productId);
+
+            //예외 없이 모든 작업이 끝난다면 커밋해 레디스에 적용시킨다
+            transaction.commit();
+
+        } catch (Exception e) {
+            if(Objects.nonNull(transaction))
+                transaction.rollback();
+            throw new BusinessException(ProductErrorCode.INVALID_STOCK);
+        } finally {
+            lock.unlock();
+        }
+        return true;
+    }
+
+    private void setTime(String setKey, String productId) {
+
+        long score = LocalDateTime.now().plusMinutes(1).toEpochSecond(ZoneOffset.UTC);
+        RScoredSortedSet<String> set = redissonClient.getScoredSortedSet(setKey);
+
+        set.add(score, productId);
+    }
+}

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
@@ -42,7 +42,7 @@ public class RedisRepositoryImpl implements RedisRepository {
             );
 
             // 레디스에 key로 매핑된 Hash(자바의 Map)을 가져온다.
-            RMap<String, Integer> map = redissonClient.getMap(key);
+            RMap<String, Integer> map = transaction.getMap(key);
 
             //값이 있으면 가져오고 없으면 DB의 재고로 잡는다
             Integer remainStock = map.getOrDefault(productId, stock);
@@ -71,11 +71,9 @@ public class RedisRepositoryImpl implements RedisRepository {
     }
 
     @Override
-    public boolean restoreStock(String hashKey, String productId, Integer quantity) {
+    public boolean adjustStock(String hashKey, String productId, Integer quantity) {
 
         RLock lock = redissonClient.getLock(productId);
-
-        RTransaction transaction = null;
 
         try {
             //락을 10초동안 얻지 못한다면 실패 반환
@@ -83,27 +81,12 @@ public class RedisRepositoryImpl implements RedisRepository {
                 return false;
             }
 
-            transaction = redissonClient.createTransaction(
-                    TransactionOptions.defaults().timeout(10, TimeUnit.SECONDS)
-            );
-
             RMap<String, Integer> map = redissonClient.getMap(hashKey);
 
-            //레디스에 저장된 상품이 아니라면 실패
-            Integer remainStock = map.get(productId);
-            if (Objects.isNull(remainStock)) {
-                return false;
-            }
+            //DB에 먼저 값이 저장되고 레디스에 저장하는 방식이기 때문에, 덮어씌워야함
+            map.fastPut(productId, quantity);
 
-            //레디스에 복구될 재고를 넣는다
-            map.fastPut(productId, remainStock + quantity);
-
-            //예외 없이 모든 작업이 끝난다면 커밋해 레디스에 적용시킨다
-            transaction.commit();
-
-        } catch (Exception e) {
-            if(Objects.nonNull(transaction))
-                transaction.rollback();
+        } catch (InterruptedException e) {
             return false;
         } finally {
             lock.unlock();

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
@@ -58,7 +58,48 @@ public class RedisRepositoryImpl implements RedisRepository {
         } catch (Exception e) {
             if(Objects.nonNull(transaction))
                 transaction.rollback();
-            throw new BusinessException(ProductErrorCode.INVALID_STOCK);
+            return false;
+        } finally {
+            lock.unlock();
+        }
+        return true;
+    }
+
+    @Override
+    public boolean restoreStock(String hashKey, String productId, Integer quantity) {
+
+        RLock lock = redissonClient.getLock(productId);
+
+        RTransaction transaction = null;
+
+        try {
+            //락을 10초동안 얻지 못한다면 실패 반환
+            if (!lock.tryLock(10, 10, TimeUnit.SECONDS)) {
+                return false;
+            }
+
+            transaction = redissonClient.createTransaction(
+                    TransactionOptions.defaults().timeout(10, TimeUnit.SECONDS)
+            );
+
+            RMap<String, Integer> map = redissonClient.getMap(hashKey);
+
+            //레디스에 저장된 상품이 아니라면 실패
+            Integer remainStock = map.get(productId);
+            if (Objects.isNull(remainStock)) {
+                return false;
+            }
+
+            //레디스에 복구될 재고를 넣는다
+            map.fastPut(productId, remainStock + quantity);
+
+            //예외 없이 모든 작업이 끝난다면 커밋해 레디스에 적용시킨다
+            transaction.commit();
+
+        } catch (Exception e) {
+            if(Objects.nonNull(transaction))
+                transaction.rollback();
+            return false;
         } finally {
             lock.unlock();
         }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/schedule/RedisStockScheduler.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/schedule/RedisStockScheduler.java
@@ -2,14 +2,14 @@ package com.palja.product_service.infrastructure.schedule;
 
 import com.palja.product_service.domain.dto.req.StockScheduleDto;
 import com.palja.product_service.domain.repository.ProductRepository;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.redisson.api.RMap;
 import org.redisson.api.RScoredSortedSet;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.IntegerCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.codec.CompositeCodec;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,22 +18,30 @@ import java.time.ZoneOffset;
 import java.util.*;
 
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class RedisStockScheduler {
 
     private final RedissonClient redissonClient;
     private final ProductRepository productRepository;
-    private final JdbcTemplate jdbcTemplate;
+
+    @Value("${redis-key.map0}")
+    private String map0Key;
+
+    @Value("${redis-key.map1}")
+    private String map1Key;
+
+    @Value("${redis-key.time-suffix}")
+    private String timeSuffix;
 
     @Scheduled(cron = "0 */5 * * * *")
     public void updateDbStock() {
 
         RMap<String, Integer> map0 = redissonClient.getMap(
-                "productStock0", new CompositeCodec(StringCodec.INSTANCE, IntegerCodec.INSTANCE));
+                map0Key, new CompositeCodec(StringCodec.INSTANCE, IntegerCodec.INSTANCE));
         RMap<String, Integer> map1 = redissonClient.getMap(
-                "productStock1", new CompositeCodec(StringCodec.INSTANCE, IntegerCodec.INSTANCE));
-        RScoredSortedSet<String> set0 = redissonClient.getScoredSortedSet("productStock0Time");
-        RScoredSortedSet<String> set1 = redissonClient.getScoredSortedSet("productStock1Time");
+                map1Key, new CompositeCodec(StringCodec.INSTANCE, IntegerCodec.INSTANCE));
+        RScoredSortedSet<String> set0 = redissonClient.getScoredSortedSet(map0Key+timeSuffix);
+        RScoredSortedSet<String> set1 = redissonClient.getScoredSortedSet(map1Key+timeSuffix);
         long now = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
 
         //2개의 Set에서 과거 ~ 현재 시간까지의 값들만 가져옴
@@ -48,14 +56,6 @@ public class RedisStockScheduler {
         Set<StockScheduleDto> set = new HashSet<>();
         idStock.forEach((k,v)-> set.add(new StockScheduleDto(UUID.fromString(k), v)));
 
-        /**
-         * 레디스에 있는 재고들을 DB에 적용시킴.
-         * 예외가 발생하면..?
-         */
         productRepository.stockBulkUpdateForSchedule(set);
-
-        //작업한 Set에서 데이터를 삭제
-        set0.removeAll(targetIds);
-        set1.removeAll(targetIds);
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/schedule/RedisStockScheduler.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/schedule/RedisStockScheduler.java
@@ -1,0 +1,61 @@
+package com.palja.product_service.infrastructure.schedule;
+
+import com.palja.product_service.domain.dto.req.StockScheduleDto;
+import com.palja.product_service.domain.repository.ProductRepository;
+import lombok.AllArgsConstructor;
+import org.redisson.api.RMap;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.IntegerCodec;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.codec.CompositeCodec;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+@Component
+@AllArgsConstructor
+public class RedisStockScheduler {
+
+    private final RedissonClient redissonClient;
+    private final ProductRepository productRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    @Scheduled(cron = "0 */5 * * * *")
+    public void updateDbStock() {
+
+        RMap<String, Integer> map0 = redissonClient.getMap(
+                "productStock0", new CompositeCodec(StringCodec.INSTANCE, IntegerCodec.INSTANCE));
+        RMap<String, Integer> map1 = redissonClient.getMap(
+                "productStock1", new CompositeCodec(StringCodec.INSTANCE, IntegerCodec.INSTANCE));
+        RScoredSortedSet<String> set0 = redissonClient.getScoredSortedSet("productStock0Time");
+        RScoredSortedSet<String> set1 = redissonClient.getScoredSortedSet("productStock1Time");
+        long now = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
+
+        //2개의 Set에서 과거 ~ 현재 시간까지의 값들만 가져옴
+        Collection<String> targetIds = set0.valueRange(Double.MIN_VALUE, true, now, true);
+        targetIds.addAll(set1.valueRange(Double.MIN_VALUE, true, now, true));
+
+        //재고정보가 저장된 map에서 위에서 필터링된 값듦만 가져옴
+        Map<String, Integer> idStock = map0.getAll(new HashSet<>(targetIds));
+        idStock.putAll(map1.getAll(new HashSet<>(targetIds)));
+
+        //레포지토리에 요청을 보낼 데이터로 가공
+        Set<StockScheduleDto> set = new HashSet<>();
+        idStock.forEach((k,v)-> set.add(new StockScheduleDto(UUID.fromString(k), v)));
+
+        /**
+         * 레디스에 있는 재고들을 DB에 적용시킴.
+         * 예외가 발생하면..?
+         */
+        productRepository.stockBulkUpdateForSchedule(set);
+
+        //작업한 Set에서 데이터를 삭제
+        set0.removeAll(targetIds);
+        set1.removeAll(targetIds);
+    }
+}

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
@@ -96,4 +96,13 @@ public class ProductController {
 
         return new ResponseEntity<>(ApiResponse.success(res, "판매 재고 차감 성공"), HttpStatus.OK);
     }
+
+    @PutMapping("/order/cancel/{productId}")
+    public ResponseEntity<ApiResponse<RestoreStockRes>> restoreStockByCancel(@PathVariable UUID productId,
+                                                                             @RequestParam Integer quantity) {
+
+        RestoreStockRes res = service.stockRestore(productId, quantity);
+
+        return new ResponseEntity<>(ApiResponse.success(res, "취소 수량 복구 성공"), HttpStatus.OK);
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
@@ -87,4 +87,13 @@ public class ProductController {
 
         return new ResponseEntity<>(ApiResponse.success(res, "상품 재고 수정 성공"), HttpStatus.OK);
     }
+
+    @PutMapping("/order/sale/{productId}")
+    public ResponseEntity<ApiResponse<SaleProductRes>> saleProduct(@PathVariable UUID productId,
+                                                                   @RequestParam Integer quantity) {
+
+        SaleProductRes res = service.saleProduct(productId, quantity);
+
+        return new ResponseEntity<>(ApiResponse.success(res, "판매 재고 차감 성공"), HttpStatus.OK);
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
@@ -105,4 +105,22 @@ public class ProductController {
 
         return new ResponseEntity<>(ApiResponse.success(res, "취소 수량 복구 성공"), HttpStatus.OK);
     }
+
+    @PutMapping("/time-deal/decrease/{productId}")
+    public ResponseEntity<ApiResponse<DecreaseStockForTimeDealRes>> decreaseStockForTimeDeal(@PathVariable UUID productId,
+                                                                   @RequestParam Integer quantity) {
+
+        DecreaseStockForTimeDealRes res = service.decreaseStockForTimeDeal(productId, quantity);
+
+        return new ResponseEntity<>(ApiResponse.success(res, "상품 재고 차감 성공"), HttpStatus.OK);
+    }
+
+    @PutMapping("/time-deal/increase/{productId}")
+    public ResponseEntity<ApiResponse<IncreaseStockForTimeDealRes>> increaseStockForTimeDeal(@PathVariable UUID productId,
+                                                                   @RequestParam Integer quantity) {
+
+        IncreaseStockForTimeDealRes res = service.increaseStockForTimeDeal(productId, quantity);
+
+        return new ResponseEntity<>(ApiResponse.success(res, "상품 재고 증가 성공"), HttpStatus.OK);
+    }
 }

--- a/product-service/src/main/resources/application-redis.yml
+++ b/product-service/src/main/resources/application-redis.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: "localhost"
+      port: 6379

--- a/product-service/src/main/resources/application-redis.yml
+++ b/product-service/src/main/resources/application-redis.yml
@@ -3,3 +3,8 @@ spring:
     redis:
       host: "localhost"
       port: 6379
+
+redis-key:
+  map0: "productStock0"
+  map1: "productStock1"
+  time-suffix: "Time"

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -9,3 +9,4 @@ spring:
     include:
       - datasource
       - zipkin
+      - redis

--- a/product-service/src/test/java/com/palja/product_service/application/service/impl/ProductServiceImplTest.java
+++ b/product-service/src/test/java/com/palja/product_service/application/service/impl/ProductServiceImplTest.java
@@ -3,8 +3,8 @@ package com.palja.product_service.application.service.impl;
 import com.palja.product_service.application.command.CreateProductCommand;
 import com.palja.product_service.application.command.FindProductListByConditionCommand;
 import com.palja.product_service.application.dto.res.CreateProductRes;
-import com.palja.product_service.application.dto.res.FindProductRes;
 import com.palja.product_service.application.dto.res.FindProductListByConditionRes;
+import com.palja.product_service.application.dto.res.FindProductRes;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
 import com.palja.product_service.domain.entity.Product;
 import com.palja.product_service.domain.repository.ProductRepository;
@@ -76,7 +76,7 @@ class ProductServiceImplTest {
         //then
         assertThat(result.getName()).isEqualTo(expected.getName());
         assertThat(result.getDescription()).isEqualTo(expected.getDescription());
-        assertThat(result.getPrice()).isEqualTo(expected.getPrice());
+        assertThat(result.getPrice()).isEqualTo(expected.getPrice().toString());
         assertThat(result.getCategory()).isEqualTo(expected.getCategory().name());
         assertThat(result.getCompanyName()).isEqualTo(expected.getCompanyName());
     }

--- a/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
+++ b/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.infrastructure.repository.impl;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RMap;
@@ -49,11 +50,18 @@ class RedisRepositoryImplTest {
     @Autowired
     private RedissonClient redissonClient;
 
+    private final String hashKey = "test:stock";
+
+    @AfterEach
+    void clean() {
+        redissonClient.getMap(hashKey).clear();
+    }
+
     @Test
     @DisplayName("판매에 의한 재고 차감시, 동시성 이슈가 없어야한다")
     void decreaseStockBySale() throws InterruptedException {
         //given
-        String hashName = "Test:stock";
+        String hashName = hashKey;
         String productId = UUID.randomUUID().toString();
         Integer dbStock = 100;
         Integer saleQuantity = 1;
@@ -65,7 +73,6 @@ class RedisRepositoryImplTest {
 
         //when
         for (int i = 1; i <= numOfThreads; i++) {
-            int finalI = i;
             executorService.submit(() -> {
                 try {
                     redisRepository.decreaseStockBySale(hashName, productId, dbStock, saleQuantity);
@@ -81,11 +88,36 @@ class RedisRepositoryImplTest {
 
         //then
         RMap<String, Integer> map = redissonClient.getMap(hashName);
-        RScoredSortedSet<String> timeSet = redissonClient.getScoredSortedSet(hashName + "time");
+        RScoredSortedSet<String> timeSet = redissonClient.getScoredSortedSet(hashName + "Time");
 
         assertThat(map.get(productId)).isEqualTo(0);
         assertThat(timeSet.size()).isEqualTo(1);
 
-        assertThat(timeSet.getScore(productId)).isBetween(beforeTime*1.0, afterTime*1.0);
+        assertThat(timeSet.getScore(productId)).isBetween(beforeTime * 1.0, afterTime * 1.0);
+    }
+
+    @Test
+    @DisplayName("재고 수량 변경에 성공한다")
+    void adjustStock() {
+        //given
+        String hashName = hashKey;
+        String productId = UUID.randomUUID().toString();
+        String productId2 = UUID.randomUUID().toString();
+        Integer beforeStock = 100;
+        Integer afterStock = 200;
+
+        redissonClient.getMap(hashName).fastPut(productId, beforeStock);
+
+        //when
+
+        redisRepository.adjustStock(hashName, productId, afterStock);
+        redisRepository.adjustStock(hashName, productId2, afterStock);
+
+        //then
+        RMap<String, Integer> map = redissonClient.getMap(hashName);
+
+        assertThat(map.size()).isEqualTo(2);
+        assertThat(map.get(productId)).isEqualTo(afterStock);
+        assertThat(map.get(productId2)).isEqualTo(afterStock);
     }
 }

--- a/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
+++ b/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
@@ -1,0 +1,91 @@
+package com.palja.product_service.infrastructure.repository.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RMap;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RedisRepositoryImplTest {
+
+    @Container
+    private static final GenericContainer<?> redisContainer =
+            new GenericContainer<>("redis:7.4.1-alpine3.20")
+                    .withExposedPorts(6379)
+                    .waitingFor(Wait.forListeningPort())
+                    .withStartupTimeout(Duration.ofSeconds(60));
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", redisContainer::getFirstMappedPort);
+    }
+
+    static {
+        redisContainer.start();
+    }
+
+    @Autowired
+    private RedisRepositoryImpl redisRepository;
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Test
+    @DisplayName("판매에 의한 재고 차감시, 동시성 이슈가 없어야한다")
+    void decreaseStockBySale() throws InterruptedException {
+        //given
+        String hashName = "Test:stock";
+        String productId = UUID.randomUUID().toString();
+        Integer dbStock = 100;
+        Integer saleQuantity = 1;
+        long beforeTime = LocalDateTime.now().plusMinutes(1).toEpochSecond(ZoneOffset.UTC);
+
+        final int numOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(numOfThreads);
+        CountDownLatch latch = new CountDownLatch(numOfThreads);
+
+        //when
+        for (int i = 1; i <= numOfThreads; i++) {
+            int finalI = i;
+            executorService.submit(() -> {
+                try {
+                    redisRepository.decreaseStockBySale(hashName, productId, dbStock, saleQuantity);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+        long afterTime = LocalDateTime.now().plusMinutes(1).toEpochSecond(ZoneOffset.UTC);
+
+        //then
+        RMap<String, Integer> map = redissonClient.getMap(hashName);
+        RScoredSortedSet<String> timeSet = redissonClient.getScoredSortedSet(hashName + "time");
+
+        assertThat(map.get(productId)).isEqualTo(0);
+        assertThat(timeSet.size()).isEqualTo(1);
+
+        assertThat(timeSet.getScore(productId)).isBetween(beforeTime*1.0, afterTime*1.0);
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #93 

<br>

## 📌 개요
- 상품이 판매될 때, DB에 있는 상품의 재고를 레디스에 옮겨서 계산합니다.
- 분산 락을 적용해 동시성 이슈를 방지합니다.
- 5분마다 스케줄링을 돌려 레디스에 기록된 상품 재고의 차감을 DB에 적용시킵니다.
- 주문 취소나 환불 요청이 들어오면 해당 아이디의 상품 재고를 DB에 먼저 적용시키고, 레디스에도 더합니다

<br>

## 🔁 변경 사항

1. 레디스 의존성이 추가되었습니다.
2. 테스트를 위해 TestContainers라는 오픈소스 의존성이 추가되었습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

기간 내 완성하지 못해 죄송하다는 말씀 먼저 드립니다.
남은건 별점과 상품 삭제, 타임딜 서비스의 생성으로 인한 재고증감과, 리뷰의 수정 삭제 인 것 같습니다.
최대한 빨리 작성하겠습니다..

정신없이 작업한지라 많은 곳이 이상할지도 모르니.. 너그러운 마음으로 확인해주시면 감사하겠습니다 (__)

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
