### PR TITLE
FEAT/타임딜 목록 조회 API 구현

### DIFF
--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
@@ -1,13 +1,16 @@
 package com.palja.timedeal_service.application.service;
 
+import com.palja.common.response.PageResponse;
 import com.palja.timedeal_service.application.command.*;
 import com.palja.timedeal_service.application.dto.TimeDealDetailRes;
+import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
 
 public interface TimeDealService {
     TimeDealDetailRes createTimeDeal(CreateTimeDealCommand command);
     TimeDealDetailRes getTimeDeal(UUID timeDealId);
+    PageResponse<TimeDealDetailRes> getTimeDeals(Pageable pageable);
     TimeDealDetailRes updateTimeDeal(UpdateTimeDealCommand command);
     TimeDealDetailRes changeTimeDealStatus(ChangeTimeDealStatusCommand command);
     void decreaseRemainingQuantity(DecreaseRemainingQuantityCommand command);

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -2,6 +2,7 @@ package com.palja.timedeal_service.application.service.impl;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
+import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.timedeal_service.application.command.*;
 import com.palja.timedeal_service.application.dto.TimeDealDetailRes;
@@ -19,6 +20,8 @@ import com.palja.timedeal_service.domain.vo.Quantity;
 import com.palja.timedeal_service.domain.vo.TimeDealStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,6 +77,15 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         log.info("타임딜 상세조회 완료");
         return TimeDealDetailRes.from(timeDeal);
+    }
+
+    @Override
+    public PageResponse<TimeDealDetailRes> getTimeDeals(Pageable pageable) {
+        Page<TimeDeal> timeDeals = timeDealRepository.searchTimeDeals(pageable);
+
+        Page<TimeDealDetailRes> timeDealDto = timeDeals.map(TimeDealDetailRes::from);
+
+        return PageResponse.from(timeDealDto);
     }
 
     @Override

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/repository/TimeDealRepository.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/repository/TimeDealRepository.java
@@ -1,6 +1,8 @@
 package com.palja.timedeal_service.domain.repository;
 
 import com.palja.timedeal_service.domain.entity.TimeDeal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -8,4 +10,5 @@ import java.util.UUID;
 public interface TimeDealRepository {
     TimeDeal save(TimeDeal timeDeal);
     Optional<TimeDeal> findDetailByTimeDealId(UUID timeDealId);
+    Page<TimeDeal> searchTimeDeals(Pageable pageable);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/JpaTimeDealRepository.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/JpaTimeDealRepository.java
@@ -1,6 +1,8 @@
 package com.palja.timedeal_service.infrastructure.repository;
 
 import com.palja.timedeal_service.domain.entity.TimeDeal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -18,4 +20,12 @@ public interface JpaTimeDealRepository extends JpaRepository<TimeDeal, UUID> {
           and td.deletedAt is null
     """)
     Optional<TimeDeal> findDetailByTimeDealId(UUID timeDealId);
+
+    @Query("""
+        select td
+        from TimeDeal td
+        join fetch td.timeDealStock ts
+        where td.deletedAt is null
+    """)
+    Page<TimeDeal> searchTimeDeals(Pageable pageable);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/adapter/TimeDealRepositoryAdapter.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/adapter/TimeDealRepositoryAdapter.java
@@ -4,6 +4,8 @@ import com.palja.timedeal_service.domain.entity.TimeDeal;
 import com.palja.timedeal_service.domain.repository.TimeDealRepository;
 import com.palja.timedeal_service.infrastructure.repository.JpaTimeDealRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -21,5 +23,10 @@ public class TimeDealRepositoryAdapter implements TimeDealRepository {
     @Override
     public Optional<TimeDeal> findDetailByTimeDealId(UUID timeDealId) {
         return jpaTimeDealRepository.findDetailByTimeDealId(timeDealId);
+    }
+
+    @Override
+    public Page<TimeDeal> searchTimeDeals(Pageable pageable) {
+        return jpaTimeDealRepository.searchTimeDeals(pageable);
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
@@ -1,8 +1,10 @@
 package com.palja.timedeal_service.presentation.controller;
 
+import brave.Response;
 import com.palja.common.annotation.RequiredRole;
 import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.timedeal_service.application.command.*;
 import com.palja.timedeal_service.application.dto.TimeDealDetailRes;
@@ -11,6 +13,11 @@ import com.palja.timedeal_service.presentation.dto.request.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.shaded.com.google.protobuf.Api;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -38,7 +45,7 @@ public class TimeDealController {
 
         TimeDealDetailRes res = timeDealService.createTimeDeal(command);
 
-        log.info("타임딜 생성 성공: timeDealId = {}", res.getTimeDealId());
+        log.info("타임딜 생성 완료: timeDealId = {}", res.getTimeDealId());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(res, "타임딜이 생성되었습니다."));
     }
 
@@ -48,8 +55,20 @@ public class TimeDealController {
 
         TimeDealDetailRes res = timeDealService.getTimeDeal(timeDealId);
 
-        log.info("타임딜 상세 조회 성공 timeDealId = {}", res.getTimeDealId());
-        return ResponseEntity.ok(ApiResponse.success(res, "타임딜 상세조회에 성공했습니다."));
+        log.info("타임딜 상세 조회 완료 timeDealId = {}", res.getTimeDealId());
+        return ResponseEntity.ok(ApiResponse.success(res, "타임딜 상세 조회에 성공했습니다."));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<TimeDealDetailRes>>> getTimeDeals(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        log.info("GET api/v1/time-deals 타임딜 목록 조회 요청");
+
+        PageResponse<TimeDealDetailRes> res = timeDealService.getTimeDeals(pageable);
+
+        log.info("타임딜 목록 조회 완료");
+        return ResponseEntity.ok(ApiResponse.success(res, "타임딜 목록 조회에 성공했습니다."));
     }
 
     @PutMapping("/{timeDealId}")
@@ -64,7 +83,7 @@ public class TimeDealController {
 
         TimeDealDetailRes res = timeDealService.updateTimeDeal(command);
 
-        log.info("타임딜 수정 성공: timeDealId = {}", res.getTimeDealId());
+        log.info("타임딜 수정 완료: timeDealId = {}", res.getTimeDealId());
         return ResponseEntity.ok(ApiResponse.success(res, "타임딜 수정에 성공했습니다."));
     }
 
@@ -80,7 +99,7 @@ public class TimeDealController {
 
         TimeDealDetailRes res = timeDealService.changeTimeDealStatus(command);
 
-        log.info("타임딜 상태 변경 성공: timeDealId = {}", res.getTimeDealId());
+        log.info("타임딜 상태 변경 완료: timeDealId = {}", res.getTimeDealId());
         return ResponseEntity.ok(ApiResponse.success(res, "타임딜 상태 변경에 성공했습니다."));
     }
 
@@ -95,7 +114,7 @@ public class TimeDealController {
 
         timeDealService.decreaseRemainingQuantity(command);
 
-        log.info("타임딜 남은 재고 차감 성공");
+        log.info("타임딜 남은 재고 차감 완료");
         return ResponseEntity.noContent().build();
     }
 
@@ -110,7 +129,7 @@ public class TimeDealController {
 
         timeDealService.restoreRemainingQuantity(command);
 
-        log.info("타임딜 남은 재고 복구 성공");
+        log.info("타임딜 남은 재고 복구 완료");
         return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #156 

<br>

## 📌 개요
- 타임딜 목록 조회 API 구현

<br>

## 🔁 변경 사항
- Pageable 기반으로 페이징 처리하여 타임딜 목록 조회 API를 구현하였습니다.
  - 목록 조회 시 발생할 수 있는 N+1 문제를 방지하기 위해 TimeDealStock을 fetch join 하여 조회하도록 구현
  - 삭제되지 않은 타임딜만 조회하도록 처리
  - PageResponse 응답 구조 통일


<br>

## 📸 스크린샷

<details>
  <summary>타임딜 목록 조회 성공</summary>
<img width="748" height="975" alt="image" src="https://github.com/user-attachments/assets/e9b90212-9cc2-4eee-b28b-505f12b33c49" />
</details>

<br>

## 👀 기타 더 이야기해볼 점
- 추후 추후 QueryDSL로 변경 예정입니다.

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
