### PR TITLE
FEAT/OrderService 타임딜 서비스 API 연동 (타임딜 검증 및 재고 처리)

### DIFF
--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/TimeDealRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/TimeDealRes.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TimeDealRes {
 
@@ -22,26 +22,4 @@ public class TimeDealRes {
     private final int discountRate;
     private final int timeDealStockQuantity;
     private final String status;
-
-    public static TimeDealRes of(
-            UUID timeDealId,
-            UUID productId,
-            LocalDateTime startAt,
-            LocalDateTime endAt,
-            BigDecimal timeDealPrice,
-            int discountRate,
-            int timeDealStockQuantity,
-            String status
-    ) {
-        return TimeDealRes.builder()
-                .timeDealId(timeDealId)
-                .productId(productId)
-                .startAt(startAt)
-                .endAt(endAt)
-                .timeDealPrice(timeDealPrice)
-                .discountRate(discountRate)
-                .timeDealStockQuantity(timeDealStockQuantity)
-                .status(status)
-                .build();
-    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -9,9 +9,6 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum OrderErrorCode implements ErrorCode {
 
-    // 사용자
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-
     // ===== 주문 관련 =====
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
     ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 상품 정보를 찾을 수 없습니다."),
@@ -34,7 +31,7 @@ public enum OrderErrorCode implements ErrorCode {
     INVENTORY_RESTORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "재고 복구에 실패했습니다."),
     COUPON_APPLICATION_FAILED(HttpStatus.BAD_REQUEST, "쿠폰 사용에 실패했습니다."),
     COUPON_RESTORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "쿠폰 복구에 실패했습니다."),
-    REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 환불에 실패했습니다."),
+
     // 주문 상태 변경 관련
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태입니다."),
     SAME_STATUS_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "동일한 상태로는 변경할 수 없습니다."),
@@ -42,12 +39,14 @@ public enum OrderErrorCode implements ErrorCode {
     USE_SPECIFIC_API_FOR_FINAL_STATUS(HttpStatus.BAD_REQUEST, "해당 상태로는 전용 API를 사용해야 합니다."),
 
     // ===== 타임딜 관련 =====
-    TIME_DEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "타임딜을 찾을 수 없습니다."),
     TIME_DEAL_EXPIRED(HttpStatus.BAD_REQUEST, "타임딜 기간이 만료되었습니다."),
     TIME_DEAL_NOT_STARTED(HttpStatus.BAD_REQUEST, "타임딜이 아직 시작되지 않았습니다."),
     TIME_DEAL_SOLD_OUT(HttpStatus.CONFLICT, "타임딜 수량이 모두 소진되었습니다."),
     TIME_DEAL_INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "타임딜 재고가 부족합니다."),
     INVALID_TIME_DEAL(HttpStatus.BAD_REQUEST, "유효하지 않은 타임딜입니다."),
+    TIME_DEAL_STOCK_DECREASE_FAILED(HttpStatus.BAD_REQUEST, "타임딜 재고 차감에 실패했습니다."),
+    TIME_DEAL_FETCH_FAILED(HttpStatus.BAD_REQUEST, "타임딜 정보를 조회할 수 없습니다."),
+    TIME_DEAL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 처리 중 오류가 발생했습니다."),
 
     // ==== 쿠폰 관련 ====
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰을 찾을 수 없습니다."),
@@ -78,7 +77,6 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_TRACKING_NUMBER(HttpStatus.BAD_REQUEST, "운송장 번호가 유효하지 않습니다."),
 
     // ===== 결제 관련 =====
-    PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "결제에 실패했습니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "결제 시간이 초과되었습니다."),
     INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 수단입니다."),
@@ -95,6 +93,22 @@ public enum OrderErrorCode implements ErrorCode {
     USER_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "사용자 서비스 연동 중 오류가 발생했습니다."),
     TIME_DEAL_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "타임딜 서비스 연동 중 오류가 발생했습니다."),
     PAYMENT_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "결제 서비스 연동 중 오류가 발생했습니다."),
+
+    // 조회 실패
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
+    TIME_DEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "타임딜 정보를 찾을 수 없습니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
+
+    // 외부 서비스 통신 실패
+    USER_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "사용자 서비스를 일시적으로 사용할 수 없습니다."),
+    TIME_DEAL_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "타임딜 서비스를 일시적으로 사용할 수 없습니다."),
+    PAYMENT_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "결제 서비스를 일시적으로 사용할 수 없습니다."),
+
+    // 비즈니스 로직 실패
+    TIME_DEAL_STOCK_DEDUCTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 재고 차감에 실패했습니다."),
+    TIME_DEAL_STOCK_RESTORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 재고 복구에 실패했습니다."),
+    PAYMENT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 오류가 발생했습니다."),
+    REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "환불 처리 중 오류가 발생했습니다."),
 
     // ===== 서버 내부 오류 =====
     ORDER_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "주문 생성 중 오류가 발생했습니다."),

--- a/order-service/src/main/java/com/palja/order_service/application/service/TimeDealService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/TimeDealService.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 public interface TimeDealService {
 
     // 타임딜 조회
-    TimeDealRes getTimeDeal(UUID timeDealId, int quantity);
+    TimeDealRes getTimeDeal(UUID timeDealId);
 
     // 타임딜 재고 차감
     void deductTimeDealStock(UUID timeDealId, int quantity);

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -97,7 +97,7 @@ public class OrderServiceImpl implements OrderService {
 
         Optional<TimeDealRes> timeDeal = Optional.empty();
         if (command.timeDealId() != null) {
-            TimeDealRes deal = timeDealService.getTimeDeal(command.timeDealId(), command.quantity());
+            TimeDealRes deal = timeDealService.getTimeDeal(command.timeDealId());
             orderValidator.validateTimeDealForOrder(deal, command.quantity());
             timeDeal = Optional.of(deal);
             log.debug("타임딜 검증 완료 - timeDealId: {}", command.timeDealId());

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/TimeDealClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/TimeDealClient.java
@@ -1,16 +1,35 @@
 package com.palja.order_service.infrastructure.external;
 
 import com.palja.common.response.ApiResponse;
+import com.palja.order_service.infrastructure.external.dto.request.TimeDealStockDecreaseDTO;
+import com.palja.order_service.infrastructure.external.dto.request.TimeDealStockRestoreDTO;
 import com.palja.order_service.infrastructure.external.dto.response.TimeDealDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.UUID;
 
 @FeignClient(name = "timedeal-service", path = "/api/v1/time-deals")
 public interface TimeDealClient {
 
+    // 타임딜 단건 조회
     @GetMapping("/{timeDealId}")
     ApiResponse<TimeDealDTO> getTimeDeal(@PathVariable("timeDealId") UUID timeDealId);
+
+    // 타임딜 재고 차감
+    @PutMapping("/{timeDealId}/stock/decrease")
+    ApiResponse<Void> decreaseTimeDealStock(
+            @PathVariable("timeDealId") UUID timeDealId,
+            @RequestBody TimeDealStockDecreaseDTO request
+    );
+
+    // 타임딜 재고 복원
+    @PutMapping("/{timeDealId}/stock/restore")
+    ApiResponse<Void> restoreTimeDealStock(
+            @PathVariable("timeDealId") UUID timeDealId,
+            @RequestBody TimeDealStockRestoreDTO request
+    );
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
@@ -36,9 +36,9 @@ public class PaymentAdapter implements PaymentService {
             log.info("결제 생성 성공: paymentId={}", response.getPaymentId());
             return response.toResponse();
         } catch (FeignException e) {
-            log.error("결제 API 호출 실패: orderId={}, status={}, message={}",
+            log.error("결제 서비스 호출 실패: orderId={}, status={}, message={}",
                     orderId, e.status(), e.getMessage(), e);
-            throw new BusinessException(OrderErrorCode.PAYMENT_SERVICE_ERROR);
+            throw new BusinessException(OrderErrorCode.PAYMENT_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("결제 생성 중 예상치 못한 오류: orderId={}, error={}",
                     orderId, e.getClass().getName(), e);
@@ -46,21 +46,25 @@ public class PaymentAdapter implements PaymentService {
         }
     }
 
+    @Override
     public PaymentCancelRes cancelPayment(UUID orderId, UUID paymentId, BigDecimal cancelAmount, String cancelReason) {
         log.info("결제 취소 요청 시작: orderId={}, paymentId={}", orderId, paymentId);
         try {
             CancelPaymentDTO request = new CancelPaymentDTO(cancelAmount, cancelReason);
             PaymentCancelDTO response = paymentClient.cancelPayment(paymentId, request).data();
-            log.info("결제 생성 성공: paymentId={}", response.getPaymentId());
+            log.info("결제 취소 성공: paymentId={}", response.getPaymentId());
             return response.toResponse();
+        } catch (FeignException.NotFound e) {
+            log.error("결제 정보 없음: paymentId={}", paymentId, e);
+            throw new BusinessException(OrderErrorCode.PAYMENT_NOT_FOUND);
         } catch (FeignException e) {
-            log.error("결제 취소 API 호출 실패: paymentId={}, status={}, message={}",
+            log.error("결제 취소 서비스 호출 실패: paymentId={}, status={}, message={}",
                     paymentId, e.status(), e.getMessage(), e);
-            throw new BusinessException(OrderErrorCode.PAYMENT_SERVICE_ERROR);
+            throw new BusinessException(OrderErrorCode.PAYMENT_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("결제 취소 중 예상치 못한 오류: paymentId={}, error={}",
                     paymentId, e.getClass().getName(), e);
-            throw new BusinessException(OrderErrorCode.PAYMENT_FAILED);
+            throw new BusinessException(OrderErrorCode.REFUND_FAILED);
         }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
@@ -25,56 +25,56 @@ public class TimeDealAdapter implements TimeDealService {
     @Override
     public TimeDealRes getTimeDeal(UUID timeDealId) {
         log.debug("타임딜 정보 조회 요청: timeDealId={}", timeDealId);
-
         try {
             TimeDealDTO dto = timeDealClient.getTimeDeal(timeDealId).data();
             log.info("타임딜 정보 조회 성공: timeDealId={}", timeDealId);
             return dto.toResponse();
+        } catch (FeignException.NotFound e) {
+            log.error("타임딜 정보 없음: timeDealId={}", timeDealId, e);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_NOT_FOUND);
         } catch (FeignException e) {
-            log.error("타임딜 조회 API 호출 실패: timeDealId={}, status={}, message={}",
+            log.error("타임딜 서비스 호출 실패: timeDealId={}, status={}, message={}",
                     timeDealId, e.status(), e.getMessage(), e);
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_ERROR);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("타임딜 정보 조회 중 예상치 못한 오류: timeDealId={}, error={}",
                     timeDealId, e.getClass().getName(), e);
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_FAILED);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_UNAVAILABLE);
         }
     }
-
 
     @Override
     public void deductTimeDealStock(UUID timeDealId, int quantity) {
         log.info("타임딜 재고 차감 요청 시작: timeDealId={}, quantity={}", timeDealId, quantity);
-
         try {
             timeDealClient.decreaseTimeDealStock(timeDealId, new TimeDealStockDecreaseDTO(quantity));
             log.info("타임딜 재고 차감 성공: timeDealId={}, quantity={}", timeDealId, quantity);
         } catch (FeignException e) {
-            log.error("타임딜 재고 차감 API 호출 실패: timeDealId={}, quantity={}, status={}, message={}",
+            log.error("타임딜 재고 차감 서비스 호출 실패: timeDealId={}, quantity={}, status={}, message={}",
                     timeDealId, quantity, e.status(), e.getMessage(), e);
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_ERROR);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("타임딜 재고 차감 중 예상치 못한 오류: timeDealId={}, quantity={}, error={}",
                     timeDealId, quantity, e.getClass().getName(), e);
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_FAILED);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_STOCK_DEDUCTION_FAILED);
         }
     }
+
 
     @Override
     public void restoreTimeDealStock(UUID timeDealId, int quantity) {
         log.info("타임딜 재고 복구 요청 시작: timeDealId={}, quantity={}", timeDealId, quantity);
-
         try {
             timeDealClient.restoreTimeDealStock(timeDealId, new TimeDealStockRestoreDTO(quantity));
             log.info("타임딜 재고 복구 성공: timeDealId={}, quantity={}", timeDealId, quantity);
         } catch (FeignException e) {
-            log.error("타임딜 재고 복구 API 호출 실패: timeDealId={}, quantity={}, status={}, message={}",
+            log.error("타임딜 재고 복구 서비스 호출 실패: timeDealId={}, quantity={}, status={}, message={}",
                     timeDealId, quantity, e.status(), e.getMessage(), e);
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_ERROR);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("타임딜 재고 복구 중 예상치 못한 오류: timeDealId={}, quantity={}, error={}",
                     timeDealId, quantity, e.getClass().getName(), e);
-            throw new BusinessException(OrderErrorCode.TIME_DEAL_FAILED);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_STOCK_RESTORE_FAILED);
         }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/TimeDealAdapter.java
@@ -1,8 +1,14 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
+import com.palja.common.exception.BusinessException;
 import com.palja.order_service.application.dto.response.TimeDealRes;
+import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.TimeDealService;
+import com.palja.order_service.infrastructure.external.TimeDealClient;
+import com.palja.order_service.infrastructure.external.dto.request.TimeDealStockDecreaseDTO;
+import com.palja.order_service.infrastructure.external.dto.request.TimeDealStockRestoreDTO;
 import com.palja.order_service.infrastructure.external.dto.response.TimeDealDTO;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,46 +20,61 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class TimeDealAdapter implements TimeDealService {
 
-    // TODO: 타임딜 서비스 연동 시 timeDealClient 주입 및 구현 추가
-    //private final TimeDealClient timeDealClient;
+    private final TimeDealClient timeDealClient;
 
     @Override
-    public TimeDealRes getTimeDeal(UUID timeDealId, int quantity) {
-        log.debug("타임딜 정보 조회: timeDealId={}", timeDealId);
+    public TimeDealRes getTimeDeal(UUID timeDealId) {
+        log.debug("타임딜 정보 조회 요청: timeDealId={}", timeDealId);
 
-        //TODO: 실제 타임딜 API 호출 (Feign)
-        //TimeDealDTO response = timeDealClient.getTimeDeal(timeDealId).data();
-        // TODO: 실제 타임딜 서비스 연동 시 위의 코드로 교체
-        // 임시 더미 데이터
-        TimeDealDTO response = TimeDealDTO.dummy(timeDealId);
-
-        return toTimeDealRes(response);
+        try {
+            TimeDealDTO dto = timeDealClient.getTimeDeal(timeDealId).data();
+            log.info("타임딜 정보 조회 성공: timeDealId={}", timeDealId);
+            return dto.toResponse();
+        } catch (FeignException e) {
+            log.error("타임딜 조회 API 호출 실패: timeDealId={}, status={}, message={}",
+                    timeDealId, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_ERROR);
+        } catch (Exception e) {
+            log.error("타임딜 정보 조회 중 예상치 못한 오류: timeDealId={}, error={}",
+                    timeDealId, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_FAILED);
+        }
     }
 
-    private TimeDealRes toTimeDealRes(TimeDealDTO dto) {
-        return TimeDealRes.of(
-                dto.getTimeDealId(),
-                dto.getProductId(),
-                dto.getStartAt(),
-                dto.getEndAt(),
-                dto.getTimeDealPrice(),
-                dto.getDiscountRate(),
-                dto.getQuantity(),
-                dto.getStatus()
-        );
-    }
 
     @Override
     public void deductTimeDealStock(UUID timeDealId, int quantity) {
-        log.debug("타임딜 재고 차감 요청: timeDealId={}, quantity={}", timeDealId, quantity);
-        // TODO: 타임딜 재고 차감 API 호출 구현
-        log.error("타임딜 재고 차감 실패: productId={}, quantity={}", timeDealId, quantity);
+        log.info("타임딜 재고 차감 요청 시작: timeDealId={}, quantity={}", timeDealId, quantity);
+
+        try {
+            timeDealClient.decreaseTimeDealStock(timeDealId, new TimeDealStockDecreaseDTO(quantity));
+            log.info("타임딜 재고 차감 성공: timeDealId={}, quantity={}", timeDealId, quantity);
+        } catch (FeignException e) {
+            log.error("타임딜 재고 차감 API 호출 실패: timeDealId={}, quantity={}, status={}, message={}",
+                    timeDealId, quantity, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_ERROR);
+        } catch (Exception e) {
+            log.error("타임딜 재고 차감 중 예상치 못한 오류: timeDealId={}, quantity={}, error={}",
+                    timeDealId, quantity, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_FAILED);
+        }
     }
 
     @Override
     public void restoreTimeDealStock(UUID timeDealId, int quantity) {
-        log.debug("타임딜 재고 복구 요청: timeDealId={}, quantity={}", timeDealId, quantity);
-        // TODO: 상품 재고 차감 API 호출 구현
-        log.error("타임딜 재고 복구 실패: timeDealId={}, quantity={}", timeDealId, quantity);
+        log.info("타임딜 재고 복구 요청 시작: timeDealId={}, quantity={}", timeDealId, quantity);
+
+        try {
+            timeDealClient.restoreTimeDealStock(timeDealId, new TimeDealStockRestoreDTO(quantity));
+            log.info("타임딜 재고 복구 성공: timeDealId={}, quantity={}", timeDealId, quantity);
+        } catch (FeignException e) {
+            log.error("타임딜 재고 복구 API 호출 실패: timeDealId={}, quantity={}, status={}, message={}",
+                    timeDealId, quantity, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_SERVICE_ERROR);
+        } catch (Exception e) {
+            log.error("타임딜 재고 복구 중 예상치 못한 오류: timeDealId={}, quantity={}, error={}",
+                    timeDealId, quantity, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.TIME_DEAL_FAILED);
+        }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -29,14 +29,17 @@ public class UserAdapter implements UserService {
             CustomerUserDTO dto = userClient.getMyCustomer().data();
             log.info("고객 사용자 조회 성공: userId={}", dto.getUserId());
             return dto.toResponse();
+        } catch (FeignException.NotFound e) {
+            log.error("사용자 정보 없음: loginId={}", loginId, e);
+            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
         } catch (FeignException e) {
-            log.error("사용자 API 호출 실패: loginId={}, status={}, message={}",
+            log.error("사용자 서비스 호출 실패: loginId={}, status={}, message={}",
                     loginId, e.status(), e.getMessage(), e);
-            throw new BusinessException(OrderErrorCode.USER_SERVICE_ERROR);
+            throw new BusinessException(OrderErrorCode.USER_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("고객 사용자 조회 중 예상치 못한 오류: loginId={}, error={}",
                     loginId, e.getClass().getName(), e);
-            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
+            throw new BusinessException(OrderErrorCode.USER_SERVICE_UNAVAILABLE);
         }
     }
 
@@ -47,14 +50,17 @@ public class UserAdapter implements UserService {
             CompanyUserDTO dto = userClient.getMyCompanyUser().data();
             log.info("판매업체 사용자 조회 성공: companyUserId={}", dto.getCompanyUserId());
             return dto.toResponse();
+        } catch (FeignException.NotFound e) {
+            log.error("사용자 정보 없음: loginId={}", loginId, e);
+            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
         } catch (FeignException e) {
-            log.error("사용자 API 호출 실패: loginId={}, status={}, message={}",
+            log.error("사용자 서비스 호출 실패: loginId={}, status={}, message={}",
                     loginId, e.status(), e.getMessage(), e);
-            throw new BusinessException(OrderErrorCode.USER_SERVICE_ERROR);
+            throw new BusinessException(OrderErrorCode.USER_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("판매업체 사용자 조회 중 예상치 못한 오류: loginId={}, error={}",
                     loginId, e.getClass().getName(), e);
-            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
+            throw new BusinessException(OrderErrorCode.USER_SERVICE_UNAVAILABLE);
         }
     }
 
@@ -65,14 +71,17 @@ public class UserAdapter implements UserService {
             ManagerUserDTO dto = userClient.getMyManager().data();
             log.info("MANAGER 사용자 조회 성공: userId={}", dto.getUserId());
             return dto.toResponse();
+        } catch (FeignException.NotFound e) {
+            log.error("사용자 정보 없음: loginId={}", loginId, e);
+            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
         } catch (FeignException e) {
-            log.error("사용자 API 호출 실패: loginId={}, status={}, message={}",
+            log.error("사용자 서비스 호출 실패: loginId={}, status={}, message={}",
                     loginId, e.status(), e.getMessage(), e);
-            throw new BusinessException(OrderErrorCode.USER_SERVICE_ERROR);
+            throw new BusinessException(OrderErrorCode.USER_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
             log.error("MANAGER 사용자 조회 중 예상치 못한 오류: loginId={}, error={}",
                     loginId, e.getClass().getName(), e);
-            throw new BusinessException(OrderErrorCode.USER_NOT_FOUND);
+            throw new BusinessException(OrderErrorCode.USER_SERVICE_UNAVAILABLE);
         }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/TimeDealStockDecreaseDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/TimeDealStockDecreaseDTO.java
@@ -1,0 +1,12 @@
+package com.palja.order_service.infrastructure.external.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeDealStockDecreaseDTO {
+    long decreaseQuantity;
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/TimeDealStockRestoreDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/TimeDealStockRestoreDTO.java
@@ -1,0 +1,12 @@
+package com.palja.order_service.infrastructure.external.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeDealStockRestoreDTO {
+    long restoreQuantity;
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/TimeDealDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/TimeDealDTO.java
@@ -1,5 +1,6 @@
 package com.palja.order_service.infrastructure.external.dto.response;
 
+import com.palja.order_service.application.dto.response.TimeDealRes;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -13,32 +14,28 @@ public class TimeDealDTO {
 
     private UUID timeDealId;
     private UUID productId;
+    private UUID companyUserId;
+    private String title;
+    private String description;
     private LocalDateTime startAt;
     private LocalDateTime endAt;
+    private BigDecimal originalPrice;
     private BigDecimal timeDealPrice;
     private int discountRate;
-    private String status; // ENUM(PENDING, OPEN, SOLD_OUT, CLOSED)
-    private int quantity;
-    private LocalDateTime createdAt;
-    private Long createdBy;
-    private LocalDateTime updatedAt;
-    private Long updatedBy;
+    private int totalQuantity;
+    private int remainingQuantity;
+    private String timeDealStatus;  // ENUM(PENDING, OPEN, SOLD_OUT, CLOSED)
 
-    // TODO: 타임딜 서비스 연동 전까지 사용하는 더미 데이터. time-deal-service 연결 후 삭제.
-    public static TimeDealDTO dummy(UUID timeDealId) {
-        return new TimeDealDTO(
-                timeDealId,
-                UUID.fromString("22222222-2222-2222-2222-222222222222"),
-                LocalDateTime.of(2025, 12, 1, 0, 0),
-                LocalDateTime.of(2025, 12, 10, 23, 59, 59),
-                BigDecimal.valueOf(9900),
-                10,
-                "OPEN",
-                37,
-                LocalDateTime.of(2025, 12, 3, 19, 0),
-                3L,
-                LocalDateTime.of(2025, 12, 3, 20, 0),
-                3L
-        );
+    public TimeDealRes toResponse() {
+        return TimeDealRes.builder()
+                .timeDealId(timeDealId)
+                .productId(productId)
+                .startAt(startAt)
+                .endAt(endAt)
+                .timeDealPrice(timeDealPrice)
+                .discountRate(discountRate)
+                .timeDealStockQuantity(remainingQuantity)
+                .status(timeDealStatus)
+                .build();
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #146 

<br>

## 📌 개요
- 주문 생성 및 취소 시 타임딜 서비스 API를 연동하여
타임딜 검증, 재고 차감, 재고 복구 기능을 구현했습니다.

<br>

## 🔁 변경 사항
- 타임딜 서비스 연동을 위한 FeignClient 추가
- 타임딜 조회 API 연동 및 유효성 검증 추가
- 주문 생성 시 타임딜 재고 차감 처리 적용
- 주문 취소 시 타임딜 재고 복구 처리 적용
- 타임딜 검증 실패 및 재고 처리 실패에 대한 비즈니스 예외 추가

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
