### PR TITLE
REFACTOR/Coupon Service Swagger 문서화 적용 및 응답 DTO 분리

### DIFF
--- a/coupon-service/build.gradle
+++ b/coupon-service/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -52,7 +54,7 @@ dependencies {
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'com.palja:common-module:0.7.1'
+    implementation 'com.palja:common-module:0.8.1'
 }
 
 dependencyManagement {

--- a/coupon-service/src/main/java/com/palja/coupon_service/CouponServiceApplication.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/CouponServiceApplication.java
@@ -2,11 +2,13 @@ package com.palja.coupon_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableDiscoveryClient
 @ComponentScan(basePackages = {"com.palja.coupon_service", "com.palja.common"})
 public class CouponServiceApplication {
 

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ChangeStatusCouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ChangeStatusCouponRes.java
@@ -1,0 +1,25 @@
+package com.palja.coupon_service.application.dto.coupon;
+
+import com.palja.coupon_service.domain.entity.Coupon;
+import com.palja.coupon_service.domain.vo.CouponStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public class ChangeStatusCouponRes {
+    private UUID couponId;
+    private CouponStatus couponStatus;
+    private LocalDateTime updateAt;
+    private String updateBy;
+
+    public static ChangeStatusCouponRes from(Coupon coupon) {
+        return ChangeStatusCouponRes.builder()
+                .couponId(coupon.getId())
+                .couponStatus(coupon.getStatus())
+                .updateAt(LocalDateTime.now())
+                .updateBy("updateBy")
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ChangeStatusCouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ChangeStatusCouponRes.java
@@ -18,8 +18,8 @@ public class ChangeStatusCouponRes {
         return ChangeStatusCouponRes.builder()
                 .couponId(coupon.getId())
                 .couponStatus(coupon.getStatus())
-                .updateAt(LocalDateTime.now())
-                .updateBy("updateBy")
+                .updateAt(coupon.getUpdatedAt())
+                .updateBy(coupon.getUpdatedBy())
                 .build();
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/CreateCouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/CreateCouponRes.java
@@ -1,0 +1,44 @@
+package com.palja.coupon_service.application.dto.coupon;
+
+import com.palja.coupon_service.domain.entity.Coupon;
+import com.palja.coupon_service.domain.vo.CouponStatus;
+import com.palja.coupon_service.domain.vo.DiscountType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CreateCouponRes {
+    private UUID couponId;
+    private String couponName;
+    private String description;
+    private DiscountType discountType;
+    private Integer discountValue;
+    private Integer totalQuantity;
+    private Integer maxDiscountAmount;
+    private Integer minOrderAmount;
+    private LocalDateTime issueStartAt;
+    private LocalDateTime issueEndAt;
+    private Integer usageDays;
+    private CouponStatus status;
+
+    public static CreateCouponRes from(Coupon coupon) {
+        return CreateCouponRes.builder()
+                .couponId(coupon.getId())
+                .couponName(coupon.getName())
+                .description(coupon.getDescription())
+                .discountType(coupon.getDiscountPolicy().getDiscountType())
+                .discountValue(coupon.getDiscountPolicy().getDiscountValue())
+                .totalQuantity(coupon.getTotalQuantity())
+                .maxDiscountAmount(coupon.getAmountPolicy().getMaxDiscountAmount())
+                .minOrderAmount(coupon.getAmountPolicy().getMinOrderAmount())
+                .issueStartAt(coupon.getIssuePeriod().getIssueStartAt())
+                .issueEndAt(coupon.getIssuePeriod().getIssueEndAt())
+                .usageDays(coupon.getUsageDays())
+                .status(coupon.getStatus())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponDetailRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponDetailRes.java
@@ -1,4 +1,4 @@
-package com.palja.coupon_service.application.dto;
+package com.palja.coupon_service.application.dto.coupon;
 
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.vo.CouponStatus;
@@ -6,13 +6,12 @@ import com.palja.coupon_service.domain.vo.DiscountType;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
 @Builder
-public class CouponDetailRes {
+public class ReadCouponDetailRes {
     private UUID couponId;
     private String couponName;
     private String description;
@@ -31,8 +30,8 @@ public class CouponDetailRes {
     private LocalDateTime updatedAt;
     private String updatedBy;
 
-    public static CouponDetailRes from(Coupon coupon) {
-        return CouponDetailRes.builder()
+    public static ReadCouponDetailRes from(Coupon coupon) {
+        return ReadCouponDetailRes.builder()
                 .couponId(coupon.getId())
                 .couponName(coupon.getName())
                 .description(coupon.getDescription())

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponRes.java
@@ -1,0 +1,38 @@
+package com.palja.coupon_service.application.dto.coupon;
+
+import com.palja.coupon_service.domain.entity.Coupon;
+import com.palja.coupon_service.domain.vo.CouponStatus;
+import com.palja.coupon_service.domain.vo.DiscountType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public class ReadCouponRes {
+    private UUID couponId;
+    private String couponName;
+    private DiscountType discountType;
+    private Integer discountValue;
+    private Integer totalQuantity;
+    private Integer issuedQuantity;
+    private LocalDateTime issueStartAt;
+    private LocalDateTime issueEndAt;
+    private Integer usageDays;
+    private CouponStatus status;
+
+    public static ReadCouponRes from(Coupon coupon) {
+        return ReadCouponRes.builder()
+                .couponId(coupon.getId())
+                .couponName(coupon.getName())
+                .discountType(coupon.getDiscountPolicy().getDiscountType())
+                .discountValue(coupon.getDiscountPolicy().getDiscountValue())
+                .totalQuantity(coupon.getTotalQuantity())
+                .issuedQuantity(coupon.getIssuedQuantity())
+                .issueStartAt(coupon.getIssuePeriod().getIssueStartAt())
+                .issueEndAt(coupon.getIssuePeriod().getIssueEndAt())
+                .usageDays(coupon.getUsageDays())
+                .status(coupon.getStatus())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/UpdateCouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/UpdateCouponRes.java
@@ -1,45 +1,38 @@
-package com.palja.coupon_service.application.dto;
+package com.palja.coupon_service.application.dto.coupon;
 
 import com.palja.coupon_service.domain.entity.Coupon;
-import com.palja.coupon_service.domain.vo.CouponStatus;
-import com.palja.coupon_service.domain.vo.DiscountType;
 import lombok.Builder;
-import lombok.Getter;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@Getter
 @Builder
-public class CouponRes {
+public class UpdateCouponRes {
     private UUID couponId;
-    private String couponName;
+    private String name;
     private String description;
-    private DiscountType discountType;
-    private Integer discountValue;
     private Integer totalQuantity;
     private Integer maxDiscountAmount;
     private Integer minOrderAmount;
     private LocalDateTime issueStartAt;
     private LocalDateTime issueEndAt;
     private Integer usageDays;
-    private CouponStatus status;
+    private LocalDateTime updateAt;
+    private String updateBy;
 
-    public static CouponRes from(Coupon coupon) {
-        return CouponRes.builder()
+    public static UpdateCouponRes from(Coupon coupon) {
+        return UpdateCouponRes.builder()
                 .couponId(coupon.getId())
-                .couponName(coupon.getName())
+                .name(coupon.getName())
                 .description(coupon.getDescription())
-                .discountType(coupon.getDiscountPolicy().getDiscountType())
-                .discountValue(coupon.getDiscountPolicy().getDiscountValue())
                 .totalQuantity(coupon.getTotalQuantity())
                 .maxDiscountAmount(coupon.getAmountPolicy().getMaxDiscountAmount())
                 .minOrderAmount(coupon.getAmountPolicy().getMinOrderAmount())
                 .issueStartAt(coupon.getIssuePeriod().getIssueStartAt())
                 .issueEndAt(coupon.getIssuePeriod().getIssueEndAt())
                 .usageDays(coupon.getUsageDays())
-                .status(coupon.getStatus())
+                .updateAt(coupon.getUpdatedAt())
+                .updateBy(coupon.getUpdatedBy())
                 .build();
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/CancelCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/CancelCouponUserRes.java
@@ -1,0 +1,22 @@
+package com.palja.coupon_service.application.dto.couponUser;
+
+import com.palja.coupon_service.domain.entity.CouponUser;
+import com.palja.coupon_service.domain.vo.CouponUserStatus;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public class CancelCouponUserRes {
+    private UUID couponUserId;
+    private String userId;
+    private CouponUserStatus status;
+
+    public static CancelCouponUserRes from(CouponUser couponUser){
+        return CancelCouponUserRes.builder()
+                .couponUserId(couponUser.getId())
+                .userId(couponUser.getUserId())
+                .status(couponUser.getStatus())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ChangeStatusCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ChangeStatusCouponUserRes.java
@@ -1,0 +1,27 @@
+package com.palja.coupon_service.application.dto.couponUser;
+
+import com.palja.coupon_service.domain.entity.CouponUser;
+import com.palja.coupon_service.domain.vo.CouponUserStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public class ChangeStatusCouponUserRes {
+    private UUID couponUserId;
+    private String userId;
+    private CouponUserStatus couponUserStatus;
+    private LocalDateTime updateAt;
+    private String updateBy;
+
+    public static ChangeStatusCouponUserRes from(CouponUser couponUser) {
+        return ChangeStatusCouponUserRes.builder()
+                .couponUserId(couponUser.getId())
+                .userId(couponUser.getUserId())
+                .couponUserStatus(couponUser.getStatus())
+                .updateAt(couponUser.getUsedAt())
+                .updateBy(couponUser.getUpdatedBy())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/CreateCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/CreateCouponUserRes.java
@@ -1,0 +1,43 @@
+package com.palja.coupon_service.application.dto.couponUser;
+
+import com.palja.coupon_service.domain.entity.Coupon;
+import com.palja.coupon_service.domain.entity.CouponUser;
+import com.palja.coupon_service.domain.vo.CouponUserStatus;
+import com.palja.coupon_service.domain.vo.DiscountType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CreateCouponUserRes {
+    private UUID couponUserId;
+    private UUID couponId;
+    private String userId;
+    private String couponName;
+    private DiscountType discountType;
+    private Integer discountValue;
+    private LocalDateTime expireAt;
+    private CouponUserStatus status;
+    private LocalDateTime createdAt;
+    private String createdBy;
+
+    public static CreateCouponUserRes from(CouponUser couponUser) {
+        Coupon coupon = couponUser.getCoupon();
+
+        return CreateCouponUserRes.builder()
+                .couponUserId(couponUser.getId())
+                .couponId(coupon.getId())
+                .userId(couponUser.getUserId())
+                .couponName(couponUser.getCoupon().getName())
+                .discountType(coupon.getDiscountPolicy().getDiscountType())
+                .discountValue(coupon.getDiscountPolicy().getDiscountValue())
+                .expireAt(couponUser.getExpireAt())
+                .status(couponUser.getStatus())
+                .createdAt(couponUser.getCreatedAt())
+                .createdBy(couponUser.getCreatedBy())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/DeleteCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/DeleteCouponUserRes.java
@@ -10,15 +10,15 @@ import java.util.UUID;
 public class DeleteCouponUserRes {
     private UUID couponUserId;
     private String userId;
-    private LocalDateTime deleteAt;
-    private String deleteBy;
+    private LocalDateTime deletedAt;
+    private String deletedBy;
 
     public static DeleteCouponUserRes from(CouponUser couponUser) {
         return DeleteCouponUserRes.builder()
                 .couponUserId(couponUser.getId())
                 .userId(couponUser.getUserId())
-                .deleteAt(couponUser.getDeletedAt())
-                .deleteBy(couponUser.getDeletedBy())
+                .deletedAt(couponUser.getDeletedAt())
+                .deletedBy(couponUser.getDeletedBy())
                 .build();
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/DeleteCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/DeleteCouponUserRes.java
@@ -1,0 +1,24 @@
+package com.palja.coupon_service.application.dto.couponUser;
+
+import com.palja.coupon_service.domain.entity.CouponUser;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public class DeleteCouponUserRes {
+    private UUID couponUserId;
+    private String userId;
+    private LocalDateTime deleteAt;
+    private String deleteBy;
+
+    public static DeleteCouponUserRes from(CouponUser couponUser) {
+        return DeleteCouponUserRes.builder()
+                .couponUserId(couponUser.getId())
+                .userId(couponUser.getUserId())
+                .deleteAt(couponUser.getDeletedAt())
+                .deleteBy(couponUser.getDeletedBy())
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ReadCouponUserDetailRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ReadCouponUserDetailRes.java
@@ -1,4 +1,4 @@
-package com.palja.coupon_service.application.dto;
+package com.palja.coupon_service.application.dto.couponUser;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.palja.coupon_service.domain.entity.Coupon;
@@ -14,7 +14,7 @@ import java.util.UUID;
 @Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class CouponUserDetailRes {
+public class ReadCouponUserDetailRes {
     private UUID couponUserId;
     private UUID couponId;
     private String userId;
@@ -30,10 +30,10 @@ public class CouponUserDetailRes {
     private UUID orderId;
     private Long discountAmount;
 
-    public static CouponUserDetailRes from(CouponUser couponUser) {
+    public static ReadCouponUserDetailRes from(CouponUser couponUser) {
         Coupon coupon = couponUser.getCoupon();
 
-        return CouponUserDetailRes.builder()
+        return ReadCouponUserDetailRes.builder()
                 .couponUserId(couponUser.getId())
                 .couponId(coupon.getId())
                 .userId(couponUser.getUserId())

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ReadCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ReadCouponUserRes.java
@@ -1,38 +1,38 @@
-package com.palja.coupon_service.application.dto;
+package com.palja.coupon_service.application.dto.couponUser;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import com.palja.coupon_service.domain.vo.CouponUserStatus;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@Getter
 @Builder
-public class UsedCouponUserRes {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReadCouponUserRes {
     private UUID couponUserId;
     private UUID couponId;
     private String userId;
     private String couponName;
+    private LocalDateTime expireAt;
     private CouponUserStatus status;
     private LocalDateTime usedAt;
     private UUID orderId;
-    private Long discountAmount;
 
-    public static UsedCouponUserRes from(CouponUser couponUser) {
+    public static ReadCouponUserRes from(CouponUser couponUser){
         Coupon coupon = couponUser.getCoupon();
 
-        return UsedCouponUserRes.builder()
+        return ReadCouponUserRes.builder()
                 .couponUserId(couponUser.getId())
                 .couponId(coupon.getId())
                 .userId(couponUser.getUserId())
                 .couponName(coupon.getName())
+                .expireAt(couponUser.getExpireAt())
                 .status(couponUser.getStatus())
                 .usedAt(couponUser.getUsedAt())
                 .orderId(couponUser.getOrderId())
-                .discountAmount(couponUser.getDiscountAmount())
                 .build();
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/UsedCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/UsedCouponUserRes.java
@@ -1,9 +1,8 @@
-package com.palja.coupon_service.application.dto;
+package com.palja.coupon_service.application.dto.couponUser;
 
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import com.palja.coupon_service.domain.vo.CouponUserStatus;
-import com.palja.coupon_service.domain.vo.DiscountType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,28 +11,28 @@ import java.util.UUID;
 
 @Getter
 @Builder
-public class CouponUserRes {
+public class UsedCouponUserRes {
     private UUID couponUserId;
     private UUID couponId;
     private String userId;
     private String couponName;
-    private DiscountType discountType;
-    private Integer discountValue;
-    private LocalDateTime expireAt;
     private CouponUserStatus status;
+    private LocalDateTime usedAt;
+    private UUID orderId;
+    private Long discountAmount;
 
-    public static CouponUserRes from(CouponUser couponUser) {
+    public static UsedCouponUserRes from(CouponUser couponUser) {
         Coupon coupon = couponUser.getCoupon();
 
-        return CouponUserRes.builder()
+        return UsedCouponUserRes.builder()
                 .couponUserId(couponUser.getId())
                 .couponId(coupon.getId())
                 .userId(couponUser.getUserId())
-                .couponName(couponUser.getCoupon().getName())
-                .discountType(coupon.getDiscountPolicy().getDiscountType())
-                .discountValue(coupon.getDiscountPolicy().getDiscountValue())
-                .expireAt(couponUser.getExpireAt())
+                .couponName(coupon.getName())
                 .status(couponUser.getStatus())
+                .usedAt(couponUser.getUsedAt())
+                .orderId(couponUser.getOrderId())
+                .discountAmount(couponUser.getDiscountAmount())
                 .build();
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponManagerService.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponManagerService.java
@@ -3,8 +3,7 @@ package com.palja.coupon_service.application.service;
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
 import com.palja.coupon_service.application.command.UpdateCouponCommand;
-import com.palja.coupon_service.application.dto.CouponRes;
-import com.palja.coupon_service.application.dto.CouponDetailRes;
+import com.palja.coupon_service.application.dto.coupon.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,14 +11,14 @@ import java.util.UUID;
 
 public interface CouponManagerService {
 
-    CouponRes createCoupon(CreateCouponCommand command);
+    CreateCouponRes createCoupon(CreateCouponCommand command);
 
-    CouponRes updateCoupon(UpdateCouponCommand command);
+    UpdateCouponRes updateCoupon(UpdateCouponCommand command);
 
-    CouponRes changeCouponStatus(ChangeCouponStatusCommand command);
+    ChangeStatusCouponRes changeCouponStatus(ChangeCouponStatusCommand command);
 
-    Page<CouponRes> getCouponList(Pageable pageable);
+    Page<ReadCouponRes> getCouponList(Pageable pageable);
 
-    CouponDetailRes getCouponDetail(UUID couponId);
+    ReadCouponDetailRes getCouponDetail(UUID couponId);
 
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
@@ -3,26 +3,24 @@ package com.palja.coupon_service.application.service;
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.IssueCouponCommand;
 import com.palja.coupon_service.application.command.UseCouponCommand;
-import com.palja.coupon_service.application.dto.CouponUserDetailRes;
-import com.palja.coupon_service.application.dto.CouponUserRes;
-import com.palja.coupon_service.application.dto.UsedCouponUserRes;
+import com.palja.coupon_service.application.dto.couponUser.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
 
 public interface CouponService {
-    CouponUserRes issueCoupon(IssueCouponCommand command);
+    CreateCouponUserRes issueCoupon(IssueCouponCommand command);
 
     UsedCouponUserRes useCoupon(UseCouponCommand command);
 
-    CouponUserRes cancelCoupon(UUID couponUserId, String userId);
+    CancelCouponUserRes cancelCoupon(UUID couponUserId, String userId);
 
-    CouponUserRes changeCouponStatus(ChangeCouponStatusCommand command);
+    ChangeStatusCouponUserRes changeCouponStatus(ChangeCouponStatusCommand command);
 
-    CouponUserRes deleteCoupon(UUID couponUserId, String loginId);
+    DeleteCouponUserRes deleteCoupon(UUID couponUserId, String loginId);
 
-    Page<CouponUserRes> getCouponList(String userId, Pageable pageable);
+    Page<ReadCouponUserRes> getCouponList(String userId, Pageable pageable);
 
-    CouponUserDetailRes getCouponDetail(UUID couponUserId, String userId);
+    ReadCouponUserDetailRes getCouponDetail(UUID couponUserId, String userId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImpl.java
@@ -4,8 +4,7 @@ import com.palja.common.exception.BusinessException;
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
 import com.palja.coupon_service.application.command.UpdateCouponCommand;
-import com.palja.coupon_service.application.dto.CouponRes;
-import com.palja.coupon_service.application.dto.CouponDetailRes;
+import com.palja.coupon_service.application.dto.coupon.*;
 import com.palja.coupon_service.application.service.CouponManagerService;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.repository.CouponRepository;
@@ -29,7 +28,7 @@ public class CouponManagerServiceImpl implements CouponManagerService {
 
     @Override
     @Transactional
-    public CouponRes createCoupon(CreateCouponCommand command) {
+    public CreateCouponRes createCoupon(CreateCouponCommand command) {
         log.info("쿠폰 생성 시작");
 
         validateCouponNameDuplicate(command.couponName());
@@ -47,12 +46,12 @@ public class CouponManagerServiceImpl implements CouponManagerService {
         Coupon savedCoupon = couponRepository.save(coupon);
 
         log.info("쿠폰 생성 완료 - couponId={}", savedCoupon.getId());
-        return CouponRes.from(savedCoupon);
+        return CreateCouponRes.from(savedCoupon);
     }
 
     @Override
     @Transactional
-    public CouponRes updateCoupon(UpdateCouponCommand command) {
+    public UpdateCouponRes updateCoupon(UpdateCouponCommand command) {
         log.info("쿠폰 수정 시작 - couponId={}", command.couponId());
 
         Coupon coupon = couponRepository.findByIdAndDeletedAtIsNull(command.couponId())
@@ -73,12 +72,12 @@ public class CouponManagerServiceImpl implements CouponManagerService {
         );
 
         log.info("쿠폰 수정 완료 - couponId={}", command.couponId());
-        return CouponRes.from(coupon);
+        return UpdateCouponRes.from(coupon);
     }
 
     @Override
     @Transactional
-    public CouponRes changeCouponStatus(ChangeCouponStatusCommand command) {
+    public ChangeStatusCouponRes changeCouponStatus(ChangeCouponStatusCommand command) {
         log.info("쿠폰 상태 변경 시작 - couponId={} status={}", command.couponId(), command.status());
 
         Coupon coupon = couponRepository.findByIdAndDeletedAtIsNull(command.couponId())
@@ -89,24 +88,24 @@ public class CouponManagerServiceImpl implements CouponManagerService {
         coupon.changeStatus(CouponStatus.valueOf(command.status().toUpperCase()));
 
         log.info("쿠폰 상태 변경 완료 - couponId={} status={} -> {}", command.couponId(), oldStatus, command.status());
-        return CouponRes.from(coupon);
+        return ChangeStatusCouponRes.from(coupon);
     }
 
     @Override
-    public Page<CouponRes> getCouponList(Pageable pageable) {
+    public Page<ReadCouponRes> getCouponList(Pageable pageable) {
         log.info("쿠폰 목록 조회 시작");
         return couponRepository.findAllByDeletedAtIsNull(pageable)
-                .map(CouponRes::from);
+                .map(ReadCouponRes::from);
     }
 
     @Override
-    public CouponDetailRes getCouponDetail(UUID couponId) {
+    public ReadCouponDetailRes getCouponDetail(UUID couponId) {
         log.info("쿠폰 조회 시작 - couponId={}", couponId);
 
         Coupon coupon = couponRepository.findByIdAndDeletedAtIsNull(couponId)
                 .orElseThrow(() -> new BusinessException(CouponErrorCode.COUPON_NOT_FOUND));
 
-        return CouponDetailRes.from(coupon);
+        return ReadCouponDetailRes.from(coupon);
     }
 
     // 쿠폰명 중복 체크

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
@@ -4,9 +4,7 @@ import com.palja.common.exception.BusinessException;
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.IssueCouponCommand;
 import com.palja.coupon_service.application.command.UseCouponCommand;
-import com.palja.coupon_service.application.dto.CouponUserDetailRes;
-import com.palja.coupon_service.application.dto.CouponUserRes;
-import com.palja.coupon_service.application.dto.UsedCouponUserRes;
+import com.palja.coupon_service.application.dto.couponUser.*;
 import com.palja.coupon_service.application.service.CouponService;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.entity.CouponUser;
@@ -33,7 +31,7 @@ public class CouponServiceImpl implements CouponService {
 
     @Override
     @Transactional
-    public CouponUserRes issueCoupon(IssueCouponCommand command) {
+    public CreateCouponUserRes issueCoupon(IssueCouponCommand command) {
         log.info("쿠폰 발급 시작 userId={} couponId={}", command.userId(), command.couponId());
 
         Coupon coupon = couponRepository.findByIdAndDeletedAtIsNull(command.couponId())
@@ -48,7 +46,7 @@ public class CouponServiceImpl implements CouponService {
         CouponUser issuedCoupon = couponUserRepository.save(couponUser);
 
         log.info("쿠폰 발급 성공 issuedCouponID={}", issuedCoupon.getCoupon().getId());
-        return CouponUserRes.from(couponUser);
+        return CreateCouponUserRes.from(couponUser);
     }
 
     @Override
@@ -67,7 +65,7 @@ public class CouponServiceImpl implements CouponService {
 
     @Override
     @Transactional
-    public CouponUserRes cancelCoupon(UUID couponUserId, String userId) {
+    public CancelCouponUserRes cancelCoupon(UUID couponUserId, String userId) {
         log.info("쿠폰 취소 시작 userId={} couponUserId={}", userId, couponUserId);
 
         CouponUser couponUser = couponUserRepository.findByIdAndUserIdAndDeletedAtIsNull(couponUserId, userId)
@@ -76,12 +74,12 @@ public class CouponServiceImpl implements CouponService {
         couponUser.cancel();
 
         log.info("쿠폰 취소 성공 userId={} couponUserId={}", userId, couponUserId);
-        return CouponUserRes.from(couponUser);
+        return CancelCouponUserRes.from(couponUser);
     }
 
     @Override
     @Transactional
-    public CouponUserRes changeCouponStatus(ChangeCouponStatusCommand command) {
+    public ChangeStatusCouponUserRes changeCouponStatus(ChangeCouponStatusCommand command) {
         log.info("쿠폰 상태 변경 시작 - couponId={} status={}", command.couponId(), command.status());
 
         CouponUser couponUser = couponUserRepository.findByIdAndUserIdAndDeletedAtIsNull(command.couponId(), command.userId())
@@ -92,12 +90,12 @@ public class CouponServiceImpl implements CouponService {
         couponUser.changeStatus(CouponUserStatus.valueOf(command.status().toUpperCase()));
 
         log.info("쿠폰 상태 변경 완료 - couponId={} status={} -> {}", command.couponId(), oldStatus, command.status());
-        return CouponUserRes.from(couponUser);
+        return ChangeStatusCouponUserRes.from(couponUser);
     }
 
     @Override
     @Transactional
-    public CouponUserRes deleteCoupon(UUID couponUserId, String userId) {
+    public DeleteCouponUserRes deleteCoupon(UUID couponUserId, String userId) {
         log.info("쿠폰 삭제 시작 - couponId={} status={}", couponUserId, userId);
 
         CouponUser couponUser = couponUserRepository.findByIdAndUserIdAndDeletedAtIsNull(couponUserId, userId)
@@ -106,26 +104,26 @@ public class CouponServiceImpl implements CouponService {
         couponUser.softDelete();
 
         log.info("쿠폰 삭제 완료 - couponId={} status={}", couponUserId, userId);
-        return CouponUserRes.from(couponUser);
+        return DeleteCouponUserRes.from(couponUser);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<CouponUserRes> getCouponList(String userId, Pageable pageable) {
+    public Page<ReadCouponUserRes> getCouponList(String userId, Pageable pageable) {
         log.info("쿠폰 목록 조회 시작 userId={}", userId);
         return couponUserRepository.findAllByUserIdAndDeletedAtIsNull(userId, pageable)
-                .map(CouponUserRes::from);
+                .map(ReadCouponUserRes::from);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public CouponUserDetailRes getCouponDetail(UUID couponUserId, String userId) {
+    public ReadCouponUserDetailRes getCouponDetail(UUID couponUserId, String userId) {
         log.info("쿠폰 상세 조회 시작 couponId={} userId={}", couponUserId, userId);
 
         CouponUser couponUser = couponUserRepository.findByIdAndUserIdAndDeletedAtIsNull(couponUserId, userId)
                 .orElseThrow(() -> new BusinessException(CouponErrorCode.USER_COUPON_NOT_FOUND));
 
-        return CouponUserDetailRes.from(couponUser);
+        return ReadCouponUserDetailRes.from(couponUser);
     }
 
     // 쿠폰 발급 검증

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
@@ -1,106 +1,66 @@
 package com.palja.coupon_service.presentation.controller;
 
-import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
-import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
-import com.palja.coupon_service.application.command.IssueCouponCommand;
-import com.palja.coupon_service.application.command.UseCouponCommand;
 import com.palja.coupon_service.application.dto.CouponUserDetailRes;
 import com.palja.coupon_service.application.dto.CouponUserRes;
 import com.palja.coupon_service.application.dto.UsedCouponUserRes;
-import com.palja.coupon_service.application.service.CouponService;
 import com.palja.coupon_service.presentation.dto.request.ChangeCouponStatusReq;
 import com.palja.coupon_service.presentation.dto.request.UseCouponReq;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.UUID;
 
-@Slf4j
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("/api/v1/coupons")
-public class CouponController {
+@Tag(name = "쿠폰 관리", description = "사용자 쿠폰 발급, 수정, 취소, 상태 변경, 삭제, 조회 API")
+public interface CouponController {
 
-    private final CouponService couponService;
+    @Operation(
+            summary = "쿠폰 발급",
+            description = "사용자의 쿠폰을 발급합니다."
+    )
+    ResponseEntity<ApiResponse<CouponUserRes>> issueCoupon(@PathVariable UUID couponId);
 
-    @PostMapping("/{couponId}")
-    public ResponseEntity<ApiResponse<CouponUserRes>> issueCoupon(@PathVariable UUID couponId) {
-        log.info("POST /api/v1/coupons/{} - 쿠폰 발급 요청 userId={}", couponId, CurrentUser.getLoginId());
+    @Operation(
+            summary = "쿠폰 사용",
+            description = "사용자의 쿠폰을 사용합니다."
+    )
+    ResponseEntity<ApiResponse<UsedCouponUserRes>> useCoupon(@PathVariable UUID couponUserId,
+                                                             @Valid @RequestBody UseCouponReq useCouponReq);
 
-        IssueCouponCommand command = new IssueCouponCommand(couponId, CurrentUser.getLoginId());
+    @Operation(
+            summary = "쿠폰 취소",
+            description = "사용자의 쿠폰을 취소합니다."
+    )
+    ResponseEntity<ApiResponse<CouponUserRes>> cancelCoupon(@PathVariable UUID couponUserId);
 
-        CouponUserRes response = couponService.issueCoupon(command);
+    @Operation(
+            summary = "쿠폰 상태 변경",
+            description = "사용자의 쿠폰 상태를 변경합니다."
+    )
+    ResponseEntity<ApiResponse<CouponUserRes>> changeCouponStatus(@PathVariable UUID couponUserId,
+                                                                  @Valid @RequestBody ChangeCouponStatusReq request);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "쿠폰이 발급되었습니다."));
-    }
+    @Operation(
+            summary = "쿠폰 삭제",
+            description = "사용자의 쿠폰을 삭제합니다."
+    )
+    ResponseEntity<ApiResponse<CouponUserRes>> deleteCoupon(@PathVariable UUID couponUserId);
 
-    @PostMapping("/{couponUserId}/use")
-    public ResponseEntity<ApiResponse<UsedCouponUserRes>> useCoupon(@PathVariable UUID couponUserId,
-                                                                    @Valid @RequestBody UseCouponReq useCouponReq) {
-        log.info("POST /api/v1/coupons/{}/use - 쿠폰 사용 요청 userId={} orderId={}", couponUserId, CurrentUser.getLoginId(), useCouponReq.getOrderId());
+    @Operation(
+            summary = "쿠폰 목록 조회",
+            description = "사용자의 보유 쿠폰 목록을 조회합니다."
+    )
+    ResponseEntity<ApiResponse<PageResponse<CouponUserRes>>> getCouponList(Pageable pageable);
 
-        UseCouponCommand command = UseCouponReq.of(couponUserId, CurrentUser.getLoginId(), useCouponReq);
-
-        UsedCouponUserRes response = couponService.useCoupon(command);
-
-        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰이 사용되었습니다."));
-    }
-
-    @PutMapping("/{couponUserId}/cancel")
-    public ResponseEntity<ApiResponse<CouponUserRes>> cancelCoupon(@PathVariable UUID couponUserId) {
-        log.info("PUT /api/v1/coupons/{}/cancel - 쿠폰 취소 요청 userId={}", couponUserId, CurrentUser.getLoginId());
-
-        CouponUserRes response = couponService.cancelCoupon(couponUserId, CurrentUser.getLoginId());
-
-        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰이 취소되었습니다."));
-    }
-
-    @PutMapping("/{couponUserId}/status")
-    public ResponseEntity<ApiResponse<CouponUserRes>> changeCouponStatus(@PathVariable UUID couponUserId,
-                                                                         @Valid @RequestBody ChangeCouponStatusReq request) {
-        log.info("PUT /api/v1/coupons/{}/status - 쿠폰 상태 변경 요청 status: {}", couponUserId, request.getStatus());
-
-        ChangeCouponStatusCommand command = ChangeCouponStatusReq.of(couponUserId, CurrentUser.getLoginId(), request);
-
-        CouponUserRes response = couponService.changeCouponStatus(command);
-
-        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 상태가 변경되었습니다."));
-    }
-
-    @DeleteMapping("/{couponUserId}")
-    public ResponseEntity<ApiResponse<CouponUserRes>> deleteCoupon(@PathVariable UUID couponUserId) {
-        log.info("DELETE /api/v1/coupons/{} - 쿠폰 삭제 요청 userId={}", couponUserId, CurrentUser.getLoginId());
-
-        CouponUserRes response = couponService.deleteCoupon(couponUserId, CurrentUser.getLoginId());
-
-        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰이 삭제되었습니다."));
-    }
-
-    @GetMapping("/me")
-    public ResponseEntity<ApiResponse<PageResponse<CouponUserRes>>> getCouponList(Pageable pageable) {
-        log.info("GET /api/v1/coupons/me - 사용자 쿠폰 목록 조회 요청 userId={}", CurrentUser.getLoginId());
-
-        Page<CouponUserRes> couponUserResPage = couponService.getCouponList(CurrentUser.getLoginId(), pageable);
-
-        PageResponse<CouponUserRes> response = PageResponse.from(couponUserResPage);
-
-        return ResponseEntity.ok(ApiResponse.success(response, "사용자 쿠폰 목록 조회"));
-    }
-
-    @GetMapping("/me/{couponUserId}")
-    public ResponseEntity<ApiResponse<CouponUserDetailRes>> getCouponDetail(@PathVariable UUID couponUserId) {
-        log.info("GET /api/v1/coupons/me/{} - 쿠폰 상세 조회 요청", couponUserId);
-
-        CouponUserDetailRes response = couponService.getCouponDetail(couponUserId, CurrentUser.getLoginId());
-
-        return ResponseEntity.ok(ApiResponse.success(response, "사용자 쿠폰 상세 조회"));
-    }
+    @Operation(
+            summary = "쿠폰 상세 조회",
+            description = "사용자의 쿠폰을 상세 조회합니다."
+    )
+    ResponseEntity<ApiResponse<CouponUserDetailRes>> getCouponDetail(@PathVariable UUID couponUserId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
@@ -2,12 +2,11 @@ package com.palja.coupon_service.presentation.controller;
 
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
-import com.palja.coupon_service.application.dto.CouponUserDetailRes;
-import com.palja.coupon_service.application.dto.CouponUserRes;
-import com.palja.coupon_service.application.dto.UsedCouponUserRes;
+import com.palja.coupon_service.application.dto.couponUser.*;
 import com.palja.coupon_service.presentation.dto.request.ChangeCouponStatusReq;
 import com.palja.coupon_service.presentation.dto.request.UseCouponReq;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
@@ -24,12 +23,15 @@ public interface CouponController {
             summary = "쿠폰 발급",
             description = "사용자의 쿠폰을 발급합니다."
     )
-    ResponseEntity<ApiResponse<CouponUserRes>> issueCoupon(@PathVariable UUID couponId);
+    ResponseEntity<ApiResponse<CreateCouponUserRes>> issueCoupon(@PathVariable UUID couponId);
 
     @Operation(
             summary = "쿠폰 사용",
             description = "사용자의 쿠폰을 사용합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse
+    })
     ResponseEntity<ApiResponse<UsedCouponUserRes>> useCoupon(@PathVariable UUID couponUserId,
                                                              @Valid @RequestBody UseCouponReq useCouponReq);
 
@@ -37,30 +39,30 @@ public interface CouponController {
             summary = "쿠폰 취소",
             description = "사용자의 쿠폰을 취소합니다."
     )
-    ResponseEntity<ApiResponse<CouponUserRes>> cancelCoupon(@PathVariable UUID couponUserId);
+    ResponseEntity<ApiResponse<CancelCouponUserRes>> cancelCoupon(@PathVariable UUID couponUserId);
 
     @Operation(
             summary = "쿠폰 상태 변경",
             description = "사용자의 쿠폰 상태를 변경합니다."
     )
-    ResponseEntity<ApiResponse<CouponUserRes>> changeCouponStatus(@PathVariable UUID couponUserId,
-                                                                  @Valid @RequestBody ChangeCouponStatusReq request);
+    ResponseEntity<ApiResponse<ChangeStatusCouponUserRes>> changeCouponStatus(@PathVariable UUID couponUserId,
+                                                                              @Valid @RequestBody ChangeCouponStatusReq request);
 
     @Operation(
             summary = "쿠폰 삭제",
             description = "사용자의 쿠폰을 삭제합니다."
     )
-    ResponseEntity<ApiResponse<CouponUserRes>> deleteCoupon(@PathVariable UUID couponUserId);
+    ResponseEntity<ApiResponse<DeleteCouponUserRes>> deleteCoupon(@PathVariable UUID couponUserId);
 
     @Operation(
             summary = "쿠폰 목록 조회",
             description = "사용자의 보유 쿠폰 목록을 조회합니다."
     )
-    ResponseEntity<ApiResponse<PageResponse<CouponUserRes>>> getCouponList(Pageable pageable);
+    ResponseEntity<ApiResponse<PageResponse<ReadCouponUserRes>>> getCouponList(Pageable pageable);
 
     @Operation(
             summary = "쿠폰 상세 조회",
             description = "사용자의 쿠폰을 상세 조회합니다."
     )
-    ResponseEntity<ApiResponse<CouponUserDetailRes>> getCouponDetail(@PathVariable UUID couponUserId);
+    ResponseEntity<ApiResponse<ReadCouponUserDetailRes>> getCouponDetail(@PathVariable UUID couponUserId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
@@ -2,8 +2,7 @@ package com.palja.coupon_service.presentation.controller;
 
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
-import com.palja.coupon_service.application.dto.CouponDetailRes;
-import com.palja.coupon_service.application.dto.CouponRes;
+import com.palja.coupon_service.application.dto.coupon.*;
 import com.palja.coupon_service.presentation.dto.request.ChangeCouponStatusReq;
 import com.palja.coupon_service.presentation.dto.request.CreateCouponReq;
 import com.palja.coupon_service.presentation.dto.request.UpdateCouponReq;
@@ -24,30 +23,30 @@ public interface CouponManagerController {
             summary = "쿠폰 생성",
             description = "쿠폰을 생성합니다."
     )
-    ResponseEntity<ApiResponse<CouponRes>> createCoupon(@Valid @RequestBody CreateCouponReq request);
+    ResponseEntity<ApiResponse<CreateCouponRes>> createCoupon(@Valid @RequestBody CreateCouponReq request);
 
     @Operation(
             summary = "쿠폰 수정",
             description = "쿠폰을 수정합니다."
     )
-    ResponseEntity<ApiResponse<CouponRes>> updateCoupon(@PathVariable UUID couponId, @Valid @RequestBody UpdateCouponReq request);
+    ResponseEntity<ApiResponse<UpdateCouponRes>> updateCoupon(@PathVariable UUID couponId, @Valid @RequestBody UpdateCouponReq request);
 
     @Operation(
             summary = "쿠폰 상태",
             description = "쿠폰 상태를 변경합니다."
     )
-    ResponseEntity<ApiResponse<CouponRes>> changeCouponStatus(@PathVariable UUID couponId,
-                                                              @Valid @RequestBody ChangeCouponStatusReq request);
+    ResponseEntity<ApiResponse<ChangeStatusCouponRes>> changeCouponStatus(@PathVariable UUID couponId,
+                                                                          @Valid @RequestBody ChangeCouponStatusReq request);
 
     @Operation(
             summary = "쿠폰 목록 조회",
             description = "생성된 쿠폰 목록을 조회합니다."
     )
-    ResponseEntity<ApiResponse<PageResponse<CouponRes>>> getCouponList(Pageable pageable);
+    ResponseEntity<ApiResponse<PageResponse<ReadCouponRes>>> getCouponList(Pageable pageable);
 
     @Operation(
             summary = "쿠폰 상세 조회",
             description = "쿠폰을 상세 조회합니다."
     )
-    ResponseEntity<ApiResponse<CouponDetailRes>> getCouponDetail(@PathVariable UUID couponId);
+    ResponseEntity<ApiResponse<ReadCouponDetailRes>> getCouponDetail(@PathVariable UUID couponId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
@@ -1,111 +1,53 @@
 package com.palja.coupon_service.presentation.controller;
 
-import com.palja.common.auditor.CurrentUser;
-import com.palja.common.exception.BusinessException;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
-import com.palja.common.vo.UserRole;
-import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
-import com.palja.coupon_service.application.command.CreateCouponCommand;
-import com.palja.coupon_service.application.command.UpdateCouponCommand;
 import com.palja.coupon_service.application.dto.CouponDetailRes;
 import com.palja.coupon_service.application.dto.CouponRes;
-import com.palja.coupon_service.application.service.CouponManagerService;
-import com.palja.coupon_service.domain.vo.CouponStatus;
-import com.palja.coupon_service.exception.CouponErrorCode;
 import com.palja.coupon_service.presentation.dto.request.ChangeCouponStatusReq;
 import com.palja.coupon_service.presentation.dto.request.CreateCouponReq;
 import com.palja.coupon_service.presentation.dto.request.UpdateCouponReq;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.UUID;
 
-@Slf4j
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("/api/v1/coupons/manager")
-public class CouponManagerController {
+@Tag(name = "관리자 쿠폰 관리", description = "관리자 쿠폰 생성, 수정, 상태 변경, 조회 API")
+public interface CouponManagerController {
 
-    private final CouponManagerService couponManagerService;
+    @Operation(
+            summary = "쿠폰 생성",
+            description = "쿠폰을 생성합니다."
+    )
+    ResponseEntity<ApiResponse<CouponRes>> createCoupon(@Valid @RequestBody CreateCouponReq request);
 
-    @PostMapping
-    public ResponseEntity<ApiResponse<CouponRes>> createCoupon(@Valid @RequestBody CreateCouponReq request) {
-        log.info("POST /api/v1/coupons/manager - 쿠폰 생성 요청");
+    @Operation(
+            summary = "쿠폰 수정",
+            description = "쿠폰을 수정합니다."
+    )
+    ResponseEntity<ApiResponse<CouponRes>> updateCoupon(@PathVariable UUID couponId, @Valid @RequestBody UpdateCouponReq request);
 
-        validateRole();
+    @Operation(
+            summary = "쿠폰 상태",
+            description = "쿠폰 상태를 변경합니다."
+    )
+    ResponseEntity<ApiResponse<CouponRes>> changeCouponStatus(@PathVariable UUID couponId,
+                                                              @Valid @RequestBody ChangeCouponStatusReq request);
 
-        CreateCouponCommand command = CreateCouponReq.of(request);
+    @Operation(
+            summary = "쿠폰 목록 조회",
+            description = "생성된 쿠폰 목록을 조회합니다."
+    )
+    ResponseEntity<ApiResponse<PageResponse<CouponRes>>> getCouponList(Pageable pageable);
 
-        CouponRes couponRes = couponManagerService.createCoupon(command);
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(couponRes, "쿠폰이 생성되었습니다."));
-    }
-
-    @PutMapping("/{couponId}")
-    public ResponseEntity<ApiResponse<CouponRes>> updateCoupon(@PathVariable UUID couponId, @Valid @RequestBody UpdateCouponReq request) {
-        log.info("PUT /api/v1/coupons/manager/{} - 쿠폰 수정 요청", couponId);
-
-        validateRole();
-
-        UpdateCouponCommand command = UpdateCouponReq.of(couponId, request);
-
-        CouponRes couponRes = couponManagerService.updateCoupon(command);
-
-        return ResponseEntity.ok(ApiResponse.success(couponRes, "쿠폰이 수정되었습니다."));
-    }
-
-    @PutMapping("/{couponId}/status")
-    public ResponseEntity<ApiResponse<CouponRes>> changeCouponStatus(@PathVariable UUID couponId,
-                                                                     @Valid @RequestBody ChangeCouponStatusReq request) {
-        log.info("PUT /api/v1/coupons/manager/{}/status - 쿠폰 상태 변경 요청 status: {}", couponId, request.getStatus());
-
-        validateRole();
-
-        ChangeCouponStatusCommand command = ChangeCouponStatusReq.of(couponId, request);
-
-        CouponRes couponRes = couponManagerService.changeCouponStatus(command);
-
-        return ResponseEntity.ok(ApiResponse.success(couponRes, "쿠폰 상태가 변경되었습니다."));
-    }
-
-
-    @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<CouponRes>>> getCouponList(Pageable pageable) {
-        log.info("GET /api/v1/coupons/manager - 쿠폰 목록 조회 요청");
-
-        validateRole();
-
-        Page<CouponRes> couponResPage = couponManagerService.getCouponList(pageable);
-
-        PageResponse<CouponRes> response = PageResponse.from(couponResPage);
-
-        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 목록 조회"));
-    }
-
-    @GetMapping("/{couponId}")
-    public ResponseEntity<ApiResponse<CouponDetailRes>> getCouponDetail(@PathVariable UUID couponId) {
-        log.info("GET /api/v1/coupons/manager/{} - 쿠폰 상세 조회 요청", couponId);
-
-        validateRole();
-
-        CouponDetailRes response = couponManagerService.getCouponDetail(couponId);
-
-        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 상세 조회"));
-    }
-
-    private void validateRole() {
-        UserRole role = CurrentUser.getRole();
-
-        if (!UserRole.MASTER.equals(role) && !UserRole.MANAGER.equals(role)) {
-            log.warn("권한 없는 사용자의 쿠폰 관리 시도 - id: {}  role: {}", CurrentUser.getLoginId(), role);
-            throw new BusinessException(CouponErrorCode.INSUFFICIENT_PERMISSION);
-        }
-    }
+    @Operation(
+            summary = "쿠폰 상세 조회",
+            description = "쿠폰을 상세 조회합니다."
+    )
+    ResponseEntity<ApiResponse<CouponDetailRes>> getCouponDetail(@PathVariable UUID couponId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponControllerImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponControllerImpl.java
@@ -1,6 +1,5 @@
 package com.palja.coupon_service.presentation.controller.impl;
 
-import com.palja.common.annotation.RequiredAnonymous;
 import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
@@ -32,7 +31,6 @@ public class CouponControllerImpl implements CouponController {
     private final CouponService couponService;
 
     @Override
-    @RequiredAnonymous
     @PostMapping("/{couponId}")
     public ResponseEntity<ApiResponse<CreateCouponUserRes>> issueCoupon(@PathVariable UUID couponId) {
         log.info("POST /api/v1/coupons/{} - 쿠폰 발급 요청 userId={}", couponId, CurrentUser.getLoginId());
@@ -45,7 +43,6 @@ public class CouponControllerImpl implements CouponController {
     }
 
     @Override
-    @RequiredAnonymous
     @PostMapping("/{couponUserId}/use")
     public ResponseEntity<ApiResponse<UsedCouponUserRes>> useCoupon(@PathVariable UUID couponUserId,
                                                                     @Valid @RequestBody UseCouponReq useCouponReq) {
@@ -59,7 +56,6 @@ public class CouponControllerImpl implements CouponController {
     }
 
     @Override
-    @RequiredAnonymous
     @PutMapping("/{couponUserId}/cancel")
     public ResponseEntity<ApiResponse<CancelCouponUserRes>> cancelCoupon(@PathVariable UUID couponUserId) {
         log.info("PUT /api/v1/coupons/{}/cancel - 쿠폰 취소 요청 userId={}", couponUserId, CurrentUser.getLoginId());
@@ -70,7 +66,6 @@ public class CouponControllerImpl implements CouponController {
     }
 
     @Override
-    @RequiredAnonymous
     @PutMapping("/{couponUserId}/status")
     public ResponseEntity<ApiResponse<ChangeStatusCouponUserRes>> changeCouponStatus(@PathVariable UUID couponUserId,
                                                                                      @Valid @RequestBody ChangeCouponStatusReq request) {
@@ -84,7 +79,6 @@ public class CouponControllerImpl implements CouponController {
     }
 
     @Override
-    @RequiredAnonymous
     @DeleteMapping("/{couponUserId}")
     public ResponseEntity<ApiResponse<DeleteCouponUserRes>> deleteCoupon(@PathVariable UUID couponUserId) {
         log.info("DELETE /api/v1/coupons/{} - 쿠폰 삭제 요청 userId={}", couponUserId, CurrentUser.getLoginId());
@@ -95,7 +89,6 @@ public class CouponControllerImpl implements CouponController {
     }
 
     @Override
-    @RequiredAnonymous
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<PageResponse<ReadCouponUserRes>>> getCouponList(Pageable pageable) {
         log.info("GET /api/v1/coupons/me - 사용자 쿠폰 목록 조회 요청 userId={}", CurrentUser.getLoginId());
@@ -108,7 +101,6 @@ public class CouponControllerImpl implements CouponController {
     }
 
     @Override
-    @RequiredAnonymous
     @GetMapping("/me/{couponUserId}")
     public ResponseEntity<ApiResponse<ReadCouponUserDetailRes>> getCouponDetail(@PathVariable UUID couponUserId) {
         log.info("GET /api/v1/coupons/me/{} - 쿠폰 상세 조회 요청", couponUserId);

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponControllerImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponControllerImpl.java
@@ -7,9 +7,7 @@ import com.palja.common.response.PageResponse;
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.IssueCouponCommand;
 import com.palja.coupon_service.application.command.UseCouponCommand;
-import com.palja.coupon_service.application.dto.CouponUserDetailRes;
-import com.palja.coupon_service.application.dto.CouponUserRes;
-import com.palja.coupon_service.application.dto.UsedCouponUserRes;
+import com.palja.coupon_service.application.dto.couponUser.*;
 import com.palja.coupon_service.application.service.CouponService;
 import com.palja.coupon_service.presentation.controller.CouponController;
 import com.palja.coupon_service.presentation.dto.request.ChangeCouponStatusReq;
@@ -36,12 +34,12 @@ public class CouponControllerImpl implements CouponController {
     @Override
     @RequiredAnonymous
     @PostMapping("/{couponId}")
-    public ResponseEntity<ApiResponse<CouponUserRes>> issueCoupon(@PathVariable UUID couponId) {
+    public ResponseEntity<ApiResponse<CreateCouponUserRes>> issueCoupon(@PathVariable UUID couponId) {
         log.info("POST /api/v1/coupons/{} - 쿠폰 발급 요청 userId={}", couponId, CurrentUser.getLoginId());
 
         IssueCouponCommand command = new IssueCouponCommand(couponId, CurrentUser.getLoginId());
 
-        CouponUserRes response = couponService.issueCoupon(command);
+        CreateCouponUserRes response = couponService.issueCoupon(command);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "쿠폰이 발급되었습니다."));
     }
@@ -63,10 +61,10 @@ public class CouponControllerImpl implements CouponController {
     @Override
     @RequiredAnonymous
     @PutMapping("/{couponUserId}/cancel")
-    public ResponseEntity<ApiResponse<CouponUserRes>> cancelCoupon(@PathVariable UUID couponUserId) {
+    public ResponseEntity<ApiResponse<CancelCouponUserRes>> cancelCoupon(@PathVariable UUID couponUserId) {
         log.info("PUT /api/v1/coupons/{}/cancel - 쿠폰 취소 요청 userId={}", couponUserId, CurrentUser.getLoginId());
 
-        CouponUserRes response = couponService.cancelCoupon(couponUserId, CurrentUser.getLoginId());
+        CancelCouponUserRes response = couponService.cancelCoupon(couponUserId, CurrentUser.getLoginId());
 
         return ResponseEntity.ok(ApiResponse.success(response, "쿠폰이 취소되었습니다."));
     }
@@ -74,13 +72,13 @@ public class CouponControllerImpl implements CouponController {
     @Override
     @RequiredAnonymous
     @PutMapping("/{couponUserId}/status")
-    public ResponseEntity<ApiResponse<CouponUserRes>> changeCouponStatus(@PathVariable UUID couponUserId,
-                                                                         @Valid @RequestBody ChangeCouponStatusReq request) {
+    public ResponseEntity<ApiResponse<ChangeStatusCouponUserRes>> changeCouponStatus(@PathVariable UUID couponUserId,
+                                                                                     @Valid @RequestBody ChangeCouponStatusReq request) {
         log.info("PUT /api/v1/coupons/{}/status - 쿠폰 상태 변경 요청 status: {}", couponUserId, request.getStatus());
 
         ChangeCouponStatusCommand command = ChangeCouponStatusReq.of(couponUserId, CurrentUser.getLoginId(), request);
 
-        CouponUserRes response = couponService.changeCouponStatus(command);
+        ChangeStatusCouponUserRes response = couponService.changeCouponStatus(command);
 
         return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 상태가 변경되었습니다."));
     }
@@ -88,10 +86,10 @@ public class CouponControllerImpl implements CouponController {
     @Override
     @RequiredAnonymous
     @DeleteMapping("/{couponUserId}")
-    public ResponseEntity<ApiResponse<CouponUserRes>> deleteCoupon(@PathVariable UUID couponUserId) {
+    public ResponseEntity<ApiResponse<DeleteCouponUserRes>> deleteCoupon(@PathVariable UUID couponUserId) {
         log.info("DELETE /api/v1/coupons/{} - 쿠폰 삭제 요청 userId={}", couponUserId, CurrentUser.getLoginId());
 
-        CouponUserRes response = couponService.deleteCoupon(couponUserId, CurrentUser.getLoginId());
+        DeleteCouponUserRes response = couponService.deleteCoupon(couponUserId, CurrentUser.getLoginId());
 
         return ResponseEntity.ok(ApiResponse.success(response, "쿠폰이 삭제되었습니다."));
     }
@@ -99,12 +97,12 @@ public class CouponControllerImpl implements CouponController {
     @Override
     @RequiredAnonymous
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<PageResponse<CouponUserRes>>> getCouponList(Pageable pageable) {
+    public ResponseEntity<ApiResponse<PageResponse<ReadCouponUserRes>>> getCouponList(Pageable pageable) {
         log.info("GET /api/v1/coupons/me - 사용자 쿠폰 목록 조회 요청 userId={}", CurrentUser.getLoginId());
 
-        Page<CouponUserRes> couponUserResPage = couponService.getCouponList(CurrentUser.getLoginId(), pageable);
+        Page<ReadCouponUserRes> couponUserResPage = couponService.getCouponList(CurrentUser.getLoginId(), pageable);
 
-        PageResponse<CouponUserRes> response = PageResponse.from(couponUserResPage);
+        PageResponse<ReadCouponUserRes> response = PageResponse.from(couponUserResPage);
 
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 쿠폰 목록 조회"));
     }
@@ -112,10 +110,10 @@ public class CouponControllerImpl implements CouponController {
     @Override
     @RequiredAnonymous
     @GetMapping("/me/{couponUserId}")
-    public ResponseEntity<ApiResponse<CouponUserDetailRes>> getCouponDetail(@PathVariable UUID couponUserId) {
+    public ResponseEntity<ApiResponse<ReadCouponUserDetailRes>> getCouponDetail(@PathVariable UUID couponUserId) {
         log.info("GET /api/v1/coupons/me/{} - 쿠폰 상세 조회 요청", couponUserId);
 
-        CouponUserDetailRes response = couponService.getCouponDetail(couponUserId, CurrentUser.getLoginId());
+        ReadCouponUserDetailRes response = couponService.getCouponDetail(couponUserId, CurrentUser.getLoginId());
 
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 쿠폰 상세 조회"));
     }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponControllerImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponControllerImpl.java
@@ -1,0 +1,122 @@
+package com.palja.coupon_service.presentation.controller.impl;
+
+import com.palja.common.annotation.RequiredAnonymous;
+import com.palja.common.auditor.CurrentUser;
+import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
+import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
+import com.palja.coupon_service.application.command.IssueCouponCommand;
+import com.palja.coupon_service.application.command.UseCouponCommand;
+import com.palja.coupon_service.application.dto.CouponUserDetailRes;
+import com.palja.coupon_service.application.dto.CouponUserRes;
+import com.palja.coupon_service.application.dto.UsedCouponUserRes;
+import com.palja.coupon_service.application.service.CouponService;
+import com.palja.coupon_service.presentation.controller.CouponController;
+import com.palja.coupon_service.presentation.dto.request.ChangeCouponStatusReq;
+import com.palja.coupon_service.presentation.dto.request.UseCouponReq;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/coupons")
+public class CouponControllerImpl implements CouponController {
+
+    private final CouponService couponService;
+
+    @Override
+    @RequiredAnonymous
+    @PostMapping("/{couponId}")
+    public ResponseEntity<ApiResponse<CouponUserRes>> issueCoupon(@PathVariable UUID couponId) {
+        log.info("POST /api/v1/coupons/{} - 쿠폰 발급 요청 userId={}", couponId, CurrentUser.getLoginId());
+
+        IssueCouponCommand command = new IssueCouponCommand(couponId, CurrentUser.getLoginId());
+
+        CouponUserRes response = couponService.issueCoupon(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "쿠폰이 발급되었습니다."));
+    }
+
+    @Override
+    @RequiredAnonymous
+    @PostMapping("/{couponUserId}/use")
+    public ResponseEntity<ApiResponse<UsedCouponUserRes>> useCoupon(@PathVariable UUID couponUserId,
+                                                                    @Valid @RequestBody UseCouponReq useCouponReq) {
+        log.info("POST /api/v1/coupons/{}/use - 쿠폰 사용 요청 userId={} orderId={}", couponUserId, CurrentUser.getLoginId(), useCouponReq.getOrderId());
+
+        UseCouponCommand command = UseCouponReq.of(couponUserId, CurrentUser.getLoginId(), useCouponReq);
+
+        UsedCouponUserRes response = couponService.useCoupon(command);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰이 사용되었습니다."));
+    }
+
+    @Override
+    @RequiredAnonymous
+    @PutMapping("/{couponUserId}/cancel")
+    public ResponseEntity<ApiResponse<CouponUserRes>> cancelCoupon(@PathVariable UUID couponUserId) {
+        log.info("PUT /api/v1/coupons/{}/cancel - 쿠폰 취소 요청 userId={}", couponUserId, CurrentUser.getLoginId());
+
+        CouponUserRes response = couponService.cancelCoupon(couponUserId, CurrentUser.getLoginId());
+
+        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰이 취소되었습니다."));
+    }
+
+    @Override
+    @RequiredAnonymous
+    @PutMapping("/{couponUserId}/status")
+    public ResponseEntity<ApiResponse<CouponUserRes>> changeCouponStatus(@PathVariable UUID couponUserId,
+                                                                         @Valid @RequestBody ChangeCouponStatusReq request) {
+        log.info("PUT /api/v1/coupons/{}/status - 쿠폰 상태 변경 요청 status: {}", couponUserId, request.getStatus());
+
+        ChangeCouponStatusCommand command = ChangeCouponStatusReq.of(couponUserId, CurrentUser.getLoginId(), request);
+
+        CouponUserRes response = couponService.changeCouponStatus(command);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 상태가 변경되었습니다."));
+    }
+
+    @Override
+    @RequiredAnonymous
+    @DeleteMapping("/{couponUserId}")
+    public ResponseEntity<ApiResponse<CouponUserRes>> deleteCoupon(@PathVariable UUID couponUserId) {
+        log.info("DELETE /api/v1/coupons/{} - 쿠폰 삭제 요청 userId={}", couponUserId, CurrentUser.getLoginId());
+
+        CouponUserRes response = couponService.deleteCoupon(couponUserId, CurrentUser.getLoginId());
+
+        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰이 삭제되었습니다."));
+    }
+
+    @Override
+    @RequiredAnonymous
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<PageResponse<CouponUserRes>>> getCouponList(Pageable pageable) {
+        log.info("GET /api/v1/coupons/me - 사용자 쿠폰 목록 조회 요청 userId={}", CurrentUser.getLoginId());
+
+        Page<CouponUserRes> couponUserResPage = couponService.getCouponList(CurrentUser.getLoginId(), pageable);
+
+        PageResponse<CouponUserRes> response = PageResponse.from(couponUserResPage);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 쿠폰 목록 조회"));
+    }
+
+    @Override
+    @RequiredAnonymous
+    @GetMapping("/me/{couponUserId}")
+    public ResponseEntity<ApiResponse<CouponUserDetailRes>> getCouponDetail(@PathVariable UUID couponUserId) {
+        log.info("GET /api/v1/coupons/me/{} - 쿠폰 상세 조회 요청", couponUserId);
+
+        CouponUserDetailRes response = couponService.getCouponDetail(couponUserId, CurrentUser.getLoginId());
+
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 쿠폰 상세 조회"));
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponManagerControllerImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponManagerControllerImpl.java
@@ -7,8 +7,7 @@ import com.palja.common.vo.UserRole;
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
 import com.palja.coupon_service.application.command.UpdateCouponCommand;
-import com.palja.coupon_service.application.dto.CouponDetailRes;
-import com.palja.coupon_service.application.dto.CouponRes;
+import com.palja.coupon_service.application.dto.coupon.*;
 import com.palja.coupon_service.application.service.CouponManagerService;
 import com.palja.coupon_service.presentation.controller.CouponManagerController;
 import com.palja.coupon_service.presentation.dto.request.ChangeCouponStatusReq;
@@ -35,59 +34,59 @@ public class CouponManagerControllerImpl implements CouponManagerController {
 
     @RequiredRole(UserRole.MANAGER)
     @PostMapping
-    public ResponseEntity<ApiResponse<CouponRes>> createCoupon(@Valid @RequestBody CreateCouponReq request) {
+    public ResponseEntity<ApiResponse<CreateCouponRes>> createCoupon(@Valid @RequestBody CreateCouponReq request) {
         log.info("POST /api/v1/coupons/manager - 쿠폰 생성 요청");
 
         CreateCouponCommand command = CreateCouponReq.of(request);
 
-        CouponRes couponRes = couponManagerService.createCoupon(command);
+        CreateCouponRes response = couponManagerService.createCoupon(command);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(couponRes, "쿠폰이 생성되었습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "쿠폰이 생성되었습니다."));
     }
 
     @RequiredRole(UserRole.MANAGER)
     @PutMapping("/{couponId}")
-    public ResponseEntity<ApiResponse<CouponRes>> updateCoupon(@PathVariable UUID couponId, @Valid @RequestBody UpdateCouponReq request) {
+    public ResponseEntity<ApiResponse<UpdateCouponRes>> updateCoupon(@PathVariable UUID couponId, @Valid @RequestBody UpdateCouponReq request) {
         log.info("PUT /api/v1/coupons/manager/{} - 쿠폰 수정 요청", couponId);
 
         UpdateCouponCommand command = UpdateCouponReq.of(couponId, request);
 
-        CouponRes couponRes = couponManagerService.updateCoupon(command);
+        UpdateCouponRes response = couponManagerService.updateCoupon(command);
 
-        return ResponseEntity.ok(ApiResponse.success(couponRes, "쿠폰이 수정되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰이 수정되었습니다."));
     }
 
     @RequiredRole(UserRole.MANAGER)
     @PutMapping("/{couponId}/status")
-    public ResponseEntity<ApiResponse<CouponRes>> changeCouponStatus(@PathVariable UUID couponId,
-                                                                     @Valid @RequestBody ChangeCouponStatusReq request) {
+    public ResponseEntity<ApiResponse<ChangeStatusCouponRes>> changeCouponStatus(@PathVariable UUID couponId,
+                                                                           @Valid @RequestBody ChangeCouponStatusReq request) {
         log.info("PUT /api/v1/coupons/manager/{}/status - 쿠폰 상태 변경 요청 status: {}", couponId, request.getStatus());
 
         ChangeCouponStatusCommand command = ChangeCouponStatusReq.of(couponId, request);
 
-        CouponRes couponRes = couponManagerService.changeCouponStatus(command);
+        ChangeStatusCouponRes response = couponManagerService.changeCouponStatus(command);
 
-        return ResponseEntity.ok(ApiResponse.success(couponRes, "쿠폰 상태가 변경되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 상태가 변경되었습니다."));
     }
 
     @RequiredRole(UserRole.MANAGER)
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<CouponRes>>> getCouponList(Pageable pageable) {
+    public ResponseEntity<ApiResponse<PageResponse<ReadCouponRes>>> getCouponList(Pageable pageable) {
         log.info("GET /api/v1/coupons/manager - 쿠폰 목록 조회 요청");
 
-        Page<CouponRes> couponResPage = couponManagerService.getCouponList(pageable);
+        Page<ReadCouponRes> couponResPage = couponManagerService.getCouponList(pageable);
 
-        PageResponse<CouponRes> response = PageResponse.from(couponResPage);
+        PageResponse<ReadCouponRes> response = PageResponse.from(couponResPage);
 
         return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 목록 조회"));
     }
 
     @RequiredRole(UserRole.MANAGER)
     @GetMapping("/{couponId}")
-    public ResponseEntity<ApiResponse<CouponDetailRes>> getCouponDetail(@PathVariable UUID couponId) {
+    public ResponseEntity<ApiResponse<ReadCouponDetailRes>> getCouponDetail(@PathVariable UUID couponId) {
         log.info("GET /api/v1/coupons/manager/{} - 쿠폰 상세 조회 요청", couponId);
 
-        CouponDetailRes response = couponManagerService.getCouponDetail(couponId);
+        ReadCouponDetailRes response = couponManagerService.getCouponDetail(couponId);
 
         return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 상세 조회"));
     }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponManagerControllerImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponManagerControllerImpl.java
@@ -1,0 +1,94 @@
+package com.palja.coupon_service.presentation.controller.impl;
+
+import com.palja.common.annotation.RequiredRole;
+import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
+import com.palja.common.vo.UserRole;
+import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
+import com.palja.coupon_service.application.command.CreateCouponCommand;
+import com.palja.coupon_service.application.command.UpdateCouponCommand;
+import com.palja.coupon_service.application.dto.CouponDetailRes;
+import com.palja.coupon_service.application.dto.CouponRes;
+import com.palja.coupon_service.application.service.CouponManagerService;
+import com.palja.coupon_service.presentation.controller.CouponManagerController;
+import com.palja.coupon_service.presentation.dto.request.ChangeCouponStatusReq;
+import com.palja.coupon_service.presentation.dto.request.CreateCouponReq;
+import com.palja.coupon_service.presentation.dto.request.UpdateCouponReq;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/coupons/manager")
+public class CouponManagerControllerImpl implements CouponManagerController {
+
+    private final CouponManagerService couponManagerService;
+
+    @RequiredRole(UserRole.MANAGER)
+    @PostMapping
+    public ResponseEntity<ApiResponse<CouponRes>> createCoupon(@Valid @RequestBody CreateCouponReq request) {
+        log.info("POST /api/v1/coupons/manager - 쿠폰 생성 요청");
+
+        CreateCouponCommand command = CreateCouponReq.of(request);
+
+        CouponRes couponRes = couponManagerService.createCoupon(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(couponRes, "쿠폰이 생성되었습니다."));
+    }
+
+    @RequiredRole(UserRole.MANAGER)
+    @PutMapping("/{couponId}")
+    public ResponseEntity<ApiResponse<CouponRes>> updateCoupon(@PathVariable UUID couponId, @Valid @RequestBody UpdateCouponReq request) {
+        log.info("PUT /api/v1/coupons/manager/{} - 쿠폰 수정 요청", couponId);
+
+        UpdateCouponCommand command = UpdateCouponReq.of(couponId, request);
+
+        CouponRes couponRes = couponManagerService.updateCoupon(command);
+
+        return ResponseEntity.ok(ApiResponse.success(couponRes, "쿠폰이 수정되었습니다."));
+    }
+
+    @RequiredRole(UserRole.MANAGER)
+    @PutMapping("/{couponId}/status")
+    public ResponseEntity<ApiResponse<CouponRes>> changeCouponStatus(@PathVariable UUID couponId,
+                                                                     @Valid @RequestBody ChangeCouponStatusReq request) {
+        log.info("PUT /api/v1/coupons/manager/{}/status - 쿠폰 상태 변경 요청 status: {}", couponId, request.getStatus());
+
+        ChangeCouponStatusCommand command = ChangeCouponStatusReq.of(couponId, request);
+
+        CouponRes couponRes = couponManagerService.changeCouponStatus(command);
+
+        return ResponseEntity.ok(ApiResponse.success(couponRes, "쿠폰 상태가 변경되었습니다."));
+    }
+
+    @RequiredRole(UserRole.MANAGER)
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<CouponRes>>> getCouponList(Pageable pageable) {
+        log.info("GET /api/v1/coupons/manager - 쿠폰 목록 조회 요청");
+
+        Page<CouponRes> couponResPage = couponManagerService.getCouponList(pageable);
+
+        PageResponse<CouponRes> response = PageResponse.from(couponResPage);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 목록 조회"));
+    }
+
+    @RequiredRole(UserRole.MANAGER)
+    @GetMapping("/{couponId}")
+    public ResponseEntity<ApiResponse<CouponDetailRes>> getCouponDetail(@PathVariable UUID couponId) {
+        log.info("GET /api/v1/coupons/manager/{} - 쿠폰 상세 조회 요청", couponId);
+
+        CouponDetailRes response = couponManagerService.getCouponDetail(couponId);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "쿠폰 상세 조회"));
+    }
+}

--- a/coupon-service/src/main/resources/application-swagger.yml
+++ b/coupon-service/src/main/resources/application-swagger.yml
@@ -1,0 +1,5 @@
+springdoc:
+  group:
+    name: coupon-service
+  swagger-ui:
+    enabled: false

--- a/coupon-service/src/main/resources/application.yml
+++ b/coupon-service/src/main/resources/application.yml
@@ -9,3 +9,5 @@ spring:
     include:
       - datasource
       - zipkin
+      - eureka
+      - swagger

--- a/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
+++ b/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
@@ -203,7 +203,7 @@ class CouponManagerServiceImplTest {
                     .build();
 
             Coupon existingCoupon = mock(Coupon.class);
-            given(existingCoupon.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
+            given(existingCoupon.getName()).willReturn("쿠폰");
             given(existingCoupon.getAmountPolicy()).willReturn(mock(AmountPolicy.class));
             given(existingCoupon.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
             given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(existingCoupon));
@@ -263,9 +263,6 @@ class CouponManagerServiceImplTest {
                     .build();
 
             Coupon existingCoupon = mock(Coupon.class);
-            given(existingCoupon.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
-            given(existingCoupon.getAmountPolicy()).willReturn(mock(AmountPolicy.class));
-            given(existingCoupon.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
             given(existingCoupon.getStatus()).willReturn(CouponStatus.ACTIVE);
             given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(existingCoupon));
 
@@ -309,12 +306,10 @@ class CouponManagerServiceImplTest {
             // given
             Coupon coupon1 = mock(Coupon.class);
             given(coupon1.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
-            given(coupon1.getAmountPolicy()).willReturn(mock(AmountPolicy.class));
             given(coupon1.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
 
             Coupon coupon2 = mock(Coupon.class);
             given(coupon2.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
-            given(coupon2.getAmountPolicy()).willReturn(mock(AmountPolicy.class));
             given(coupon2.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
 
             Pageable pageable = PageRequest.of(0, 10);

--- a/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
+++ b/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponManagerServiceImplTest.java
@@ -4,8 +4,7 @@ import com.palja.common.exception.BusinessException;
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import com.palja.coupon_service.application.command.CreateCouponCommand;
 import com.palja.coupon_service.application.command.UpdateCouponCommand;
-import com.palja.coupon_service.application.dto.CouponDetailRes;
-import com.palja.coupon_service.application.dto.CouponRes;
+import com.palja.coupon_service.application.dto.coupon.*;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.repository.CouponRepository;
 import com.palja.coupon_service.domain.vo.*;
@@ -78,7 +77,7 @@ class CouponManagerServiceImplTest {
             given(couponRepository.save(any(Coupon.class))).willReturn(savedCoupon);
 
             // when
-            CouponRes result = couponManagerService.createCoupon(command);
+            CreateCouponRes result = couponManagerService.createCoupon(command);
 
             // then
             assertThat(result).isNotNull();
@@ -210,7 +209,7 @@ class CouponManagerServiceImplTest {
             given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(existingCoupon));
 
             // when
-            CouponRes result = couponManagerService.updateCoupon(command);
+            UpdateCouponRes result = couponManagerService.updateCoupon(command);
 
             // then
             assertThat(result).isNotNull();
@@ -271,7 +270,7 @@ class CouponManagerServiceImplTest {
             given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(existingCoupon));
 
             // when
-            CouponRes result = couponManagerService.changeCouponStatus(command);
+            ChangeStatusCouponRes result = couponManagerService.changeCouponStatus(command);
 
             // then
             assertThat(result).isNotNull();
@@ -326,7 +325,7 @@ class CouponManagerServiceImplTest {
             given(couponRepository.findAllByDeletedAtIsNull(pageable)).willReturn(couponPage);
 
             // when
-            Page<CouponRes> result = couponManagerService.getCouponList(pageable);
+            Page<ReadCouponRes> result = couponManagerService.getCouponList(pageable);
 
             // then
             assertThat(result).isNotNull();
@@ -345,7 +344,7 @@ class CouponManagerServiceImplTest {
             given(couponRepository.findAllByDeletedAtIsNull(pageable)).willReturn(couponPage);
 
             // when
-            Page<CouponRes> result = couponManagerService.getCouponList(pageable);
+            Page<ReadCouponRes> result = couponManagerService.getCouponList(pageable);
 
             // then
             assertThat(result).isNotNull();
@@ -370,7 +369,7 @@ class CouponManagerServiceImplTest {
             given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(coupon));
 
             // when
-            CouponDetailRes result = couponManagerService.getCouponDetail(couponId);
+            ReadCouponDetailRes result = couponManagerService.getCouponDetail(couponId);
 
             // then
             assertThat(result).isNotNull();


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #152 

<br>

## 📌 개요
Controller를 Swagger 문서화 적용했습니다. 
응답 DTO의 네이밍을 RESTful 컨벤션에 맞게 통일했습니다.

<br>

## 🔁 변경 사항

### 1. Controller 아키텍처 개선
- **Interface-Implementation 패턴 적용**:
  - `CouponController` → Interface로 변경, `CouponControllerImpl` 구현체 추가
  - `CouponManagerController` → Interface로 변경, `CouponManagerControllerImpl` 구현체 추가
- **Swagger 문서화**: 
  - Interface에 `@Tag`, `@Operation` 어노테이션 적용
  - API 명세를 코드와 분리하여 가독성 향상

### 2. DTO 패키지 구조 개선
- **도메인별 패키지 분리**:
  - `application.dto.coupon` - 관리자용 쿠폰 DTO
  - `application.dto.couponUser` - 사용자용 쿠폰 DTO
- **DTO 네이밍 통일**:
  - Create: `CreateCouponRes`, `CreateCouponUserRes`
  - Read: `ReadCouponRes`, `ReadCouponDetailRes`, `ReadCouponUserRes`, `ReadCouponUserDetailRes`
  - Update: `UpdateCouponRes`
  - Delete: `DeleteCouponUserRes`
  - Change Status: `ChangeStatusCouponRes`, `ChangeStatusCouponUserRes`
  - Cancel: `CancelCouponUserRes`

### 3. 권한 검증 개선
- **어노테이션 기반 권한 검증**:
  - 기존: Controller 내부에서 `validateRole()` 메서드 호출
  - 개선: `@RequiredRole(UserRole.MANAGER)` 어노테이션 사용
  - `@RequiredAnonymous` 어노테이션으로 인증 필요 여부 명시

### 4. Swagger 설정
- **SpringDoc OpenAPI 추가**: `springdoc-openapi-starter-webmvc-ui:2.8.14`
- **설정 파일 추가**: `application-swagger.yml`
- **Eureka 클라이언트 활성화**: `@EnableDiscoveryClient` 추가

### 5. 기타 개선사항
- **common-module 버전 업그레이드**: 0.7.1 → 0.8.1

<br>

## 📸 스크린샷

<details>
  <summary>Swagger UI</summary>
  
<img width="2161" height="1258" alt="image" src="https://github.com/user-attachments/assets/2a3a678e-9619-4a74-84b6-410a889c7289" />


</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.