### PR TITLE
FEAT/OrderService 결제 서비스 API 연동

### DIFF
--- a/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
@@ -13,6 +13,7 @@ public record CreateOrderCommand(
         int quantity,
         UUID timeDealId,
         UUID couponId,
+        String paymentKey,
         String paymentMethod,
         DeliveryCommand delivery
 ) {

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -82,6 +82,7 @@ public enum OrderErrorCode implements ErrorCode {
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "결제 시간이 초과되었습니다."),
     INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 수단입니다."),
+    INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 키입니다."),
 
     // ===== 권한 관련 =====
     USER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "접근 권한이 없는 사용자입니다."),

--- a/order-service/src/main/java/com/palja/order_service/application/service/PaymentService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/PaymentService.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public interface PaymentService {
 
-    PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, PaymentMethod paymentMethod);
+    PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, String paymentKey, PaymentMethod paymentMethod);
 
-    PaymentCancelRes cancelPayment(UUID orderId, UUID paymentId);
+    PaymentCancelRes cancelPayment(UUID orderId, UUID paymentId, BigDecimal cancelAmount, String cancelReason);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -103,7 +103,7 @@ public class OrderServiceImpl implements OrderService {
             log.debug("타임딜 검증 완료 - timeDealId: {}", command.timeDealId());
         }
 
-        // 4. 쿠폰 조회 및 검증 (선택적)
+        // 쿠폰 조회 및 검증 (선택적)
         Optional<CouponRes> coupon = Optional.empty();
         if (command.couponId() != null) {
             CouponRes c = couponService.getCoupon(command.couponId());
@@ -111,6 +111,12 @@ public class OrderServiceImpl implements OrderService {
             coupon = Optional.of(c);
             log.debug("쿠폰 검증 완료 - couponId: {}", command.couponId());
         }
+
+        // paymentKey 검증
+        if (command.paymentKey() == null || command.paymentKey().isBlank()) {
+            throw new BusinessException(OrderErrorCode.INVALID_PAYMENT_KEY);
+        }
+        log.debug("결제 키 검증 완료 - paymentKey: {}", command.paymentKey());
 
         PaymentMethod paymentMethod = PaymentMethod.from(command.paymentMethod());
         log.debug("결제 수단 검증 완료 - paymentMethod: {}", paymentMethod);
@@ -121,6 +127,7 @@ public class OrderServiceImpl implements OrderService {
                 timeDeal,
                 coupon,
                 command.quantity(),
+                command.paymentKey(),
                 paymentMethod
         );
     }
@@ -184,7 +191,7 @@ public class OrderServiceImpl implements OrderService {
         // TODO: 이벤트 발행으로 대체
         reserveInventory(order, context.timeDeal());
         applyCoupon(order.getCouponId(), order.getOrderId());
-        executePayment(order, context.customer().getUserId(), context.paymentMethod());
+        executePayment(order, context.customer().getUserId(), context.paymentKey(), context.paymentMethod());
     }
 
     /**
@@ -234,10 +241,10 @@ public class OrderServiceImpl implements OrderService {
 
     // 결제 실행
     // TODO: 이벤트 기반 처리
-    private void executePayment(Order order, Long userId, PaymentMethod paymentMethod) {
+    private void executePayment(Order order, Long userId, String paymentKey, PaymentMethod paymentMethod) {
         try {
             PaymentCreateRes payment = paymentService.createPayment(
-                    order.getOrderId(), userId, order.getOrderAmount().getFinalAmount(), paymentMethod
+                    order.getOrderId(), userId, order.getOrderAmount().getFinalAmount(), paymentKey, paymentMethod
             );
 
             order.markAsPaid(payment.getPaymentId());
@@ -279,7 +286,7 @@ public class OrderServiceImpl implements OrderService {
         order.cancel(command.cancelReason(), command.CurrentUserLoginId());
 
         // TODO: Kafka Event 발행으로 전환
-        processOrderCancellationExternalEvents(order);
+        processOrderCancellationExternalEvents(order, command.cancelReason());
 
         orderRepository.save(order);
         log.info("주문 취소 완료 - orderId: {}", command.orderId());
@@ -288,23 +295,23 @@ public class OrderServiceImpl implements OrderService {
     }
 
     // 주문 취소
-    private void processOrderCancellationExternalEvents(Order order) {
+    private void processOrderCancellationExternalEvents(Order order, String cancelReason) {
         // TODO: 이벤트 발행으로 대체
-        refundPayment(order);
+        refundPayment(order, cancelReason);
         restoreInventory(order);
         restoreCoupon(order);
     }
 
     // 결제 환불
     // TODO: 이벤트 기반 처리
-    private void refundPayment(Order order) {
+    private void refundPayment(Order order, String cancelReason) {
         if (order.getPaymentId() == null) {
             log.debug("환불할 결제 정보 없음 - orderId: {}", order.getOrderId());
             return;
         }
 
         try {
-            paymentService.cancelPayment(order.getOrderId(), order.getPaymentId());
+            paymentService.cancelPayment(order.getOrderId(), order.getPaymentId(), order.getOrderAmount().getFinalAmount(), cancelReason);
             log.info("결제 환불 완료 - paymentId: {}, amount: {}",
                     order.getPaymentId(), order.getOrderAmount().getFinalAmount());
         } catch (Exception e) {
@@ -520,7 +527,7 @@ public class OrderServiceImpl implements OrderService {
             Optional<TimeDealRes> timeDeal,
             Optional<CouponRes> coupon,
             int quantity,
-
+            String paymentKey,
             PaymentMethod paymentMethod
     ) {}
 

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
@@ -27,16 +27,14 @@ public class PaymentAdapter implements PaymentService {
     private final PaymentClient paymentClient;
 
     @Override
-    public PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, PaymentMethod paymentMethod) {
+    public PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, String paymentKey, PaymentMethod paymentMethod) {
         log.debug("결제 생성 요청: orderId={}, userId={}, amount={}, paymentMethod={}",
                 orderId, userId, amount, paymentMethod);
         try {
-            CreatePaymentDTO request = new CreatePaymentDTO(orderId, userId, amount, paymentMethod);
+            CreatePaymentDTO request = new CreatePaymentDTO(orderId, amount, paymentMethod, "KRW", paymentKey);
             PaymentCreateDTO response = paymentClient.createPayment(request).data();
             log.info("결제 생성 성공: paymentId={}", response.getPaymentId());
-            //return response.toResponse();
-            // TODO: 실제 결제 서비스 연동 시 위의 코드로 교체
-            return response.toResponseByDummy();
+            return response.toResponse();
         } catch (FeignException e) {
             log.error("결제 API 호출 실패: orderId={}, status={}, message={}",
                     orderId, e.status(), e.getMessage(), e);
@@ -48,15 +46,13 @@ public class PaymentAdapter implements PaymentService {
         }
     }
 
-    public PaymentCancelRes cancelPayment(UUID orderId, UUID paymentId) {
+    public PaymentCancelRes cancelPayment(UUID orderId, UUID paymentId, BigDecimal cancelAmount, String cancelReason) {
         log.info("결제 취소 요청 시작: orderId={}, paymentId={}", orderId, paymentId);
         try {
-            CancelPaymentDTO request = new CancelPaymentDTO("주문 취소");
+            CancelPaymentDTO request = new CancelPaymentDTO(cancelAmount, cancelReason);
             PaymentCancelDTO response = paymentClient.cancelPayment(paymentId, request).data();
             log.info("결제 생성 성공: paymentId={}", response.getPaymentId());
-            //return response.toResponse();
-            // TODO: 실제 결제 서비스 연동 시 위의 코드로 교체
-            return response.toResponseDummy(paymentId);
+            return response.toResponse();
         } catch (FeignException e) {
             log.error("결제 취소 API 호출 실패: paymentId={}, status={}, message={}",
                     paymentId, e.status(), e.getMessage(), e);

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CancelPaymentDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CancelPaymentDTO.java
@@ -4,10 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CancelPaymentDTO {
 
-    private String reason;
+    private BigDecimal cancelAmount;
+    private String cancelReason;
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CreatePaymentDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CreatePaymentDTO.java
@@ -14,7 +14,8 @@ import java.util.UUID;
 public class CreatePaymentDTO {
 
     private UUID orderId;
-    private Long userId;
     private BigDecimal amount;
     private PaymentMethod paymentMethod;
+    private String currency;
+    private String paymentKey;
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentCancelDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentCancelDTO.java
@@ -16,26 +16,15 @@ public class PaymentCancelDTO {
 
     private UUID paymentId;
     private UUID orderId;
-    private Long userId;
     private BigDecimal amount;
-    private String paymentMethod;
-    private String currency;
-    private String paymentKey;
     private String status;
+    private String cancelReason;
     private LocalDateTime completedAt;
 
     public PaymentCancelRes toResponse() {
         return PaymentCancelRes.builder()
                 .paymentId(paymentId)
                 .amount(amount)
-                .build();
-    }
-
-    // TODO: 결제 서비스 연동 완료 전까지 사용하는 더미 데이터 (TOSS_SECRET_KEY 받으면 제거)
-    public PaymentCancelRes toResponseDummy(UUID paymentId) {
-        return PaymentCancelRes.builder()
-                .paymentId(paymentId)
-                .amount(BigDecimal.valueOf(30000))
                 .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentCreateDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/PaymentCreateDTO.java
@@ -16,27 +16,15 @@ public class PaymentCreateDTO {
 
     private UUID paymentId;
     private UUID orderId;
-    private Long userId;
     private BigDecimal amount;
-    private String paymentMethod;   // CARD, ACCOUNT,  EASY_PAY, MOBILE, VIRTUAL_ACCOUNT
-    private String currency;        // KRW
-    private String paymentKey;      // tossKey-abc123
+    private String paymentMethod;
     private String status;          // PENDING, APPROVED, FAILED, CANCELED
     private LocalDateTime requestedAt;
-    private LocalDateTime completedAt;
 
     public PaymentCreateRes toResponse() {
         return PaymentCreateRes.builder()
                 .paymentId(paymentId)
                 .amount(amount)
-                .build();
-    }
-
-    // TODO: 결제 서비스 연동 완료 전까지 사용하는 더미 데이터 (TOSS_SECRET_KEY 받으면 제거)
-    public PaymentCreateRes toResponseByDummy() {
-        return PaymentCreateRes.builder()
-                .paymentId(UUID.fromString("10000000-0000-0000-1000-000000000000"))
-                .amount(BigDecimal.valueOf(30000))
                 .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
@@ -3,6 +3,7 @@ package com.palja.order_service.presentation.dto.request;
 import com.palja.order_service.application.command.CreateOrderCommand;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,7 +28,10 @@ public class CreateOrderReq {
 
     private UUID couponId;
 
-    @NotNull(message = "결제 수단은 필수입니다.")
+    @NotBlank(message = "결제 Key는 필수입니다.")
+    private String paymentKey;
+
+    @NotBlank(message = "결제 수단은 필수입니다.")
     private String paymentMethod;
 
     @NotNull(message = "배송 정보는 필수입니다.")
@@ -42,6 +46,7 @@ public class CreateOrderReq {
                 .quantity(quantity)
                 .timeDealId(timeDealId)
                 .couponId(couponId)
+                .paymentKey(paymentKey)
                 .paymentMethod(paymentMethod)
                 .delivery(delivery.toCommand())
                 .build();


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #170 

<br>

## 📌 개요
- Toss Secret Key 설정을 추가하고, Feign 클라이언트를 통해 결제 서비스 연동을 구현했습니다.

<br>

## 🔁 변경 사항
- Toss Secret Key(Environment) 설정 추가
- 결제 서비스의 결제 생성/취소 API에 맞게 요청/응답 DTO 구조 수정
- 기존 dummy 결제 처리 제거
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
<img width="968" height="171" alt="스크린샷 2025-12-09 222847" src="https://github.com/user-attachments/assets/a6b956b1-4ef4-477e-a392-0e4a3f17ebb8" />
</details>

<br>

## 👀 기타 더 이야기해볼 점
테스트 과정에서 금액 부족, 결제 정보 불일치 등 예외가 발생하고 있어
결제 서비스와 주고받는 데이터가 정확히 일치하는지 확인이 필요합니다.
<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
