### PR TITLE
FEAT/OrderService 사용자 서비스 API 연동 (사용자 검증) 

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -37,7 +37,7 @@ ext {
 }
 
 dependencies {
-	implementation 'com.palja:common-module:0.8.0'
+	implementation 'com.palja:common-module:0.8.4'
 	// QueryDSL (jakarta 버전)
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/CompanyUserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/CompanyUserRes.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import java.util.UUID;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CompanyUserRes {
 
@@ -20,24 +20,4 @@ public class CompanyUserRes {
     private final String email;
     private final UserRole role;
     private final String status;
-
-    public static CompanyUserRes of(
-            Long userId,
-            UUID companyUserId,
-            String loginId,
-            String companyName,
-            String email,
-            UserRole role,
-            String status
-    ) {
-        return CompanyUserRes.builder()
-                .userId(userId)
-                .companyUserId(companyUserId)
-                .loginId(loginId)
-                .companyName(companyName)
-                .email(email)
-                .role(role)
-                .status(status)
-                .build();
-    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/CustomerUserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/CustomerUserRes.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CustomerUserRes {
 
@@ -17,22 +17,4 @@ public class CustomerUserRes {
     private final String email;
     private final UserRole role;
     private final String status;
-
-    public static CustomerUserRes of(
-            Long userId,
-            String loginId,
-            String name,
-            String email,
-            UserRole role,
-            String status
-    ) {
-        return CustomerUserRes.builder()
-                .userId(userId)
-                .loginId(loginId)
-                .name(name)
-                .email(email)
-                .role(role)
-                .status(status)
-                .build();
-    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/ManagerUserRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/ManagerUserRes.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ManagerUserRes {
 
@@ -17,22 +17,4 @@ public class ManagerUserRes {
     private final String email;
     private final UserRole role;
     private final String status;
-
-    public static ManagerUserRes of(
-            Long userId,
-            String loginId,
-            String name,
-            String email,
-            UserRole role,
-            String status
-    ) {
-        return ManagerUserRes.builder()
-                .userId(userId)
-                .loginId(loginId)
-                .name(name)
-                .email(email)
-                .role(role)
-                .status(status)
-                .build();
-    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/UserService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/UserService.java
@@ -7,11 +7,11 @@ import com.palja.order_service.application.dto.response.ManagerUserRes;
 public interface UserService {
 
     // 고객 사용자 조회
-    CustomerUserRes getCustomerUserByLoginId(String loginId);
-
-    // 매니저 사용자 조회
-    ManagerUserRes getManagerUserByLoginId(String loginId);
+    CustomerUserRes getMyCustomer(String loginId);
 
     // 판매업체 사용자 조회
-    CompanyUserRes getCompanyUserByLoginId(String loginId);
+    CompanyUserRes getMyCompanyUser(String loginId);
+
+    // 매니저 사용자 조회
+    ManagerUserRes getMyManager(String loginId);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -86,7 +86,7 @@ public class OrderServiceImpl implements OrderService {
 
     // 주문 생성에 필요한 데이터 수집 및 검증
     private OrderCreationContext collectAndValidateOrderData(CreateOrderCommand command) {
-        CustomerUserRes customer = userService.getCustomerUserByLoginId(command.loginId());
+        CustomerUserRes customer = userService.getMyCustomer(command.loginId());
         orderValidator.validateCustomerForOrder(customer);
         log.debug("고객 검증 완료 - userId: {}", customer.getUserId());
 
@@ -491,11 +491,11 @@ public class OrderServiceImpl implements OrderService {
 
     // ===== Private: Utility =====
     private Long resolveCustomerId(String loginId) {
-        return userService.getCustomerUserByLoginId(loginId).getUserId();
+        return userService.getMyCustomer(loginId).getUserId();
     }
 
     private UUID resolveCompanyUserId(String loginId) {
-        return userService.getCompanyUserByLoginId(loginId).getCompanyUserId();
+        return userService.getMyCompanyUser(loginId).getCompanyUserId();
     }
 
     private UUID resolveProductSellerId(UUID productId) {

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
@@ -428,6 +428,6 @@ public class OrderValidator {
 
     // 관리자 권한 검증 (유효한 관리자)
     public void validateManager(String loginId) {
-        userService.getManagerUserByLoginId(loginId);
+        userService.getMyManager(loginId);
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/UserClient.java
@@ -11,15 +11,16 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name = "user-service", path = "/api/v1")
 public interface UserClient {
 
-    // customer 사용자 정보 조회
-    @GetMapping("/customers/{loginId}")
-    ApiResponse<CustomerUserDTO> getCustomerUserByLoginId(@PathVariable("loginId") String loginId);
+    // customer: 회원 단건 조회 (본인)
+    @GetMapping("/customers/me")
+    ApiResponse<CustomerUserDTO> getMyCustomer();
 
-    // manager 사용자 정보 조회
-    @GetMapping("/managers/{loginId}")
-    ApiResponse<ManagerUserDTO> getManagerUserByLoginId(@PathVariable("loginId") String loginId);
+    // company-user: 회원 단건 조회 (본인)
+    @GetMapping("/company-users/me")
+    ApiResponse<CompanyUserDTO> getMyCompanyUser();
 
-    // company-user 사용자 정보 조회
-    @GetMapping("/company-users/{loginId}")
-    ApiResponse<CompanyUserDTO> getCompanyUserByLoginId(@PathVariable("loginId") String loginId);
+    // manager: 회원 단건 조회 (본인)
+    @GetMapping("/managers/me")
+    ApiResponse<ManagerUserDTO> getMyManager();
+
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -1,12 +1,16 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
+import com.palja.common.exception.BusinessException;
 import com.palja.order_service.application.dto.response.CompanyUserRes;
 import com.palja.order_service.application.dto.response.CustomerUserRes;
 import com.palja.order_service.application.dto.response.ManagerUserRes;
+import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.UserService;
+import com.palja.order_service.infrastructure.external.UserClient;
 import com.palja.order_service.infrastructure.external.dto.response.CompanyUserDTO;
 import com.palja.order_service.infrastructure.external.dto.response.CustomerUserDTO;
 import com.palja.order_service.infrastructure.external.dto.response.ManagerUserDTO;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -16,67 +20,59 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UserAdapter implements UserService {
 
-    // TODO: 유저 서비스 연동 시 userClient 주입 및 구현 추가
-    //private final UserClient userClient;
+    private final UserClient userClient;
 
     @Override
-    public CustomerUserRes getCustomerUserByLoginId(String loginId) {
+    public CustomerUserRes getMyCustomer(String loginId) {
         log.debug("고객 사용자 조회 요청: loginId={}", loginId);
-
-        // TODO: user-service 연동 시 FeignClient 호출
-        // CustomerUserDTO dto = userClient.getCustomerUserByLoginId(loginId).getData();
-        // TODO: 실제 유저 서비스 연동 시 위의 코드로 교체
-        // 임시 더미 데이터
-        CustomerUserDTO response = CustomerUserDTO.dummy(loginId);
-
-        return CustomerUserRes.of(
-                response.getUserId(),
-                response.getLoginId(),
-                response.getName(),
-                response.getEmail(),
-                response.getRole(),
-                response.getStatus()
-        );
+        try {
+            CustomerUserDTO dto = userClient.getMyCustomer().data();
+            log.info("고객 사용자 조회 성공: userId={}", dto.getUserId());
+            return dto.toResponse();
+        } catch (FeignException e) {
+            log.error("사용자 API 호출 실패: loginId={}, status={}, message={}",
+                    loginId, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.USER_SERVICE_ERROR);
+        } catch (Exception e) {
+            log.error("고객 사용자 조회 중 예상치 못한 오류: loginId={}, error={}",
+                    loginId, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
+        }
     }
 
     @Override
-    public ManagerUserRes getManagerUserByLoginId(String loginId) {
-        log.debug("MANAGER 사용자 조회 요청: loginId={}", loginId);
-
-        // TODO: user-service 연동 시 FeignClient 호출
-        // ManagerUserDTO dto = userClient.getManagerUserByLoginId(loginId).getData();
-        // TODO: 실제 유저 서비스 연동 시 위의 코드로 교체
-        // 임시 더미 데이터
-        ManagerUserDTO dto = ManagerUserDTO.dummy(loginId);
-
-        return ManagerUserRes.of(
-                dto.getUserId(),
-                dto.getLoginId(),
-                dto.getName(),
-                dto.getEmail(),
-                dto.getRole(),
-                dto.getStatus()
-        );
-    }
-
-    @Override
-    public CompanyUserRes getCompanyUserByLoginId(String loginId) {
+    public CompanyUserRes getMyCompanyUser(String loginId) {
         log.debug("판매업체 사용자 조회 요청: loginId={}", loginId);
+        try {
+            CompanyUserDTO dto = userClient.getMyCompanyUser().data();
+            log.info("판매업체 사용자 조회 성공: companyUserId={}", dto.getCompanyUserId());
+            return dto.toResponse();
+        } catch (FeignException e) {
+            log.error("사용자 API 호출 실패: loginId={}, status={}, message={}",
+                    loginId, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.USER_SERVICE_ERROR);
+        } catch (Exception e) {
+            log.error("판매업체 사용자 조회 중 예상치 못한 오류: loginId={}, error={}",
+                    loginId, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
+        }
+    }
 
-        // TODO: user-service 연동 시 FeignClient 호출
-        // CompanyUserDTO dto = userClient.getCompanyUserByLoginId(loginId).getData();
-        // TODO: 실제 유저 서비스 연동 시 위의 코드로 교체
-        // 임시 더미 데이터
-        CompanyUserDTO dto = CompanyUserDTO.dummy(loginId);
-
-        return CompanyUserRes.of(
-                dto.getUserId(),
-                dto.getCompanyUserId(),
-                dto.getLoginId(),
-                dto.getCompanyName(),
-                dto.getEmail(),
-                dto.getRole(),
-                dto.getStatus()
-        );
+    @Override
+    public ManagerUserRes getMyManager(String loginId) {
+        log.debug("MANAGER 사용자 조회 요청: loginId={}", loginId);
+        try {
+            ManagerUserDTO dto = userClient.getMyManager().data();
+            log.info("MANAGER 사용자 조회 성공: userId={}", dto.getUserId());
+            return dto.toResponse();
+        } catch (FeignException e) {
+            log.error("사용자 API 호출 실패: loginId={}, status={}, message={}",
+                    loginId, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.USER_SERVICE_ERROR);
+        } catch (Exception e) {
+            log.error("MANAGER 사용자 조회 중 예상치 못한 오류: loginId={}, error={}",
+                    loginId, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
+        }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CompanyUserDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CompanyUserDTO.java
@@ -1,8 +1,8 @@
 package com.palja.order_service.infrastructure.external.dto.response;
 
 import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.dto.response.CompanyUserRes;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,23 +29,15 @@ public class CompanyUserDTO {
     private LocalDateTime updatedAt;
     private String updatedBy;
 
-    // TODO: 사용자 서비스 연동 전까지 사용하는 더미 데이터. user-service 연결 후 삭제.
-    public static CompanyUserDTO dummy(String loginId) {
-        return new CompanyUserDTO(
-                100L,
-                UUID.fromString("11111111-1111-1111-1111-111111111111"),
-                loginId,
-                "company",
-                "업체",
-                "123-45-67890",
-                "company@gmail.com",
-                "서울시 강남구 테헤란로 123",
-                UserRole.COMPANY_USER,
-                "PENDING",
-                LocalDateTime.now(),
-                loginId,
-                LocalDateTime.now(),
-                loginId
-        );
+    public CompanyUserRes toResponse() {
+        return CompanyUserRes.builder()
+                .userId(userId)
+                .companyUserId(companyUserId)
+                .loginId(loginId)
+                .companyName(companyName)
+                .email(email)
+                .role(role)
+                .status(status)
+                .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CustomerUserDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/CustomerUserDTO.java
@@ -1,6 +1,7 @@
 package com.palja.order_service.infrastructure.external.dto.response;
 
 import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.dto.response.CustomerUserRes;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,20 +25,14 @@ public class CustomerUserDTO {
     private LocalDateTime updatedAt;
     private String updatedBy;
 
-    // TODO: 사용자 서비스 연동 전까지 사용하는 더미 데이터. user-service 연결 후 삭제.
-    public static CustomerUserDTO dummy(String loginId) {
-        return new CustomerUserDTO(
-                1L,
-                loginId,
-                loginId,
-                loginId + "@example.com",
-                "서울시 강남구 테헤란로 123",
-                UserRole.CUSTOMER,
-                "ACTIVE",
-                LocalDateTime.now(),
-                loginId,
-                LocalDateTime.now(),
-                loginId
-        );
+    public CustomerUserRes toResponse() {
+        return CustomerUserRes.builder()
+                .userId(userId)
+                .loginId(loginId)
+                .name(name)
+                .email(email)
+                .role(role)
+                .status(status)
+                .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ManagerUserDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ManagerUserDTO.java
@@ -1,6 +1,7 @@
 package com.palja.order_service.infrastructure.external.dto.response;
 
 import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.dto.response.ManagerUserRes;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ public class ManagerUserDTO {
     private String loginId;
     private String name;
     private String email;
+    private String address;
     private UserRole role;   // MASTER, MANAGER, CUSTOMER, COMPANY_USER
     private String status;   // PENDING, ACTIVE
     private LocalDateTime createdAt;
@@ -23,19 +25,14 @@ public class ManagerUserDTO {
     private LocalDateTime updatedAt;
     private String updatedBy;
 
-    // TODO: 사용자 서비스 연동 전까지 사용하는 더미 데이터. user-service 연결 후 삭제.
-    public static ManagerUserDTO dummy(String loginId) {
-        return new ManagerUserDTO(
-                1L,
-                loginId,
-                loginId,
-                loginId + "@example.com",
-                UserRole.MANAGER,
-                "ACTIVE",
-                LocalDateTime.now(),
-                loginId,
-                LocalDateTime.now(),
-                loginId
-        );
+    public ManagerUserRes toResponse() {
+        return ManagerUserRes.builder()
+                .userId(userId)
+                .loginId(loginId)
+                .name(name)
+                .email(email)
+                .role(role)
+                .status(status)
+                .build();
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #141 

<br>

## 📌 개요
사용자 서비스 연동을 Feign 클라이언트 기반으로 구현했습니다.

<br>

## 🔁 변경 사항
- 사용자 서비스 연동용 UserClient 추가 (Feign)
- 고객/관리자/업체판매자 조회 API 연동
- 주문 생성/취소/조회/상태 변경 시 사용자 검증 로직을 외부 API 기반으로 변경
- 기존 dummy 데이터 및 내부 임시 검증 로직 제거

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
