### PR TITLE
FIX/ GatewayService 게이트웨이에서 경로를 관리하지 않고 모두 통과시키도록 변경

### DIFF
--- a/gateway-service/src/main/java/com/palja/gateway_service/filter/AuthorizationFilter.java
+++ b/gateway-service/src/main/java/com/palja/gateway_service/filter/AuthorizationFilter.java
@@ -3,19 +3,13 @@ package com.palja.gateway_service.filter;
 import static com.palja.gateway_service.util.RedisKeyConstants.*;
 
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
-import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palja.gateway_service.redis.TokenRepository;
 import com.palja.gateway_service.util.JwtUtil;
 
@@ -30,33 +24,12 @@ import reactor.core.publisher.Mono;
 public class AuthorizationFilter implements GlobalFilter {
 
 	private final JwtUtil jwtUtil;
-	private final ObjectMapper objectMapper;
 	private final TokenRepository tokenRepository;
-
-	private static final List<String> swaggerPaths = List.of(
-		"/swagger-ui",
-		"/v3/api-docs",
-		"/swagger-resources"
-	);
-
-	private final Map<String, List<String>> permitAllPaths = Map.of(
-		"/api/v1/auth/login", List.of("POST"),
-		"/api/v1/auth/refresh", List.of("POST"),
-		"/api/v1/customers", List.of("POST"),
-		"/api/v1/company-users", List.of("POST")
-	);
 
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		ServerHttpRequest request = exchange.getRequest();
-		String path = request.getURI().getPath();
-		String method = request.getMethod().name();
-
-		log.info("[%s] %s".formatted(method, request.getURI()));
-
-		if (swaggerPaths.stream().anyMatch(path::startsWith)) {
-			return chain.filter(exchange);
-		}
+		log.info("[%s] %s".formatted(request.getMethod().name(), request.getURI()));
 
 		List<String> authorizationHeaders = request.getHeaders().get("Authorization");
 		if (authorizationHeaders != null && !authorizationHeaders.isEmpty()) {
@@ -77,34 +50,9 @@ public class AuthorizationFilter implements GlobalFilter {
 					return chain.filter(exchange.mutate().request(mutatedRequest).build());
 				}
 			}
-		} else {
-			if (permitAllPaths.containsKey(path) && permitAllPaths.get(path).contains(method)) {
-				return chain.filter(exchange);
-			}
 		}
 
-		exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
-		exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
-
-		return exchange.getResponse().writeWith(getBuffer(exchange));
-	}
-
-	private Mono<DataBuffer> getBuffer(ServerWebExchange exchange) {
-		try {
-			byte[] bytes = objectMapper.writeValueAsBytes(getBody());
-			DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(bytes);
-			return Mono.just(buffer);
-		} catch (JsonProcessingException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	private Map<String, Object> getBody() {
-		return Map.of(
-			"success", false,
-			"code", "FORBIDDEN",
-			"message", "접근 권한이 없습니다."
-		);
+		return chain.filter(exchange);
 	}
 
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #159 

<br>

## 📌 개요
- 게이트웨이에서 인증 상태에 따라 특정 경로 접근을 제한하지 않고 모든 경로를 통과시키도록 변경했습니다.

<br>

## 🔁 변경 사항
- 만약 비로그인 사용자도 접근할 수 있는 API들이 점점 많아지게 되면 매번 게이트웨이에 경로를 추가해야하기 때문에 모든 경로를 허용하도록 변경했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
- 액세스 토큰만 검증하고 넘겨주면 결국엔 인증 상태에 따라 컨트롤러에서 권한을 확인하는 과정에서 접근이 제한돼서 때문에 튜터님께서 이렇게 하는게 더 괜찮을 것 같다고 하셔서 변경해봤습니다!

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
