### PR TITLE
FEAT/ UserService 회원 삭제 시 연관 데이터도 삭제되도록 구현

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.palja:common-module:0.7.1'
+    implementation 'com.palja:common-module:0.8.1'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/user-service/src/main/java/com/palja/user_service/UserServiceApplication.java
+++ b/user-service/src/main/java/com/palja/user_service/UserServiceApplication.java
@@ -3,6 +3,7 @@ package com.palja.user_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @ComponentScan(basePackages = {"com.palja.user_service", "com.palja.common"})
 @EnableJpaAuditing
 @EnableDiscoveryClient
+@EnableFeignClients
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/ProductService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/ProductService.java
@@ -1,0 +1,9 @@
+package com.palja.user_service.application.service;
+
+import java.util.UUID;
+
+public interface ProductService {
+
+	void deleteAllProducts(UUID companyUserId);
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/service/ReviewService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/ReviewService.java
@@ -1,0 +1,7 @@
+package com.palja.user_service.application.service;
+
+public interface ReviewService {
+
+	void deleteAllReviews(Long userId);
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/service/TimeDealService.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/TimeDealService.java
@@ -1,0 +1,9 @@
+package com.palja.user_service.application.service;
+
+import java.util.UUID;
+
+public interface TimeDealService {
+
+	void deleteAllTimeDeals(UUID companyUserId);
+
+}

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -22,6 +22,7 @@ import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes
 import com.palja.user_service.application.dto.response.UpdateCompanyUserDetailRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CompanyUserService;
+import com.palja.user_service.application.service.ProductService;
 import com.palja.user_service.application.service.TimeDealService;
 import com.palja.user_service.application.util.JwtUtil;
 import com.palja.user_service.domain.entity.CompanyUser;
@@ -39,10 +40,13 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 
 	private final CompanyUserRepository companyUserRepository;
 	private final UserRepository userRepository;
+	private final TokenRepository tokenRepository;
+
+	private final TimeDealService timeDealService;
+	private final ProductService productService;
+
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtil jwtUtil;
-	private final TokenRepository tokenRepository;
-	private final TimeDealService timeDealService;
 
 	@Override
 	@Transactional
@@ -141,6 +145,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
 		companyUser.softDelete();
 		timeDealService.deleteAllTimeDeals(companyUser.getId());
+		productService.deleteAllProducts(companyUser.getId());
 	}
 
 	@Override
@@ -149,6 +154,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		CompanyUser companyUser = getCompanyUserByLoginId(currentUserLoginId);
 		companyUser.softDelete();
 		timeDealService.deleteAllTimeDeals(companyUser.getId());
+		productService.deleteAllProducts(companyUser.getId());
 
 		String substringAccessToken = jwtUtil.substringToken(accessToken);
 		String hashKey = jwtUtil.hashingTokenToSHA256(substringAccessToken);

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -22,6 +22,7 @@ import com.palja.user_service.application.dto.response.ReadCompanyUserSummaryRes
 import com.palja.user_service.application.dto.response.UpdateCompanyUserDetailRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CompanyUserService;
+import com.palja.user_service.application.service.TimeDealService;
 import com.palja.user_service.application.util.JwtUtil;
 import com.palja.user_service.domain.entity.CompanyUser;
 import com.palja.user_service.domain.entity.User;
@@ -41,6 +42,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtil jwtUtil;
 	private final TokenRepository tokenRepository;
+	private final TimeDealService timeDealService;
 
 	@Override
 	@Transactional
@@ -138,6 +140,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 
 		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
 		companyUser.softDelete();
+		timeDealService.deleteAllTimeDeals(companyUser.getId());
 	}
 
 	@Override
@@ -145,6 +148,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	public void deleteMe(String accessToken, String currentUserLoginId) {
 		CompanyUser companyUser = getCompanyUserByLoginId(currentUserLoginId);
 		companyUser.softDelete();
+		timeDealService.deleteAllTimeDeals(companyUser.getId());
 
 		String substringAccessToken = jwtUtil.substringToken(accessToken);
 		String hashKey = jwtUtil.hashingTokenToSHA256(substringAccessToken);

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -19,6 +19,7 @@ import com.palja.user_service.application.dto.response.ReadCustomerSummaryRes;
 import com.palja.user_service.application.dto.response.UpdateCustomerDetailRes;
 import com.palja.user_service.application.exception.UserErrorCode;
 import com.palja.user_service.application.service.CustomerService;
+import com.palja.user_service.application.service.ReviewService;
 import com.palja.user_service.application.util.JwtUtil;
 import com.palja.user_service.domain.entity.User;
 import com.palja.user_service.domain.repository.TokenRepository;
@@ -31,9 +32,12 @@ import lombok.RequiredArgsConstructor;
 public class CustomerServiceImpl implements CustomerService {
 
 	private final UserRepository userRepository;
+	private final TokenRepository tokenRepository;
+
+	private final ReviewService reviewService;
+
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtil jwtUtil;
-	private final TokenRepository tokenRepository;
 
 	@Override
 	@Transactional
@@ -116,6 +120,7 @@ public class CustomerServiceImpl implements CustomerService {
 
 		User user = getCustomerByLoginId(loginId);
 		user.softDelete();
+		reviewService.deleteAllReviews(user.getId());
 	}
 
 	@Override
@@ -123,6 +128,7 @@ public class CustomerServiceImpl implements CustomerService {
 	public void deleteMe(String accessToken, String currentUserLoginId) {
 		User user = getCustomerByLoginId(currentUserLoginId);
 		user.softDelete();
+		reviewService.deleteAllReviews(user.getId());
 
 		String substringAccessToken = jwtUtil.substringToken(accessToken);
 		String hashKey = jwtUtil.hashingTokenToSHA256(substringAccessToken);

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/ProductClient.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/ProductClient.java
@@ -1,0 +1,18 @@
+package com.palja.user_service.infrastructure.external.feign;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.palja.common.response.ApiResponse;
+
+@FeignClient(name = "product-service", path = "/api/v1/products")
+public interface ProductClient {
+
+	// TODO: 고도화 때 이벤트 기반 비동기 호출로 변경
+	@DeleteMapping("/user/{companyUserId}")
+	ApiResponse<Void> deleteAllProducts(@PathVariable("companyUserId") UUID companyUserId);
+
+}

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/ReviewClient.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/ReviewClient.java
@@ -1,0 +1,16 @@
+package com.palja.user_service.infrastructure.external.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.palja.common.response.ApiResponse;
+
+@FeignClient(name = "review-service", path = "/api/v1/reviews")
+public interface ReviewClient {
+
+	// TODO: 고도화 때 이벤트 기반 비동기 호출로 변경
+	@DeleteMapping("/{userId}")
+	ApiResponse<Void> deleteAllReviews(@PathVariable("userId") Long userId);
+
+}

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/TimeDealClient.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/TimeDealClient.java
@@ -1,0 +1,18 @@
+package com.palja.user_service.infrastructure.external.feign;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.palja.common.response.ApiResponse;
+
+@FeignClient(name = "timedeal-service", path = "/api/v1/time-deals")
+public interface TimeDealClient {
+
+	// TODO: 고도화 때 이벤트 기반 비동기 호출로 변경
+	@DeleteMapping("/{companyUserId}")
+	ApiResponse<Void> deleteAllTimeDeals(@PathVariable("companyUserId") UUID companyUserId);
+
+}

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ProductAdapter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ProductAdapter.java
@@ -34,7 +34,7 @@ public class ProductAdapter implements ProductService {
 	}
 
 	private ApiResponse<Void> getDummy(UUID companyUserId) {
-		return ApiResponse.success("리뷰가 삭제되었습니다.");
+		return ApiResponse.success("상품이 삭제되었습니다.");
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ProductAdapter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ProductAdapter.java
@@ -1,0 +1,34 @@
+package com.palja.user_service.infrastructure.external.feign.adapter;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.common.exception.CommonErrorCode;
+import com.palja.user_service.application.service.ProductService;
+import com.palja.user_service.infrastructure.external.feign.ProductClient;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductAdapter implements ProductService {
+
+	private final ProductClient productClient;
+
+	@Override
+	public void deleteAllProducts(UUID companyUserId) {
+		try {
+			productClient.deleteAllProducts(companyUserId);
+		} catch (FeignException e) {
+			log.error("[Feign] status={} url=[{}] {} message={}",
+				e.status(), e.request().httpMethod().name(), e.request().url(), e.contentUTF8());
+			throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
+		}
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ProductAdapter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ProductAdapter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
+import com.palja.common.response.ApiResponse;
 import com.palja.user_service.application.service.ProductService;
 import com.palja.user_service.infrastructure.external.feign.ProductClient;
 
@@ -23,12 +24,17 @@ public class ProductAdapter implements ProductService {
 	@Override
 	public void deleteAllProducts(UUID companyUserId) {
 		try {
-			productClient.deleteAllProducts(companyUserId);
+			getDummy(companyUserId); // TODO: API 개발 완료 후 실제 호출로 변경
+			// productClient.deleteAllProducts(companyUserId);
 		} catch (FeignException e) {
 			log.error("[Feign] status={} url=[{}] {} message={}",
 				e.status(), e.request().httpMethod().name(), e.request().url(), e.contentUTF8());
 			throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
 		}
+	}
+
+	private ApiResponse<Void> getDummy(UUID companyUserId) {
+		return ApiResponse.success("리뷰가 삭제되었습니다.");
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ReviewAdapter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ReviewAdapter.java
@@ -1,0 +1,32 @@
+package com.palja.user_service.infrastructure.external.feign.adapter;
+
+import org.springframework.stereotype.Component;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.common.exception.CommonErrorCode;
+import com.palja.user_service.application.service.ReviewService;
+import com.palja.user_service.infrastructure.external.feign.ReviewClient;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReviewAdapter implements ReviewService {
+
+	private final ReviewClient reviewClient;
+
+	@Override
+	public void deleteAllReviews(Long userId) {
+		try {
+			reviewClient.deleteAllReviews(userId);
+		} catch (FeignException e) {
+			log.error("[Feign] status={} url=[{}] {} message={}",
+				e.status(), e.request().httpMethod().name(), e.request().url(), e.contentUTF8());
+			throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
+		}
+	}
+
+}

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ReviewAdapter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/ReviewAdapter.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
+import com.palja.common.response.ApiResponse;
 import com.palja.user_service.application.service.ReviewService;
 import com.palja.user_service.infrastructure.external.feign.ReviewClient;
 
@@ -21,12 +22,17 @@ public class ReviewAdapter implements ReviewService {
 	@Override
 	public void deleteAllReviews(Long userId) {
 		try {
-			reviewClient.deleteAllReviews(userId);
+			getDummy(userId); // TODO: API 개발 완료 후 실제 호출로 변경
+			// reviewClient.deleteAllReviews(userId);
 		} catch (FeignException e) {
 			log.error("[Feign] status={} url=[{}] {} message={}",
 				e.status(), e.request().httpMethod().name(), e.request().url(), e.contentUTF8());
 			throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
 		}
+	}
+
+	private ApiResponse<Void> getDummy(Long userId) {
+		return ApiResponse.success("리뷰가 삭제되었습니다.");
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/TimeDealAdapter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/TimeDealAdapter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
+import com.palja.common.response.ApiResponse;
 import com.palja.user_service.application.service.TimeDealService;
 import com.palja.user_service.infrastructure.external.feign.TimeDealClient;
 
@@ -23,12 +24,17 @@ public class TimeDealAdapter implements TimeDealService {
 	@Override
 	public void deleteAllTimeDeals(UUID companyUserId) {
 		try {
-			timeDealClient.deleteAllTimeDeals(companyUserId);
+			getDummy(companyUserId); // TODO: API 개발 완료 후 실제 호출로 변경
+			// timeDealClient.deleteAllTimeDeals(companyUserId);
 		} catch (FeignException e) {
 			log.error("[Feign] status={} url=[{}] {} message={}",
 				e.status(), e.request().httpMethod().name(), e.request().url(), e.contentUTF8());
 			throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
 		}
+	}
+
+	private ApiResponse<Void> getDummy(UUID companyUserId) {
+		return ApiResponse.success("타임딜이 삭제되었습니다.");
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/TimeDealAdapter.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/external/feign/adapter/TimeDealAdapter.java
@@ -1,0 +1,34 @@
+package com.palja.user_service.infrastructure.external.feign.adapter;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.common.exception.CommonErrorCode;
+import com.palja.user_service.application.service.TimeDealService;
+import com.palja.user_service.infrastructure.external.feign.TimeDealClient;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TimeDealAdapter implements TimeDealService {
+
+	private final TimeDealClient timeDealClient;
+
+	@Override
+	public void deleteAllTimeDeals(UUID companyUserId) {
+		try {
+			timeDealClient.deleteAllTimeDeals(companyUserId);
+		} catch (FeignException e) {
+			log.error("[Feign] status={} url=[{}] {} message={}",
+				e.status(), e.request().httpMethod().name(), e.request().url(), e.contentUTF8());
+			throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
+		}
+	}
+
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #153 

<br>

## 📌 개요
- 회원 삭제 시 각각 연관된 데이터를 삭제할 수 있도록 FeignClient를 구현했습니다.

<br>

## 🔁 변경 사항
- 업체 판매자 : 등록한 타임딜과 상품을 삭제하는 로직(FeignClinet)을 추가했습니다.
- 일반 사용자 : 등록한 리뷰를 삭제하는 로직(FeignClient)을 추가했습니다.
- 개발 후 더미를 호출하도록 변경했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
