### PR TITLE
FEAT/ UserService Swagger 작성

### DIFF
--- a/gateway-service/src/main/resources/application-swagger.yml
+++ b/gateway-service/src/main/resources/application-swagger.yml
@@ -1,6 +1,8 @@
 springdoc:
   swagger-ui:
     use-root-path: true
+    operations-sorter: method
+    tags-sorter: alpha
     urls:
       - name: payment-service
         url: /v3/api-docs/payment-service

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -53,13 +53,14 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.palja:common-module:0.6.1'
+    implementation 'com.palja:common-module:0.7.1'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.11'
     annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.11:jpa'
     testImplementation 'org.mockito:mockito-core:5.20.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 }
 
 dependencyManagement {

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
@@ -1,18 +1,76 @@
 package com.palja.user_service.presentation.controller;
 
+import static com.palja.user_service.presentation.util.AuthResponseExamples.*;
+
 import org.springframework.http.ResponseEntity;
 
-import com.palja.common.response.ApiResponse;
 import com.palja.user_service.presentation.dto.request.LoginUserReq;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 
+@Tag(name = "Auth-Controller", description = "인증 관련 API")
 public interface AuthController {
 
-	ResponseEntity<ApiResponse<Void>> login(LoginUserReq requestDto, HttpServletResponse response);
+	@Operation(summary = "로그인", description = "아이디와 비밀번호를 통해 로그인하고 토큰을 발급합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "로그인 되었습니다.",
+			content = @Content(mediaType = "application/json", examples = @ExampleObject(value = LOGIN_SUCCESS))),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+			content = @Content(mediaType = "application/json", examples = {
+				@ExampleObject(name = "잘못된 요청 형식", value = INVALID_BODY),
+				@ExampleObject(name = "아이디 미입력", value = EMPTY_LOGIN_ID),
+				@ExampleObject(name = "비밀번호 미입력", value = EMPTY_PASSWORD),
+			})),
+		@ApiResponse(responseCode = "401", description = "인증에 실패했습니다.",
+			content = @Content(mediaType = "application/json", examples = {
+				@ExampleObject(name = "회원 정보 불일치", value = MISMATCH_INFO),
+				@ExampleObject(name = "가입 대기 상태", value = STATUS_PENDING),
+			})),
+		@ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.",
+			content = @Content(mediaType = "application/json", examples = {
+				@ExampleObject(name = "권한 부족", value = FORBIDDEN),
+			}))
+	})
+	ResponseEntity<com.palja.common.response.ApiResponse<Void>> login(
+		LoginUserReq requestDto, HttpServletResponse response
+	);
 
-	ResponseEntity<ApiResponse<Void>> refresh(String accessToken, String refreshToken, HttpServletResponse response);
 
-	ResponseEntity<ApiResponse<Void>> logout(String accessToken, HttpServletResponse response);
+	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 통해 액세스 토큰을 재발급합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "토큰이 재발급 되었습니다.",
+			content = @Content(mediaType = "application/json", examples = @ExampleObject(value = REFRESH_SUCCESS))),
+		@ApiResponse(responseCode = "401", description = "인증에 실패했습니다.",
+			content = @Content(mediaType = "application/json", examples = {
+				@ExampleObject(name = "잘못된 리프레시 토큰", value = INVALID_REFRESH_TOKEN),
+				@ExampleObject(name = "유효하지 않는 회원", value = INVALID_LOGIN_USER),
+			}))
+	})
+	ResponseEntity<com.palja.common.response.ApiResponse<Void>> refresh(
+		String accessToken, String refreshToken, HttpServletResponse response
+	);
+
+	@Operation(summary = "로그아웃", description = "로그아웃을 하고 액세스 토큰을 블랙리스트에 등록합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "로그아웃 되었습니다.",
+			content = @Content(mediaType = "application/json", examples = @ExampleObject(value = LOGOUT_SUCCESS))),
+		@ApiResponse(responseCode = "401", description = "인증에 실패했습니다.",
+			content = @Content(mediaType = "application/json", examples = {
+				@ExampleObject(name = "유효하지 않는 회원", value = INVALID_LOGIN_USER),
+			})),
+		@ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.",
+			content = @Content(mediaType = "application/json", examples = {
+				@ExampleObject(name = "권한 부족", value = FORBIDDEN),
+			}))
+	})
+	ResponseEntity<com.palja.common.response.ApiResponse<Void>> logout(
+		String accessToken, HttpServletResponse response
+	);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/AuthController.java
@@ -41,7 +41,6 @@ public interface AuthController {
 		LoginUserReq requestDto, HttpServletResponse response
 	);
 
-
 	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 통해 액세스 토큰을 재발급합니다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "토큰이 재발급 되었습니다.",

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -48,10 +48,10 @@ public interface CompanyUserController {
 		@Parameter(example = "company1") String loginId, UpdateCompanyUserReq requestDto
 	);
 
-	@Operation(summary = "업체 판매자 상태 수정", description = "현재 로그인한 업체 판매자 자신의 정보를 수정합니다.")
+	@Operation(summary = "업체 판매자 수정 - 본인", description = "현재 로그인한 업체 판매자 자신의 정보를 수정합니다.")
 	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateMe(UpdateCompanyUserReq requestDto);
 
-	@Operation(summary = "업체 판매자 수정 - 본인", description = "업체 판매자의 상태를 변경합니다.")
+	@Operation(summary = "업체 판매자 상태 수정", description = "업체 판매자의 상태를 변경합니다.")
 	ResponseEntity<ApiResponse<Void>> updateStatus(
 		@Parameter(example = "company1") String loginId, UpdateCompanyUserStatusReq requestDto
 	);

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -2,6 +2,7 @@ package com.palja.user_service.presentation.controller;
 
 import java.util.UUID;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
@@ -15,32 +16,53 @@ import com.palja.user_service.presentation.dto.request.CreateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserReq;
 import com.palja.user_service.presentation.dto.request.UpdateCompanyUserStatusReq;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 
+@Tag(name = "CompanyUser-Controller", description = "업체 판매자 관련 API")
 public interface CompanyUserController {
 
+	@Operation(summary = "업체 판매자 생성", description = "새로운 업체 판매자를 생성합니다.")
 	ResponseEntity<ApiResponse<CreateUserRes>> create(CreateCompanyUserReq requestDto);
 
+	@Operation(summary = "업체 판매자 목록 조회", description = "검색 조건에 해당하는 업체 판매자 목록을 페이징하여 조회합니다.")
 	ResponseEntity<ApiResponse<PageResponse<ReadCompanyUserSummaryRes>>> getAll(
-		String loginId, String email, String name, String status, Pageable pageable
+		String loginId, String email, String name, String status, @ParameterObject Pageable pageable
 	);
 
-	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByLoginId(String loginId);
+	@Operation(summary = "업체 판매자 조회 - LoginID", description = "LoginID가 일치하는 업체 판매자의 상세 정보를 조회합니다.")
+	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByLoginId(@Parameter(example = "company1") String loginId);
 
-	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByCompanyUserId(UUID companyUserId);
+	@Operation(summary = "업체 판매자 조회 - UserID", description = "UserID가 일치하는 업체 판매자의 상세 정보를 조회합니다.")
+	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByCompanyUserId(
+		@Parameter(example = "02d2d97b-4cfa-4438-9e8c-6f68709dfbff") UUID companyUserId
+	);
 
+	@Operation(summary = "업체 판매자 조회 - 본인", description = "현재 로그인한 업체 판매자 자신의 상세 정보를 조회합니다.")
 	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getMe();
 
-	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateByLoginId(String loginId, UpdateCompanyUserReq requestDto);
+	@Operation(summary = "업체 판매자 수정 - LoginID", description = "LoginID가 일치하는 업체 판매자의 정보를 수정합니다.")
+	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateByLoginId(
+		@Parameter(example = "company1") String loginId, UpdateCompanyUserReq requestDto
+	);
 
+	@Operation(summary = "업체 판매자 수정 - 본인", description = "현재 로그인한 업체 판매자 자신의 정보를 수정합니다.")
 	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateMe(UpdateCompanyUserReq requestDto);
 
-	ResponseEntity<ApiResponse<Void>> updateStatus(String loginId, UpdateCompanyUserStatusReq requestDto);
+	@Operation(summary = "업체 판매자 수정 - 본인", description = "업체 판매자의 상태를 변경합니다.")
+	ResponseEntity<ApiResponse<Void>> updateStatus(
+		@Parameter(example = "company1") String loginId, UpdateCompanyUserStatusReq requestDto
+	);
 
-	ResponseEntity<ApiResponse<Void>> deleteByLoginId(String loginId);
+	@Operation(summary = "업체 판매자 삭제 - LoginID", description = "LoginID가 일치하는 업체 판매자를 삭제합니다.")
+	ResponseEntity<ApiResponse<Void>> deleteByLoginId(@Parameter(example = "company1") String loginId);
 
+	@Operation(summary = "업체 판매자 삭제 - 본인", description = "현재 로그인한 업체 판매자 자신을 삭제합니다.")
 	ResponseEntity<ApiResponse<Void>> deleteMe(String accessToken, HttpServletResponse response);
 
-	ResponseEntity<ApiResponse<Void>> reject(String loginId);
+	@Operation(summary = "업체 판매자 삭제 - 가입 거절", description = "회원 가입 요청을 거절하고 업체 판매자를 삭제합니다.")
+	ResponseEntity<ApiResponse<Void>> reject(@Parameter(example = "company1") String loginId);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -48,7 +48,7 @@ public interface CompanyUserController {
 		@Parameter(example = "company1") String loginId, UpdateCompanyUserReq requestDto
 	);
 
-	@Operation(summary = "업체 판매자 수정 - 본인", description = "현재 로그인한 업체 판매자 자신의 정보를 수정합니다.")
+	@Operation(summary = "업체 판매자 상태 수정", description = "현재 로그인한 업체 판매자 자신의 정보를 수정합니다.")
 	ResponseEntity<ApiResponse<UpdateCompanyUserDetailRes>> updateMe(UpdateCompanyUserReq requestDto);
 
 	@Operation(summary = "업체 판매자 수정 - 본인", description = "업체 판매자의 상태를 변경합니다.")

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CompanyUserController.java
@@ -35,7 +35,7 @@ public interface CompanyUserController {
 	@Operation(summary = "업체 판매자 조회 - LoginID", description = "LoginID가 일치하는 업체 판매자의 상세 정보를 조회합니다.")
 	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByLoginId(@Parameter(example = "company1") String loginId);
 
-	@Operation(summary = "업체 판매자 조회 - UserID", description = "UserID가 일치하는 업체 판매자의 상세 정보를 조회합니다.")
+	@Operation(summary = "업체 판매자 조회 - CompanyUserID", description = "CompanyUserID가 일치하는 업체 판매자의 상세 정보를 조회합니다.")
 	ResponseEntity<ApiResponse<ReadCompanyUserDetailRes>> getByCompanyUserId(
 		@Parameter(example = "02d2d97b-4cfa-4438-9e8c-6f68709dfbff") UUID companyUserId
 	);

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/CustomerController.java
@@ -1,5 +1,6 @@
 package com.palja.user_service.presentation.controller;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
@@ -12,28 +13,43 @@ import com.palja.user_service.application.dto.response.UpdateCustomerDetailRes;
 import com.palja.user_service.presentation.dto.request.CreateCustomerReq;
 import com.palja.user_service.presentation.dto.request.UpdateCustomerReq;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 
+@Tag(name = "Customer-Controller", description = "일반 사용자 관련 API")
 public interface CustomerController {
 
+	@Operation(summary = "일반 사용자 생성", description = "새로운 일반 사용자를 생성합니다.")
 	ResponseEntity<ApiResponse<CreateUserRes>> create(CreateCustomerReq requestDto);
 
+	@Operation(summary = "일반 사용자 목록 조회", description = "검색 조건에 해당하는 일반 사용자 목록을 페이징하여 조회합니다.")
 	ResponseEntity<ApiResponse<PageResponse<ReadCustomerSummaryRes>>> getAll(
-		String loginId, String email, String name, Pageable pageable
+		String loginId, String email, String name, @ParameterObject Pageable pageable
 	);
 
-	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByLoginId(String loginId);
+	@Operation(summary = "일반 사용자 조회 - LoginID", description = "LoginID가 일치하는 일반 사용자의 상세 정보를 조회합니다.")
+	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByLoginId(@Parameter(example = "customer1") String loginId);
 
-	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByUserId(Long userId);
+	@Operation(summary = "일반 사용자 조회 - UserID", description = "UserID가 일치하는 일반 사용자의 상세 정보를 조회합니다.")
+	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getByUserId(@Parameter(example = "1") Long userId);
 
+	@Operation(summary = "일반 사용자 조회 - 본인", description = "현재 로그인한 일반 사용자 자신의 상세 정보를 조회합니다.")
 	ResponseEntity<ApiResponse<ReadCustomerDetailRes>> getMe();
 
-	ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateByLoginId(String loginId, UpdateCustomerReq requestDto);
+	@Operation(summary = "일반 사용자 수정 - LoginID", description = "LoginID가 일치하는 일반 사용자의 정보를 수정합니다.")
+	ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateByLoginId(
+		@Parameter(example = "customer1") String loginId, UpdateCustomerReq requestDto
+	);
 
+	@Operation(summary = "일반 사용자 수정 - 본인", description = "현재 로그인한 일반 사용자 자신의 정보를 수정합니다.")
 	ResponseEntity<ApiResponse<UpdateCustomerDetailRes>> updateMe(UpdateCustomerReq requestDto);
 
-	ResponseEntity<ApiResponse<Void>> deleteByLoginId(String loginId);
+	@Operation(summary = "일반 사용자 삭제 - LoginID", description = "LoginID가 일치하는 일반 사용자를 삭제합니다.")
+	ResponseEntity<ApiResponse<Void>> deleteByLoginId(@Parameter(example = "customer1") String loginId);
 
+	@Operation(summary = "일반 사용자 삭제 - 본인", description = "현재 로그인한 일반 사용자 자신을 삭제합니다.")
 	ResponseEntity<ApiResponse<Void>> deleteMe(String accessToken, HttpServletResponse response);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/controller/ManagerController.java
@@ -1,8 +1,8 @@
 package com.palja.user_service.presentation.controller;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
@@ -13,24 +13,39 @@ import com.palja.user_service.application.dto.response.UpdateManagerDetailRes;
 import com.palja.user_service.presentation.dto.request.CreateManagerReq;
 import com.palja.user_service.presentation.dto.request.UpdateManagerReq;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Manager-Controller", description = "관리자 관련 API")
 public interface ManagerController {
 
+	@Operation(summary = "관리자 생성", description = "새로운 관리자를 생성합니다.")
 	ResponseEntity<ApiResponse<CreateUserRes>> create(CreateManagerReq requestDto);
 
+	@Operation(summary = "관리자 목록 조회", description = "검색 조건에 해당하는 관리자 목록을 페이징하여 조회합니다.")
 	ResponseEntity<ApiResponse<PageResponse<ReadManagerSummaryRes>>> getAll(
-		String loginId, String email, String name, Pageable pageable
+		String loginId, String email, String name, @ParameterObject Pageable pageable
 	);
 
-	ResponseEntity<ApiResponse<ReadManagerDetailRes>> getByLoginId(String loginId);
+	@Operation(summary = "관리자 조회 - LoginID", description = "LoginID가 일치하는 관리자의 상세 정보를 조회합니다.")
+	ResponseEntity<ApiResponse<ReadManagerDetailRes>> getByLoginId(@Parameter(example = "manager1") String loginId);
 
-	ResponseEntity<ApiResponse<ReadManagerDetailRes>> getByUserId(Long userId);
+	@Operation(summary = "관리자 조회 - UserID", description = "UserID가 일치하는 관리자의 상세 정보를 조회합니다.")
+	ResponseEntity<ApiResponse<ReadManagerDetailRes>> getByUserId(@Parameter(example = "1") Long userId);
 
+	@Operation(summary = "관리자 조회 - 본인", description = "현재 로그인한 관리자 자신의 상세 정보를 조회합니다.")
 	ResponseEntity<ApiResponse<ReadManagerDetailRes>> getMe();
 
-	ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateByLoginId(String loginId, UpdateManagerReq requestDto);
+	@Operation(summary = "관리자 수정 - LoginID", description = "LoginID가 일치하는 관리자의 정보를 수정합니다.")
+	ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateByLoginId(
+		@Parameter(example = "manager1") String loginId, UpdateManagerReq requestDto
+	);
 
+	@Operation(summary = "관리자 수정 - 본인", description = "현재 로그인한 관리자 자신의 정보를 수정합니다.")
 	ResponseEntity<ApiResponse<UpdateManagerDetailRes>> updateMe(UpdateManagerReq requestDto);
 
-	ResponseEntity<ApiResponse<Void>> deleteByLoginId(String loginId);
+	@Operation(summary = "관리자 삭제 - LoginID", description = "LoginID가 일치하는 관리자를 삭제합니다.")
+	ResponseEntity<ApiResponse<Void>> deleteByLoginId(@Parameter(example = "manager1") String loginId);
 
 }

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/CreateCompanyUserReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/CreateCompanyUserReq.java
@@ -7,6 +7,7 @@ import com.palja.user_service.presentation.dto.validation.annotation.ValidLoginI
 import com.palja.user_service.presentation.dto.validation.annotation.ValidName;
 import com.palja.user_service.presentation.dto.validation.annotation.ValidPassword;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,24 +17,31 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateCompanyUserReq {
 
+	@Schema(description = "아이디", example = "company1")
 	@ValidLoginId
 	private String loginId;
 
+	@Schema(description = "비밀번호", example = "Password123!")
 	@ValidPassword
 	private String password;
 
+	@Schema(description = "이름", example = "판매자")
 	@ValidName
 	private String name;
 
+	@Schema(description = "업체 이름", example = "업체1")
 	@NotBlank(message = "업체 이름을 입력해주세요.")
 	private String companyName;
 
+	@Schema(description = "사업자 등록 번호", example = "123-45-67890")
 	@ValidCompanyNumber
 	private String companyNumber;
 
+	@Schema(description = "이메일", example = "company1@gmail.com")
 	@ValidEmail
 	private String email;
 
+	@Schema(description = "주소", example = "서울시 강남구 테헤란로 123")
 	@NotBlank(message = "주소를 입력해주세요.")
 	private String address;
 

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/CreateCustomerReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/CreateCustomerReq.java
@@ -6,6 +6,7 @@ import com.palja.user_service.presentation.dto.validation.annotation.ValidLoginI
 import com.palja.user_service.presentation.dto.validation.annotation.ValidName;
 import com.palja.user_service.presentation.dto.validation.annotation.ValidPassword;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,18 +16,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateCustomerReq {
 
+	@Schema(description = "아이디", example = "customer1")
 	@ValidLoginId
 	private String loginId;
 
+	@Schema(description = "비밀번호", example = "Password123!")
 	@ValidPassword
 	private String password;
 
+	@Schema(description = "이름", example = "사용자")
 	@ValidName
 	private String name;
 
+	@Schema(description = "이메일", example = "customer1@gmail.com")
 	@ValidEmail
 	private String email;
 
+	@Schema(description = "주소", example = "서울시 강남구 테헤란로 123")
 	@NotBlank(message = "주소를 입력해주세요.")
 	private String address;
 

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/CreateManagerReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/CreateManagerReq.java
@@ -6,6 +6,7 @@ import com.palja.user_service.presentation.dto.validation.annotation.ValidLoginI
 import com.palja.user_service.presentation.dto.validation.annotation.ValidName;
 import com.palja.user_service.presentation.dto.validation.annotation.ValidPassword;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,18 +16,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateManagerReq {
 
+	@Schema(description = "아이디", example = "manager1")
 	@ValidLoginId
 	private String loginId;
 
+	@Schema(description = "비밀번호", example = "Password123!")
 	@ValidPassword
 	private String password;
 
+	@Schema(description = "이름", example = "관리자")
 	@ValidName
 	private String name;
 
+	@Schema(description = "이메일", example = "manager1@gmail.com")
 	@ValidEmail
 	private String email;
 
+	@Schema(description = "주소", example = "서울시 강남구 테헤란로 123")
 	@NotBlank(message = "주소를 입력해주세요.")
 	private String address;
 

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/LoginUserReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/LoginUserReq.java
@@ -2,6 +2,7 @@ package com.palja.user_service.presentation.dto.request;
 
 import com.palja.user_service.application.command.LoginUserCommand;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,9 +12,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LoginUserReq {
 
+	@Schema(description = "아이디", example = "manager1")
 	@NotBlank(message = "아이디를 입력해주세요.")
 	private String loginId;
 
+	@Schema(description = "비밀번호", example = "Password123!")
 	@NotBlank(message = "비밀번호를 입력해주세요.")
 	private String password;
 

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCompanyUserReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCompanyUserReq.java
@@ -2,6 +2,7 @@ package com.palja.user_service.presentation.dto.request;
 
 import com.palja.user_service.application.command.UpdateCompanyUserCommand;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UpdateCompanyUserReq {
 
+	@Schema(description = "업체 이름", example = "업체1")
 	private String companyName;
+
+	@Schema(description = "주소", example = "서울시 강남구 테헤란로 123")
 	private String address;
 
 	public static UpdateCompanyUserCommand of(UpdateCompanyUserReq requestDto) {

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCompanyUserStatusReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCompanyUserStatusReq.java
@@ -2,6 +2,7 @@ package com.palja.user_service.presentation.dto.request;
 
 import com.palja.user_service.application.command.UpdateCompanyUserStatusCommand;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UpdateCompanyUserStatusReq {
 
+	@Schema(description = "상태", example = "active")
 	@NotBlank(message = "상태를 입력해주세요.")
 	private String status;
 

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCustomerReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateCustomerReq.java
@@ -2,6 +2,7 @@ package com.palja.user_service.presentation.dto.request;
 
 import com.palja.user_service.application.command.UpdateCustomerCommand;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UpdateCustomerReq {
 
+	@Schema(description = "주소", example = "서울시 강남구 테헤란로 123")
 	private String address;
 
 	public static UpdateCustomerCommand of(UpdateCustomerReq requestDto) {

--- a/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateManagerReq.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/dto/request/UpdateManagerReq.java
@@ -2,6 +2,7 @@ package com.palja.user_service.presentation.dto.request;
 
 import com.palja.user_service.application.command.UpdateManagerCommand;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UpdateManagerReq {
 
+	@Schema(description = "주소", example = "서울시 강남구 테헤란로 123")
 	private String address;
 
 	public static UpdateManagerCommand of(UpdateManagerReq requestDto) {

--- a/user-service/src/main/java/com/palja/user_service/presentation/util/AuthResponseExamples.java
+++ b/user-service/src/main/java/com/palja/user_service/presentation/util/AuthResponseExamples.java
@@ -1,0 +1,93 @@
+package com.palja.user_service.presentation.util;
+
+public class AuthResponseExamples {
+
+	public static final String LOGIN_SUCCESS = """
+		{
+			"success": true,
+			"code": "OK",
+			"message": "로그인 되었습니다."
+		}
+		""";
+
+	public static final String REFRESH_SUCCESS = """
+		{
+			"success": true,
+			"code": "OK",
+			"message": "토큰이 재발급 되었습니다."
+		}
+		""";
+
+	public static final String LOGOUT_SUCCESS = """
+		{
+		    "success": true,
+		    "code": "OK",
+		    "message": "로그아웃 되었습니다."
+		}
+		""";
+
+	public static final String INVALID_BODY = """
+		{
+			"success": false,
+			"code": "BAD_REQUEST",
+			"message": "잘못된 입력값입니다 (형식을 확인해주세요.)"
+		}
+		""";
+
+	public static final String EMPTY_LOGIN_ID = """
+		{
+		    "success": false,
+		    "code": "BAD_REQUEST",
+		    "message": "잘못된 입력값입니다 ({loginId=아이디를 입력해주세요.})"
+		}
+		""";
+
+	public static final String EMPTY_PASSWORD = """
+		{
+		    "success": false,
+		    "code": "BAD_REQUEST",
+		    "message": "잘못된 입력값입니다 ({loginId=비밀번호를 입력해주세요.})"
+		}
+		""";
+
+	public static final String MISMATCH_INFO = """
+		{
+		    "success": false,
+		    "code": "UNAUTHORIZED",
+		    "message": "로그인 정보가 잘못되었습니다."
+		}
+		""";
+
+	public static final String STATUS_PENDING = """
+		{
+		    "success": false,
+		    "code": "UNAUTHORIZED",
+		    "message": "가입 승인 대기 중인 계정입니다."
+		}
+		""";
+
+	public static final String FORBIDDEN = """
+		{
+		    "success": false,
+		    "code": "FORBIDDEN",
+		    "message": "권한이 없습니다"
+		}
+		""";
+
+	public static final String INVALID_REFRESH_TOKEN = """
+		{
+		    "success": false,
+		    "code": "UNAUTHORIZED",
+		    "message": "다시 로그인해주세요."
+		}
+		""";
+
+	public static final String INVALID_LOGIN_USER = """
+		{
+		    "success": false,
+		    "code": "UNAUTHORIZED",
+		    "message": "다시 로그인해주세요."
+		}
+		""";
+
+}

--- a/user-service/src/main/resources/application-swagger.yml
+++ b/user-service/src/main/resources/application-swagger.yml
@@ -1,0 +1,5 @@
+springdoc:
+  group:
+    name: user-service
+  swagger-ui:
+    enabled: false

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -12,3 +12,4 @@ spring:
       - security
       - redis
       - eureka
+      - swagger


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #121 

<br>

## 📌 개요
- 유저 서비스의 각 Controller 및 RequestDto에 Swagger 설정 코드를 추가했습니다.

<br>

## 🔁 변경 사항
- AuthController
  - Controller에 이름과 설명을 추가했습니다.
  - DTO에 예시 데이터를 추가했습니다. 
  - 성공 및 실패 응답 예시를 작성했습니다.
- ManagerController, CustomerController, CompanyUserController
  - Controller에 이름과 설명을 추가했습니다.
  - DTO에 예시 데이터를 추가했습니다. 
- 게이트웨이 포트(8080)에 user-service의 Swagger를 등록했습니다.
- Swagger에서 각 API를 알파벳과 메서드 순으로 정렬했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
지금 Common에 FeignClientConfig도 추가해야하는데 만약 버전을 올리면 지금 단계에서 모든 분들이 ApiResponse 이름을 변경해주셔야 해서 Common의 ApiResponse 이름 변경은 다른 분들 MVP 개발이 끝나시면 하겠습니다! 

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
