### PR TITLE
FEAT/ProductService 상품 삭제 기능 구현

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.kafka:spring-kafka'
-    implementation 'com.palja:common-module:0.6.0'
+    implementation 'com.palja:common-module:0.7.1'
     implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.11'
     annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.11:jpa'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -32,4 +32,6 @@ public interface ProductService {
     DecreaseStockForTimeDealRes decreaseStockForTimeDeal(UUID productId, Integer quantity);
 
     IncreaseStockForTimeDealRes increaseStockForTimeDeal(UUID productId, Integer quantity);
+
+    void deleteProduct(UUID productId);
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -218,6 +218,20 @@ public class ProductServiceImpl implements ProductService {
         return new IncreaseStockForTimeDealRes(productId, Boolean.TRUE);
     }
 
+    @Override
+    @Transactional
+    public void deleteProduct(UUID productId) {
+
+        /**
+         * TODO: 로그인 아이디를 받아와서, 그 아이디로 유저서비스에서 UUID를 가져와 비교해야함.
+         */
+        Product product = repository.findProduct(productId);
+        repository.deleteProduct(product);
+
+        boolean result = redisRepository.deleteProductStock(createRedisHashKey(productId), productId.toString());
+        validateRedisOperation(result);
+    }
+
     private String createRedisHashKey(UUID productId) {
 
         //상품 아이디의 앞 7자리를 해시해, 짝수냐 아니냐로 키를 나눔

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -226,7 +226,7 @@ public class ProductServiceImpl implements ProductService {
          * TODO: 로그인 아이디를 받아와서, 그 아이디로 유저서비스에서 UUID를 가져와 비교해야함.
          */
         Product product = repository.findProduct(productId);
-        repository.deleteProduct(product);
+        product.delete();
 
         boolean result = redisRepository.deleteProductStock(createRedisHashKey(productId), productId.toString());
         validateRedisOperation(result);

--- a/product-service/src/main/java/com/palja/product_service/domain/entity/Product.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/entity/Product.java
@@ -119,4 +119,9 @@ public class Product extends BaseEntity {
         this.price = price.multiply(rate);
         return this.price;
     }
+
+    public void delete() {
+        this.productStock.delete();
+        super.softDelete();
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/entity/ProductStock.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/entity/ProductStock.java
@@ -48,4 +48,8 @@ public class ProductStock extends BaseEntity {
         this.quantity = quantity;
         return this;
     }
+
+    protected void delete() {
+        super.softDelete();
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
@@ -21,4 +21,6 @@ public interface ProductRepository {
     List<Product> findProductsToCondition(FindListByConditionReq condition, Pageable pageable);
 
     void stockBulkUpdateForSchedule(Collection<StockScheduleDto> dtos);
+
+    void deleteProduct(Product product);
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/RedisRepository.java
@@ -5,4 +5,6 @@ public interface RedisRepository {
     boolean decreaseStockBySale(String key, String productId, Integer stock, Integer quantity);
 
     boolean adjustStock(String hashKey, String productId, Integer quantity);
+
+    boolean deleteProductStock(String hashKey, String productId);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -56,4 +56,10 @@ public class ProductRepositoryImpl implements ProductRepository {
 
         jdbcProductRepository.stockBulkUpdateForSchedule(dtos);
     }
+
+    @Override
+    public void deleteProduct(Product product) {
+
+        jpaProductRepository.delete(product);
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
@@ -94,6 +94,28 @@ public class RedisRepositoryImpl implements RedisRepository {
         return true;
     }
 
+    @Override
+    public boolean deleteProductStock(String hashKey, String productId) {
+
+        RLock lock = redissonClient.getLock(productId);
+
+        try {
+            //락을 10초동안 얻지 못한다면 실패 반환
+            if (!lock.tryLock(10, 10, TimeUnit.SECONDS)) {
+                return false;
+            }
+
+            RMap<String, Integer> map = redissonClient.getMap(hashKey);
+            map.fastRemove(productId);
+
+        } catch (InterruptedException e) {
+            return false;
+        } finally {
+            lock.unlock();
+        }
+        return true;
+    }
+
     private void setTime(String setKey, String productId) {
 
         long score = LocalDateTime.now().plusMinutes(1).toEpochSecond(ZoneOffset.UTC);

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImpl.java
@@ -106,7 +106,10 @@ public class RedisRepositoryImpl implements RedisRepository {
             }
 
             RMap<String, Integer> map = redissonClient.getMap(hashKey);
+            RScoredSortedSet<String> set = redissonClient.getScoredSortedSet(hashKey+timeSuffix);
+
             map.fastRemove(productId);
+            set.remove(productId);
 
         } catch (InterruptedException e) {
             return false;

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/ProductController.java
@@ -123,4 +123,11 @@ public class ProductController {
 
         return new ResponseEntity<>(ApiResponse.success(res, "상품 재고 증가 성공"), HttpStatus.OK);
     }
+
+    @DeleteMapping("/manager/{productId}")
+    public ResponseEntity<ApiResponse<?>> deleteProduct(@PathVariable UUID productId) {
+
+        service.deleteProduct(productId);
+        return new ResponseEntity<>(ApiResponse.success("상품 삭제 성공"), HttpStatus.OK);
+    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #138 

<br>

## 📌 개요
- DB에서 상품을 논리적 삭제한다
- 레디스에 재고정보도 삭제한다

<br>

## 🔁 변경 사항

1. Common 모듈 버전 0.7.1로 변경했습니다
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

판매자의 UUID와 상품의 판매자 ID의 검증은 구현되지 않았습니다.
<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
