### PR TITLE
Feat/ProductService 타임딜의 요청에 따른 재고의 증감 구현 & 주문 서비스의 요청에 판매자 ID 추가

### DIFF
--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/DecreaseStockForTimeDealRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/DecreaseStockForTimeDealRes.java
@@ -1,0 +1,14 @@
+package com.palja.product_service.application.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class DecreaseStockForTimeDealRes {
+
+    private UUID productId;
+    private Boolean status;
+}

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/IncreaseStockForTimeDealRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/IncreaseStockForTimeDealRes.java
@@ -1,0 +1,14 @@
+package com.palja.product_service.application.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class IncreaseStockForTimeDealRes {
+
+    private UUID productId;
+    private Boolean status;
+}

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/ProductInfoForOrderRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/ProductInfoForOrderRes.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 public class ProductInfoForOrderRes {
 
     private UUID productId;
+    private UUID companyUserId;
     private String productName;
     private BigDecimal price;
     private int stockQuantity;

--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -28,4 +28,8 @@ public interface ProductService {
     SaleProductRes saleProduct(UUID productId, Integer quantity);
 
     RestoreStockRes stockRestore(UUID productId, Integer quantity);
+
+    DecreaseStockForTimeDealRes decreaseStockForTimeDeal(UUID productId, Integer quantity);
+
+    IncreaseStockForTimeDealRes increaseStockForTimeDeal(UUID productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -8,6 +8,7 @@ import com.palja.product_service.application.dto.res.*;
 import com.palja.product_service.application.service.ProductService;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
 import com.palja.product_service.domain.entity.Product;
+import com.palja.product_service.domain.entity.ProductStock;
 import com.palja.product_service.domain.repository.ProductRepository;
 import com.palja.product_service.domain.repository.RedisRepository;
 import com.palja.product_service.domain.vo.Category;
@@ -169,11 +170,8 @@ public class ProductServiceImpl implements ProductService {
         Product product = repository.findProduct(productId);
         Integer stock = product.getProductStock().getQuantity();
 
-        boolean finish = redisRepository.decreaseStockBySale(hashKey, productId.toString(), stock, quantity);
-
-        if (!finish) {
-            throw new BusinessException(ProductErrorCode.CONNECTION_ERROR_REDIS);
-        }
+        boolean result = redisRepository.decreaseStockBySale(hashKey, productId.toString(), stock, quantity);
+        validateRedisOperation(result);
 
         return new SaleProductRes(productId, Boolean.TRUE);
     }
@@ -182,15 +180,42 @@ public class ProductServiceImpl implements ProductService {
     @Transactional
     public RestoreStockRes stockRestore(UUID productId, Integer quantity) {
 
-        repository.restoreStock(productId, quantity);
+        ProductStock restoredStock = repository.findProduct(productId).increaseStock(quantity);
 
         String hashKey = createRedisHashKey(productId);
-        boolean finish = redisRepository.restoreStock(hashKey, productId.toString(), quantity);
-        if (!finish) {
-            throw new BusinessException(ProductErrorCode.CONNECTION_ERROR_REDIS);
-        }
+        boolean result = redisRepository.adjustStock(
+                hashKey, productId.toString(), restoredStock.getQuantity());
+        validateRedisOperation(result);
 
         return new RestoreStockRes(productId, Boolean.TRUE);
+    }
+
+    @Override
+    @Transactional
+    public DecreaseStockForTimeDealRes decreaseStockForTimeDeal(UUID productId, Integer quantity) {
+
+        ProductStock decreasedStock = repository.findProduct(productId).decreaseStock(quantity);
+
+        String hashKey = createRedisHashKey(productId);
+        boolean result = redisRepository.adjustStock(
+                hashKey, productId.toString(), decreasedStock.getQuantity());
+        validateRedisOperation(result);
+
+        return new DecreaseStockForTimeDealRes(productId, Boolean.TRUE);
+    }
+
+    @Override
+    @Transactional
+    public IncreaseStockForTimeDealRes increaseStockForTimeDeal(UUID productId, Integer quantity) {
+
+        ProductStock increasedStock = repository.findProduct(productId).increaseStock(quantity);
+
+        String hashKey = createRedisHashKey(productId);
+        boolean result = redisRepository.adjustStock(
+                hashKey, productId.toString(), increasedStock.getQuantity());
+        validateRedisOperation(result);
+
+        return new IncreaseStockForTimeDealRes(productId, Boolean.TRUE);
     }
 
     private String createRedisHashKey(UUID productId) {
@@ -202,5 +227,11 @@ public class ProductServiceImpl implements ProductService {
         if(hash % 2 == 0)
             return map0Key;
         else return map1Key;
+    }
+
+    private void validateRedisOperation(boolean redisResult) {
+        if (!redisResult) {
+            throw new BusinessException(ProductErrorCode.CONNECTION_ERROR_REDIS);
+        }
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
@@ -21,6 +21,4 @@ public interface ProductRepository {
     List<Product> findProductsToCondition(FindListByConditionReq condition, Pageable pageable);
 
     void stockBulkUpdateForSchedule(Collection<StockScheduleDto> dtos);
-
-    void restoreStock(UUID productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
@@ -4,5 +4,5 @@ public interface RedisRepository {
 
     boolean decreaseStockBySale(String key, String productId, Integer stock, Integer quantity);
 
-    boolean restoreStock(String hashKey, String productId, Integer quantity);
+    boolean adjustStock(String hashKey, String productId, Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
@@ -42,6 +42,7 @@ public class DslProductRepository {
         return queryFactory.select(Projections.constructor(
                         ProductInfoForOrderRes.class,
                         product.id,
+                        product.companyUserId,
                         product.name,
                         product.price.amount,
                         product.productStock.quantity))

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
@@ -16,8 +16,4 @@ public interface JpaProductRepository extends JpaRepository<Product, UUID> {
     Optional<Product> findByIdFetchStock(@Param("productId") UUID productId);
 
     Boolean existsByCompanyNameAndCategoryAndNameAndDeletedAtIsNull(String companyName, Category category, String name);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE ProductStock ps Set ps.quantity = ps.quantity + :quantity WHERE ps.product.id = :productId")
-    void restoreStock(@Param("productId")UUID productId, @Param("quantity") Integer quantity);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -56,9 +56,4 @@ public class ProductRepositoryImpl implements ProductRepository {
 
         jdbcProductRepository.stockBulkUpdateForSchedule(dtos);
     }
-
-    @Override
-    public void restoreStock(UUID productId, Integer quantity) {
-        jpaProductRepository.restoreStock(productId, quantity);
-    }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
@@ -42,7 +42,7 @@ public class RedisRepositoryImpl implements RedisRepository {
             );
 
             // 레디스에 key로 매핑된 Hash(자바의 Map)을 가져온다.
-            RMap<String, Integer> map = redissonClient.getMap(key);
+            RMap<String, Integer> map = transaction.getMap(key);
 
             //값이 있으면 가져오고 없으면 DB의 재고로 잡는다
             Integer remainStock = map.getOrDefault(productId, stock);
@@ -71,11 +71,9 @@ public class RedisRepositoryImpl implements RedisRepository {
     }
 
     @Override
-    public boolean restoreStock(String hashKey, String productId, Integer quantity) {
+    public boolean adjustStock(String hashKey, String productId, Integer quantity) {
 
         RLock lock = redissonClient.getLock(productId);
-
-        RTransaction transaction = null;
 
         try {
             //락을 10초동안 얻지 못한다면 실패 반환
@@ -83,27 +81,12 @@ public class RedisRepositoryImpl implements RedisRepository {
                 return false;
             }
 
-            transaction = redissonClient.createTransaction(
-                    TransactionOptions.defaults().timeout(10, TimeUnit.SECONDS)
-            );
-
             RMap<String, Integer> map = redissonClient.getMap(hashKey);
 
-            //레디스에 저장된 상품이 아니라면 실패
-            Integer remainStock = map.get(productId);
-            if (Objects.isNull(remainStock)) {
-                return false;
-            }
+            //DB에 먼저 값이 저장되고 레디스에 저장하는 방식이기 때문에, 덮어씌워야함
+            map.fastPut(productId, quantity);
 
-            //레디스에 복구될 재고를 넣는다
-            map.fastPut(productId, remainStock + quantity);
-
-            //예외 없이 모든 작업이 끝난다면 커밋해 레디스에 적용시킨다
-            transaction.commit();
-
-        } catch (Exception e) {
-            if(Objects.nonNull(transaction))
-                transaction.rollback();
+        } catch (InterruptedException e) {
             return false;
         } finally {
             lock.unlock();

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
@@ -105,4 +105,22 @@ public class ProductController {
 
         return new ResponseEntity<>(ApiResponse.success(res, "취소 수량 복구 성공"), HttpStatus.OK);
     }
+
+    @PutMapping("/time-deal/decrease/{productId}")
+    public ResponseEntity<ApiResponse<DecreaseStockForTimeDealRes>> decreaseStockForTimeDeal(@PathVariable UUID productId,
+                                                                   @RequestParam Integer quantity) {
+
+        DecreaseStockForTimeDealRes res = service.decreaseStockForTimeDeal(productId, quantity);
+
+        return new ResponseEntity<>(ApiResponse.success(res, "상품 재고 차감 성공"), HttpStatus.OK);
+    }
+
+    @PutMapping("/time-deal/increase/{productId}")
+    public ResponseEntity<ApiResponse<IncreaseStockForTimeDealRes>> increaseStockForTimeDeal(@PathVariable UUID productId,
+                                                                   @RequestParam Integer quantity) {
+
+        IncreaseStockForTimeDealRes res = service.increaseStockForTimeDeal(productId, quantity);
+
+        return new ResponseEntity<>(ApiResponse.success(res, "상품 재고 증가 성공"), HttpStatus.OK);
+    }
 }

--- a/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
+++ b/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.infrastructure.repository.impl;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RMap;
@@ -49,11 +50,18 @@ class RedisRepositoryImplTest {
     @Autowired
     private RedissonClient redissonClient;
 
+    private final String hashKey = "test:stock";
+
+    @AfterEach
+    void clean() {
+        redissonClient.getMap(hashKey).clear();
+    }
+
     @Test
     @DisplayName("판매에 의한 재고 차감시, 동시성 이슈가 없어야한다")
     void decreaseStockBySale() throws InterruptedException {
         //given
-        String hashName = "Test:stock";
+        String hashName = hashKey;
         String productId = UUID.randomUUID().toString();
         Integer dbStock = 100;
         Integer saleQuantity = 1;
@@ -65,7 +73,6 @@ class RedisRepositoryImplTest {
 
         //when
         for (int i = 1; i <= numOfThreads; i++) {
-            int finalI = i;
             executorService.submit(() -> {
                 try {
                     redisRepository.decreaseStockBySale(hashName, productId, dbStock, saleQuantity);
@@ -81,11 +88,36 @@ class RedisRepositoryImplTest {
 
         //then
         RMap<String, Integer> map = redissonClient.getMap(hashName);
-        RScoredSortedSet<String> timeSet = redissonClient.getScoredSortedSet(hashName + "time");
+        RScoredSortedSet<String> timeSet = redissonClient.getScoredSortedSet(hashName + "Time");
 
         assertThat(map.get(productId)).isEqualTo(0);
         assertThat(timeSet.size()).isEqualTo(1);
 
-        assertThat(timeSet.getScore(productId)).isBetween(beforeTime*1.0, afterTime*1.0);
+        assertThat(timeSet.getScore(productId)).isBetween(beforeTime * 1.0, afterTime * 1.0);
+    }
+
+    @Test
+    @DisplayName("재고 수량 변경에 성공한다")
+    void adjustStock() {
+        //given
+        String hashName = hashKey;
+        String productId = UUID.randomUUID().toString();
+        String productId2 = UUID.randomUUID().toString();
+        Integer beforeStock = 100;
+        Integer afterStock = 200;
+
+        redissonClient.getMap(hashName).fastPut(productId, beforeStock);
+
+        //when
+
+        redisRepository.adjustStock(hashName, productId, afterStock);
+        redisRepository.adjustStock(hashName, productId2, afterStock);
+
+        //then
+        RMap<String, Integer> map = redissonClient.getMap(hashName);
+
+        assertThat(map.size()).isEqualTo(2);
+        assertThat(map.get(productId)).isEqualTo(afterStock);
+        assertThat(map.get(productId2)).isEqualTo(afterStock);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #128 

<br>

## 📌 개요
- 타임딜 서비스에서 들어오는 상품 재고의 차감 & 증가 기능의 구현입니다
- DB에 먼저 반영하고, 반영에 성공하면 레디스에 있는 상품재고에 이를 덮어씌웁니다.

<br>

## 🔁 변경 사항

1. 재고변경에 JPQL이 아닌, 작성했었던 도메인 클래스의 메서드를 사용하도록 변경했습니다.
2. 주문 서비스의 상품 정보 요청의 반환 데이터에 상품에 등록된 판매자의 UUID를 추가했습니다.
3. 레디스의 키 값을 설정파일로 따로 빼고 @Value 어노테이션으로 가져오도록 변경했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
