### PR TITLE
FEAT/OrderService 결제 서비스 API 연동 (결제 생성/취소) 

### DIFF
--- a/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
@@ -13,6 +13,7 @@ public record CreateOrderCommand(
         int quantity,
         UUID timeDealId,
         UUID couponId,
+        String paymentMethod,
         DeliveryCommand delivery
 ) {
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/PaymentMethod.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/PaymentMethod.java
@@ -1,0 +1,23 @@
+package com.palja.order_service.application.dto;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.order_service.application.exception.OrderErrorCode;
+
+public enum PaymentMethod {
+    CARD,
+    ACCOUNT,
+    EASY_PAY,
+    MOBILE,
+    VIRTUAL_ACCOUNT;
+
+    public static PaymentMethod from(String value) {
+        if (value == null) {
+            throw new BusinessException(OrderErrorCode.INVALID_PAYMENT_METHOD);
+        }
+        try {
+            return PaymentMethod.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(OrderErrorCode.INVALID_PAYMENT_METHOD);
+        }
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/PaymentCancelRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/PaymentCancelRes.java
@@ -9,23 +9,10 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentCancelRes {
 
     private UUID paymentId;
     private BigDecimal amount;
-    private String status;
-
-    public static PaymentCancelRes of(
-            UUID paymentId,
-            BigDecimal amount,
-            String status
-    ) {
-        return PaymentCancelRes.builder()
-                .paymentId(paymentId)
-                .amount(amount)
-                .status(status)
-                .build();
-    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/PaymentCreateRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/PaymentCreateRes.java
@@ -9,17 +9,10 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class PaymentRes {
+public class PaymentCreateRes {
 
     private final UUID paymentId;
     private final BigDecimal amount;
-
-    public static PaymentRes of(UUID paymentId, BigDecimal amount) {
-        return PaymentRes.builder()
-                .paymentId(paymentId)
-                .amount(amount)
-                .build();
-    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -26,8 +26,15 @@ public enum OrderErrorCode implements ErrorCode {
     MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "필수 입력 항목이 누락되었습니다."),
     ORDER_CANNOT_BE_CANCELLED(HttpStatus.BAD_REQUEST, "취소할 수 없는 주문 상태입니다."),
     ORDER_DELIVERY_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 배송이 시작되어 취소할 수 없습니다."),
-    REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "환불 처리에 실패했습니다."),
     INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "주문 금액이 올바르지 않습니다."),
+    ORDER_CANNOT_BE_CANCELED(HttpStatus.BAD_REQUEST, "현재 상태에서는 주문을 취소할 수 없습니다."),
+    NO_CANCEL_PERMISSION(HttpStatus.FORBIDDEN, "해당 주문을 취소할 권한이 없습니다."),
+
+    INVENTORY_DEDUCTION_FAILED(HttpStatus.BAD_REQUEST, "재고 차감에 실패했습니다."),
+    INVENTORY_RESTORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "재고 복구에 실패했습니다."),
+    COUPON_APPLICATION_FAILED(HttpStatus.BAD_REQUEST, "쿠폰 사용에 실패했습니다."),
+    COUPON_RESTORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "쿠폰 복구에 실패했습니다."),
+    REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 환불에 실패했습니다."),
     // 주문 상태 변경 관련
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태입니다."),
     SAME_STATUS_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "동일한 상태로는 변경할 수 없습니다."),
@@ -74,6 +81,7 @@ public enum OrderErrorCode implements ErrorCode {
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "결제에 실패했습니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "결제 시간이 초과되었습니다."),
+    INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 수단입니다."),
 
     // ===== 권한 관련 =====
     USER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "접근 권한이 없는 사용자입니다."),

--- a/order-service/src/main/java/com/palja/order_service/application/service/PaymentService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/PaymentService.java
@@ -1,13 +1,15 @@
 package com.palja.order_service.application.service;
 
-import com.palja.order_service.application.dto.response.PaymentRes;
+import com.palja.order_service.application.dto.PaymentMethod;
+import com.palja.order_service.application.dto.response.PaymentCancelRes;
+import com.palja.order_service.application.dto.response.PaymentCreateRes;
 
 import java.math.BigDecimal;
 import java.util.UUID;
 
 public interface PaymentService {
 
-    PaymentRes createPayment(UUID orderId, Long userId, BigDecimal amount, String paymentMethod);
+    PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, PaymentMethod paymentMethod);
 
-    void cancelPayment(UUID orderId, UUID paymentId);
+    PaymentCancelRes cancelPayment(UUID orderId, UUID paymentId);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -5,6 +5,7 @@ import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CancelOrderCommand;
 import com.palja.order_service.application.command.CreateOrderCommand;
+import com.palja.order_service.application.dto.PaymentMethod;
 import com.palja.order_service.application.dto.response.*;
 import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.*;
@@ -19,9 +20,7 @@ import com.palja.order_service.presentation.dto.request.CustomerOrderSearchReq;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,6 +58,7 @@ public class OrderServiceImpl implements OrderService {
      * - 외부 시스템 처리 (재고, 쿠폰, 결제)
      * - 영속화
      */
+    // TODO: Kafka Event 기반 비동기 처리 및 Saga 패턴 적용
     @Transactional
     public OrderCreateRes createOrder(CreateOrderCommand command) {
         log.info("주문 생성 시작 - loginId: {}, productId: {}, quantity: {}",
@@ -74,7 +74,7 @@ public class OrderServiceImpl implements OrderService {
         orderRepository.save(order);
         log.info("주문 엔티티 생성 및 임시 저장 완료 (결제 전) - orderId: {}", order.getOrderId());
 
-        // 외부 시스템 처리 (동기)
+        // TODO: Kafka Event 발행으로 전환
         processOrderCreationExternalEvents(order, context);
 
         orderRepository.save(order);
@@ -112,12 +112,16 @@ public class OrderServiceImpl implements OrderService {
             log.debug("쿠폰 검증 완료 - couponId: {}", command.couponId());
         }
 
+        PaymentMethod paymentMethod = PaymentMethod.from(command.paymentMethod());
+        log.debug("결제 수단 검증 완료 - paymentMethod: {}", paymentMethod);
+
         return new OrderCreationContext(
                 customer,
                 product,
                 timeDeal,
                 coupon,
-                command.quantity()
+                command.quantity(),
+                paymentMethod
         );
     }
 
@@ -175,14 +179,12 @@ public class OrderServiceImpl implements OrderService {
         );
     }
 
-    /**
-     * 외부 시스템 처리 (재고, 쿠폰, 결제)
-     * TODO: 추후 비동기 + Saga 패턴으로 개선 예정
-     */
+    // 외부 시스템 처리 (재고, 쿠폰, 결제)
     private void processOrderCreationExternalEvents(Order order, OrderCreationContext context) {
+        // TODO: 이벤트 발행으로 대체
         reserveInventory(order, context.timeDeal());
         applyCoupon(order.getCouponId(), order.getOrderId());
-        executePayment(order, context.customer().getUserId());
+        executePayment(order, context.customer().getUserId(), context.paymentMethod());
     }
 
     /**
@@ -190,44 +192,63 @@ public class OrderServiceImpl implements OrderService {
      * - 타임딜 주문: 타임딜 재고만 차감
      * - 일반 주문: 상품 재고만 차감
      */
+    // TODO: 이벤트 기반 처리
     private void reserveInventory(Order order, Optional<TimeDealRes> timeDeal) {
         UUID productId = order.getOrderItem().getProductId();
         int quantity = order.getOrderItem().getQuantity();
 
-        if (timeDeal.isPresent()) {
-            // 타임딜 재고만 차감
-            TimeDealRes deal = timeDeal.get();
-            timeDealService.deductTimeDealStock(deal.getTimeDealId(), quantity);
-            log.info("타임딜 재고 차감 완료 - timeDealId: {}, quantity: {}",
-                    deal.getTimeDealId(), quantity);
-        } else {
-            // 일반 상품 재고만 차감
-            productService.deductProductStock(productId, quantity);
-            log.info("상품 재고 차감 완료 - productId: {}, quantity: {}", productId, quantity);
+        try {
+            if (timeDeal.isPresent()) {
+                TimeDealRes deal = timeDeal.get();
+                timeDealService.deductTimeDealStock(deal.getTimeDealId(), quantity);
+                log.info("타임딜 재고 차감 완료 - timeDealId: {}, quantity: {}",
+                        deal.getTimeDealId(), quantity);
+            } else {
+                productService.deductProductStock(productId, quantity);
+                log.info("상품 재고 차감 완료 - productId: {}, quantity: {}", productId, quantity);
+            }
+        } catch (Exception e) {
+            log.error("재고 차감 실패 - orderId: {}, productId: {}, isTimeDeal: {}",
+                    order.getOrderId(), productId, timeDeal.isPresent(), e);
+            // TODO: 보상 트랜잭션 처리
+            throw new BusinessException(OrderErrorCode.INVENTORY_DEDUCTION_FAILED);
         }
     }
 
     // 쿠폰 사용
+    // TODO: 이벤트 기반 처리
     private void applyCoupon(UUID couponId, UUID orderId) {
         if (couponId == null) {
             return;
         }
 
-        couponService.useCoupon(couponId, orderId);
-        log.info("쿠폰 사용 완료 - couponId: {}, orderId: {}", couponId, orderId);
+        try {
+            couponService.useCoupon(couponId, orderId);
+            log.info("쿠폰 사용 완료 - couponId: {}, orderId: {}", couponId, orderId);
+        } catch (Exception e) {
+            log.error("쿠폰 사용 실패 - orderId: {}, couponId: {}", orderId, couponId, e);
+            // TODO: 보상 트랜잭션 처리 (재고 복구)
+            throw new BusinessException(OrderErrorCode.COUPON_APPLICATION_FAILED);
+        }
     }
 
     // 결제 실행
-    private void executePayment(Order order, Long userId) {
-        PaymentRes payment = paymentService.createPayment(
-                order.getOrderId(),
-                userId,
-                order.getOrderAmount().getFinalAmount(),
-                "CARD" // TODO: 결제 수단을 Command로 받도록 개선
-        );
+    // TODO: 이벤트 기반 처리
+    private void executePayment(Order order, Long userId, PaymentMethod paymentMethod) {
+        try {
+            PaymentCreateRes payment = paymentService.createPayment(
+                    order.getOrderId(), userId, order.getOrderAmount().getFinalAmount(), paymentMethod
+            );
 
-        order.markAsPaid(payment.getPaymentId());
-        log.info("결제 완료 - paymentId: {}, amount: {}", payment.getPaymentId(), payment.getAmount());
+            order.markAsPaid(payment.getPaymentId());
+            log.info("결제 완료 - paymentId: {}, amount: {}",
+                    payment.getPaymentId(), payment.getAmount());
+        } catch (Exception e) {
+            log.error("결제 실패 - orderId: {}, amount: {}",
+                    order.getOrderId(), order.getOrderAmount().getFinalAmount(), e);
+            // TODO: 보상 트랜잭션 처리 (재고 복구, 쿠폰 복구)
+            throw new BusinessException(OrderErrorCode.PAYMENT_FAILED);
+        }
     }
 
     // ====== Order Cancellation Workflow ======
@@ -238,6 +259,7 @@ public class OrderServiceImpl implements OrderService {
      * - 주문 취소 처리 (도메인)
      * - 보상 트랜잭션 (환불, 재고, 쿠폰)
      */
+    // TODO: Kafka Event 기반 비동기 처리 및 자동 보상 트랜잭션
     @Transactional
     public OrderCancelRes cancelOrder(CancelOrderCommand command) {
         log.info("주문 취소 시작 - orderId: {}, requestedBy: {}",
@@ -245,7 +267,6 @@ public class OrderServiceImpl implements OrderService {
 
         Order order = findOrderWithDetails(command.orderId());
 
-        // 권한 검증
         OrderAuthContext authContext = createAuthContext(order, command.CurrentUserLoginId(), command.CurrentUserRole());
         orderValidator.verifyCancellationPermission(
                 order,
@@ -255,10 +276,9 @@ public class OrderServiceImpl implements OrderService {
                 authContext.productSellerId()
         );
 
-        // 도메인 로직: 취소 처리
         order.cancel(command.cancelReason(), command.CurrentUserLoginId());
 
-        // 보상 트랜잭션
+        // TODO: Kafka Event 발행으로 전환
         processOrderCancellationExternalEvents(order);
 
         orderRepository.save(order);
@@ -267,14 +287,16 @@ public class OrderServiceImpl implements OrderService {
         return OrderCancelRes.from(order);
     }
 
-    // 주문 취소 (보상 트랜잭션 실행)
+    // 주문 취소
     private void processOrderCancellationExternalEvents(Order order) {
+        // TODO: 이벤트 발행으로 대체
         refundPayment(order);
         restoreInventory(order);
         restoreCoupon(order);
     }
 
     // 결제 환불
+    // TODO: 이벤트 기반 처리
     private void refundPayment(Order order) {
         if (order.getPaymentId() == null) {
             log.debug("환불할 결제 정보 없음 - orderId: {}", order.getOrderId());
@@ -288,6 +310,7 @@ public class OrderServiceImpl implements OrderService {
         } catch (Exception e) {
             log.error("결제 환불 실패 - orderId: {}, paymentId: {}",
                     order.getOrderId(), order.getPaymentId(), e);
+            // TODO: 결제 환불 실패 (보상 트랜잭션 처리)
             throw new BusinessException(OrderErrorCode.REFUND_FAILED);
         }
     }
@@ -297,9 +320,11 @@ public class OrderServiceImpl implements OrderService {
      * - 타임딜 주문: 타임딜 재고만 복구
      * - 일반 주문: 상품 재고만 복구
      */
+    // TODO: 이벤트 기반 처리
     private void restoreInventory(Order order) {
         UUID productId = order.getOrderItem().getProductId();
         int quantity = order.getOrderItem().getQuantity();
+        UUID paymentId = order.getPaymentId();
 
         try {
             if (order.isTimeDealOrder()) {
@@ -317,11 +342,13 @@ public class OrderServiceImpl implements OrderService {
         } catch (Exception e) {
             log.error("재고 복구 실패 - orderId: {}, productId: {}, isTimeDeal: {}",
                     order.getOrderId(), productId, order.isTimeDealOrder(), e);
-            // TODO: 재고 복구 실패 처리
+            // TODO: 재고 복구 실패 (보상 트랜젝션 처리)
+            throw new BusinessException(OrderErrorCode.INVENTORY_RESTORE_FAILED);
         }
     }
 
-     // 쿠폰 복구
+    // 쿠폰 복구
+    // TODO: 이벤트 기반 처리
     private void restoreCoupon(Order order) {
         if (order.getCouponId() == null) {
             return;
@@ -334,7 +361,8 @@ public class OrderServiceImpl implements OrderService {
         } catch (Exception e) {
             log.error("쿠폰 복구 실패 - orderId: {}, couponId: {}",
                     order.getOrderId(), order.getCouponId(), e);
-            // TODO: 쿠폰 복구 실패 정책 적용 (자동 재발급)
+            // TODO: 쿠폰 복구 실패 (보상 트랜젝션 처리)
+            throw new BusinessException(OrderErrorCode.COUPON_RESTORE_FAILED);
         }
     }
 
@@ -491,7 +519,9 @@ public class OrderServiceImpl implements OrderService {
             ProductRes product,
             Optional<TimeDealRes> timeDeal,
             Optional<CouponRes> coupon,
-            int quantity
+            int quantity,
+
+            PaymentMethod paymentMethod
     ) {}
 
     // 권한 검증 컨텍스트

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -384,7 +384,7 @@ public class OrderServiceImpl implements OrderService {
 
         Long userId = resolveCustomerId(loginId);
 
-        OrderStatus orderStatus = parseOrderStatus(request.getStatus());
+        OrderStatus orderStatus = OrderStatus.from(request.getStatus());
         LocalDateTime startDateTime = toStartDateTimeOrMin(request.getStartDate());
         LocalDateTime endDateTime = toEndDateTimeOrMax(request.getEndDate());
         Page<Order> orderPage = findCustomerOrdersWithFilters(
@@ -444,17 +444,6 @@ public class OrderServiceImpl implements OrderService {
     public Order findOrderWithDetails(UUID orderId) {
         return orderRepository.findOrderByIdWithItemAndDelivery(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
-    }
-
-    private OrderStatus parseOrderStatus(String status) {
-        if (status == null || status.isBlank()) {
-            return null;
-        }
-        try {
-            return OrderStatus.valueOf(status.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            return null; // 잘못된 값이면 필터 미적용
-        }
     }
 
     private LocalDateTime toStartDateTimeOrMin(LocalDate date) {

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
@@ -221,4 +221,14 @@ public enum OrderStatus {
             );
         }
     }
+    public static OrderStatus from(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+        try {
+            return OrderStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null; // 잘못된 값이면 필터 미적용
+        }
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
@@ -1,9 +1,17 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
-import com.palja.order_service.application.dto.response.PaymentRes;
+import com.palja.common.exception.BusinessException;
+import com.palja.order_service.application.dto.PaymentMethod;
+import com.palja.order_service.application.dto.response.PaymentCancelRes;
+import com.palja.order_service.application.dto.response.PaymentCreateRes;
+import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.PaymentService;
+import com.palja.order_service.infrastructure.external.PaymentClient;
+import com.palja.order_service.infrastructure.external.dto.request.CancelPaymentDTO;
+import com.palja.order_service.infrastructure.external.dto.request.CreatePaymentDTO;
 import com.palja.order_service.infrastructure.external.dto.response.PaymentCancelDTO;
 import com.palja.order_service.infrastructure.external.dto.response.PaymentCreateDTO;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -16,30 +24,47 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class PaymentAdapter implements PaymentService {
 
-    // TODO: 결제 서비스 연동 시 PaymentClient 주입 및 구현 추가
-    //private final PaymentClient paymentClient;
+    private final PaymentClient paymentClient;
 
     @Override
-    public PaymentRes createPayment(UUID orderId, Long userId, BigDecimal amount, String paymentMethod) {
+    public PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, PaymentMethod paymentMethod) {
         log.debug("결제 생성 요청: orderId={}, userId={}, amount={}, paymentMethod={}",
                 orderId, userId, amount, paymentMethod);
-
-        // TODO: payment-service 연동 시 FeignClient 호출 사용
-        // CreatePaymentDTO request = new CreatePaymentDTO(orderId, userId, amount, paymentMethod);
-        // PaymentCreateDTO response = paymentClient.createPayment(request).data();
-        // TODO: 실제 결제 서비스 연동 시 위의 코드로 교체
-        // 임시 더미 데이터
-        PaymentCreateDTO dummy = PaymentCreateDTO.dummy(orderId, userId, amount);
-
-        return PaymentRes.of(dummy.getPaymentId(), dummy.getAmount());
+        try {
+            CreatePaymentDTO request = new CreatePaymentDTO(orderId, userId, amount, paymentMethod);
+            PaymentCreateDTO response = paymentClient.createPayment(request).data();
+            log.info("결제 생성 성공: paymentId={}", response.getPaymentId());
+            //return response.toResponse();
+            // TODO: 실제 결제 서비스 연동 시 위의 코드로 교체
+            return response.toResponseByDummy();
+        } catch (FeignException e) {
+            log.error("결제 API 호출 실패: orderId={}, status={}, message={}",
+                    orderId, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.PAYMENT_SERVICE_ERROR);
+        } catch (Exception e) {
+            log.error("결제 생성 중 예상치 못한 오류: orderId={}, error={}",
+                    orderId, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.PAYMENT_FAILED);
+        }
     }
 
-    public void cancelPayment(UUID orderId, UUID paymentId) {
-        log.info("결제 취소 요청 시작: paymentId={}", paymentId);
-        // TODO: payment-service 연동 시 FeignClient 호출 사용
-        //CancelPaymentDTO request = new CancelPaymentDTO("주문 취소");
-        //PaymentCancelDTO response = paymentClient.cancelPayment(paymentId, request).data();
-        // TODO: 실제 결제 서비스 연동 시 위의 코드로 교체
-        PaymentCancelDTO dummy = PaymentCancelDTO.dummy(orderId, paymentId);
+    public PaymentCancelRes cancelPayment(UUID orderId, UUID paymentId) {
+        log.info("결제 취소 요청 시작: orderId={}, paymentId={}", orderId, paymentId);
+        try {
+            CancelPaymentDTO request = new CancelPaymentDTO("주문 취소");
+            PaymentCancelDTO response = paymentClient.cancelPayment(paymentId, request).data();
+            log.info("결제 생성 성공: paymentId={}", response.getPaymentId());
+            //return response.toResponse();
+            // TODO: 실제 결제 서비스 연동 시 위의 코드로 교체
+            return response.toResponseDummy(paymentId);
+        } catch (FeignException e) {
+            log.error("결제 취소 API 호출 실패: paymentId={}, status={}, message={}",
+                    paymentId, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.PAYMENT_SERVICE_ERROR);
+        } catch (Exception e) {
+            log.error("결제 취소 중 예상치 못한 오류: paymentId={}, error={}",
+                    paymentId, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.PAYMENT_FAILED);
+        }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CreatePaymentDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CreatePaymentDTO.java
@@ -1,5 +1,6 @@
 package com.palja.order_service.infrastructure.external.dto.request;
 
+import com.palja.order_service.application.dto.PaymentMethod;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,17 +16,5 @@ public class CreatePaymentDTO {
     private UUID orderId;
     private Long userId;
     private BigDecimal amount;
-    private String paymentMethod; // CARD 등
-
-    /**
-     * TODO: 결제 서비스 연동 전까지 사용하는 더미 데이터. payment-service 연동 후 삭제.
-     */
-    public static CreatePaymentDTO dummy(UUID orderId, Long userId, BigDecimal amount) {
-        return new CreatePaymentDTO(
-                orderId,
-                userId,
-                amount,
-                "CARD"
-        );
-    }
+    private PaymentMethod paymentMethod;
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentCancelDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentCancelDTO.java
@@ -1,5 +1,6 @@
 package com.palja.order_service.infrastructure.external.dto.response;
 
+import com.palja.order_service.application.dto.response.PaymentCancelRes;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,18 +24,18 @@ public class PaymentCancelDTO {
     private String status;
     private LocalDateTime completedAt;
 
-    // TODO: 결제 서비스 연동 전까지 사용하는 더미 데이터. payment-service 연동 후 삭제.
-    public static PaymentCancelDTO dummy(UUID orderId, UUID paymentId) {
-        return new PaymentCancelDTO(
-                paymentId,
-                orderId,
-                1L,
-                BigDecimal.valueOf(12000),
-                "CARD",
-                "KRW",
-                "tossKey-abc123",
-                "CANCELED",
-                LocalDateTime.now()
-        );
+    public PaymentCancelRes toResponse() {
+        return PaymentCancelRes.builder()
+                .paymentId(paymentId)
+                .amount(amount)
+                .build();
+    }
+
+    // TODO: 결제 서비스 연동 완료 전까지 사용하는 더미 데이터 (TOSS_SECRET_KEY 받으면 제거)
+    public PaymentCancelRes toResponseDummy(UUID paymentId) {
+        return PaymentCancelRes.builder()
+                .paymentId(paymentId)
+                .amount(BigDecimal.valueOf(30000))
+                .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentCreateDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentCreateDTO.java
@@ -1,5 +1,6 @@
 package com.palja.order_service.infrastructure.external.dto.response;
 
+import com.palja.order_service.application.dto.response.PaymentCreateRes;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,19 +25,18 @@ public class PaymentCreateDTO {
     private LocalDateTime requestedAt;
     private LocalDateTime completedAt;
 
-    // TODO: 결제 서비스 연동 전까지 사용하는 더미 데이터. payment-service 연동 후 삭제.
-    public static PaymentCreateDTO dummy(UUID orderId, Long userId, BigDecimal amount) {
-        return new PaymentCreateDTO(
-                UUID.randomUUID(),
-                orderId,
-                userId,
-                amount,
-                "CARD",
-                "KRW",
-                "dummy-payment-key-" + UUID.randomUUID(),
-                "APPROVED",
-                LocalDateTime.now(),
-                LocalDateTime.now()
-        );
+    public PaymentCreateRes toResponse() {
+        return PaymentCreateRes.builder()
+                .paymentId(paymentId)
+                .amount(amount)
+                .build();
+    }
+
+    // TODO: 결제 서비스 연동 완료 전까지 사용하는 더미 데이터 (TOSS_SECRET_KEY 받으면 제거)
+    public PaymentCreateRes toResponseByDummy() {
+        return PaymentCreateRes.builder()
+                .paymentId(UUID.fromString("10000000-0000-0000-1000-000000000000"))
+                .amount(BigDecimal.valueOf(30000))
+                .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
@@ -27,6 +27,9 @@ public class CreateOrderReq {
 
     private UUID couponId;
 
+    @NotNull(message = "결제 수단은 필수입니다.")
+    private String paymentMethod;
+
     @NotNull(message = "배송 정보는 필수입니다.")
     @Valid
     private DeliveryReq delivery;
@@ -39,6 +42,7 @@ public class CreateOrderReq {
                 .quantity(quantity)
                 .timeDealId(timeDealId)
                 .couponId(couponId)
+                .paymentMethod(paymentMethod)
                 .delivery(delivery.toCommand())
                 .build();
     }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #140 

<br>

## 📌 개요
결제 서비스 연동을 Feign 클라이언트 기반으로 구현했습니다.

<br>

## 🔁 변경 사항
- 결제 서비스 API 호출을 위한 Feign 클라이언트 연동
- 결제 요청에 필요한 paymentMethod 입력값 추가
- PaymentMethod enum 도입 및 문자열 파싱 로직 적용
- Payment DTO 내 불필요한 정적 메서드 제거
- 결제 취소/환불 응답 변환 로직 개선
- 주문 생성/취소/결제 흐름의 비즈니스 예외 처리 강화

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
- Toss AccessKey 적용 후 기존 dummy 값은 제거할 예정입니다.
 
<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.