### PR TITLE
FEAT/ 게이트웨이에 각 MSA 서비스 Swagger 연결

### DIFF
--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.14'
 }
 
 dependencyManagement {

--- a/gateway-service/src/main/java/com/palja/gateway_service/filter/AuthorizationFilter.java
+++ b/gateway-service/src/main/java/com/palja/gateway_service/filter/AuthorizationFilter.java
@@ -33,6 +33,12 @@ public class AuthorizationFilter implements GlobalFilter {
 	private final ObjectMapper objectMapper;
 	private final TokenRepository tokenRepository;
 
+	private static final List<String> swaggerPaths = List.of(
+		"/swagger-ui",
+		"/v3/api-docs",
+		"/swagger-resources"
+	);
+
 	private final Map<String, List<String>> permitAllPaths = Map.of(
 		"/api/v1/auth/login", List.of("POST"),
 		"/api/v1/auth/refresh", List.of("POST"),
@@ -47,6 +53,10 @@ public class AuthorizationFilter implements GlobalFilter {
 		String method = request.getMethod().name();
 
 		log.info("[%s] %s".formatted(method, request.getURI()));
+
+		if (swaggerPaths.stream().anyMatch(path::startsWith)) {
+			return chain.filter(exchange);
+		}
 
 		List<String> authorizationHeaders = request.getHeaders().get("Authorization");
 		if (authorizationHeaders != null && !authorizationHeaders.isEmpty()) {

--- a/gateway-service/src/main/resources/application-route.yml
+++ b/gateway-service/src/main/resources/application-route.yml
@@ -11,33 +11,75 @@ spring:
               uri: lb://payment-service
               predicates:
                 - Path=/api/v1/payments/**, /api/v1/payment-logs/**
+            - id: payment-service-docs
+              uri: lb://payment-service
+              predicates:
+                - Path=/v3/api-docs/payment-service
+              filters:
+                - RewritePath=/v3/api-docs/payment-service, /v3/api-docs
 
             - id: review-service
               uri: lb://review-service
               predicates:
                 - Path=/api/v1/reviews/**
+            - id: review-service-docs
+              uri: lb://review-service
+              predicates:
+                - Path=/v3/api-docs/review-service
+              filters:
+                - RewritePath=/v3/api-docs/review-service, /v3/api-docs
 
             - id: user-service
               uri: lb://user-service
               predicates:
                 - Path=/api/v1/managers/**, /api/v1/customers/**, /api/v1/company-users/**, /api/v1/auth/**
+            - id: user-service-docs
+              uri: lb://user-service
+              predicates:
+                - Path=/v3/api-docs/user-service
+              filters:
+                - RewritePath=/v3/api-docs/user-service, /v3/api-docs
 
             - id: product-service
               uri: lb://product-service
               predicates:
                 - Path=/api/v1/products/**
+            - id: product-service-docs
+              uri: lb://product-service
+              predicates:
+                - Path=/v3/api-docs/product-service
+              filters:
+                - RewritePath=/v3/api-docs/product-service, /v3/api-docs
 
             - id: order-service
               uri: lb://order-service
               predicates:
                 - Path=/api/v1/orders/**
+            - id: order-service-docs
+              uri: lb://order-service
+              predicates:
+                - Path=/v3/api-docs/order-service
+              filters:
+                - RewritePath=/v3/api-docs/order-service, /v3/api-docs
 
             - id: coupon-service
               uri: lb://coupon-service
               predicates:
                 - Path=/api/v1/coupons/**
+            - id: coupon-service-docs
+              uri: lb://coupon-service
+              predicates:
+                - Path=/v3/api-docs/coupon-service
+              filters:
+                - RewritePath=/v3/api-docs/coupon-service, /v3/api-docs
 
             - id: timedeal-service
               uri: lb://timedeal-service
               predicates:
                 - Path=/api/v1/time-deals/**
+            - id: timedeal-service-docs
+              uri: lb://timedeal-service
+              predicates:
+                - Path=/v3/api-docs/timedeal-service
+              filters:
+                - RewritePath=/v3/api-docs/timedeal-service, /v3/api-docs

--- a/gateway-service/src/main/resources/application-swagger.yml
+++ b/gateway-service/src/main/resources/application-swagger.yml
@@ -1,0 +1,24 @@
+springdoc:
+  swagger-ui:
+    use-root-path: true
+    urls:
+      - name: payment-service
+        url: /v3/api-docs/payment-service
+
+      - name: review-service
+        url: /v3/api-docs/review-service
+
+      - name: user-service
+        url: /v3/api-docs/user-service
+
+      - name: product-service
+        url: /v3/api-docs/product-service
+
+      - name: order-service
+        url: /v3/api-docs/order-service
+
+      - name: coupon-service
+        url: /v3/api-docs/coupon-service
+
+      - name: timedeal-service
+        url: /v3/api-docs/timedeal-service

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -11,3 +11,4 @@ spring:
       - route
       - security
       - redis
+      - swagger


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #130 

<br>

## 📌 개요
- 게이트웨이에 각 MSA 서비스 Swagger 경로를 등록했습니다.

<br>

## 🔁 변경 사항
- 각 서비스의 스웨거 API 문서가 게이트웨이에 통합됩니다.
- Swagger 관련 url이 필터를 통과하도록 추가했습니다.
- localhost:8080으로 접속하면 자동으로 localhost:8080/swagger-ui/index.html로 이동되도록 설정했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
일단 유저 서비스는 스웨거 추가해서 게이트웨이에 등록되는거 테스트해봤는데 다른 서비스는 나중에 테스트해보고 에러나면 수정하겠습니다!

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
