### PR TITLE
FEAT/OrderService 상품 서비스 API 연동 (상품 검증 및 재고 반영)

### DIFF
--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/ProductRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/ProductRes.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductRes {
     private UUID companyUserId;
@@ -17,20 +17,4 @@ public class ProductRes {
     private String productName;
     private BigDecimal price;
     private int stockQuantity;
-
-    public static ProductRes of(
-            UUID companyUserId,
-            UUID productId,
-            String productName,
-            BigDecimal price,
-            int stockQuantity
-    ) {
-        return ProductRes.builder()
-                .companyUserId(companyUserId)
-                .productId(productId)
-                .productName(productName)
-                .price(price)
-                .stockQuantity(stockQuantity)
-                .build();
-    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -61,7 +61,6 @@ public enum OrderErrorCode implements ErrorCode {
     // ==== 상품 관련 =====
     INVALID_PRODUCT(HttpStatus.BAD_REQUEST, "유효하지 않은 상품입니다."),
     INVALID_PRODUCT_PRICE(HttpStatus.BAD_REQUEST, "상품 가격 정보가 올바르지 않습니다."),
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
     PRODUCT_UNAVAILABLE(HttpStatus.BAD_REQUEST, "판매 중단된 상품입니다."),
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
     OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "품절된 상품입니다."),
@@ -93,19 +92,23 @@ public enum OrderErrorCode implements ErrorCode {
     TIME_DEAL_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "타임딜 서비스 연동 중 오류가 발생했습니다."),
     PAYMENT_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "결제 서비스 연동 중 오류가 발생했습니다."),
 
-    // 조회 실패
+    // 조회 실패,
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 정보를 찾을 수 없습니다."),
     TIME_DEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "타임딜 정보를 찾을 수 없습니다."),
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰 정보를 찾을 수 없습니다."),
 
     // 외부 서비스 통신 실패
     USER_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "사용자 서비스를 일시적으로 사용할 수 없습니다."),
+    PRODUCT_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "상품 서비스를 일시적으로 사용할 수 없습니다."),
     TIME_DEAL_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "타임딜 서비스를 일시적으로 사용할 수 없습니다."),
     PAYMENT_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "결제 서비스를 일시적으로 사용할 수 없습니다."),
     COUPON_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "쿠폰 서비스를 일시적으로 사용할 수 없습니다."),
 
     // 비즈니스 로직 실패
+    PRODUCT_STOCK_DEDUCTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 차감에 실패했습니다."),
+    PRODUCT_STOCK_RESTORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 복구에 실패했습니다."),
     TIME_DEAL_STOCK_DEDUCTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 재고 차감에 실패했습니다."),
     TIME_DEAL_STOCK_RESTORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "타임딜 재고 복구에 실패했습니다."),
     PAYMENT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 오류가 발생했습니다."),

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/ProductClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/ProductClient.java
@@ -35,6 +35,6 @@ public interface ProductClient {
     );
 
     // TODO: 판매자 id로 판매자 상품 목록 API 호출 구현
-    @GetMapping("/order//seller/{companyUserId}")
+    @GetMapping("/order/seller/{companyUserId}")
     List<UUID> getProductIdsByCompanyUserId(@PathVariable("companyUserId") UUID companyUserId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/ProductClient.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/ProductClient.java
@@ -2,15 +2,39 @@ package com.palja.order_service.infrastructure.external;
 
 import com.palja.common.response.ApiResponse;
 import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
+import com.palja.order_service.infrastructure.external.dto.response.ProductStockDecreaseDTO;
+import com.palja.order_service.infrastructure.external.dto.response.ProductStockRestoreDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
 import java.util.UUID;
 
 @FeignClient(name = "product-service", path = "/api/v1/products")
 public interface ProductClient {
 
-    @GetMapping("/{productId}")
+    // 주문 서비스용 상품 정보 조회
+    @GetMapping("/order/{productId}")
     ApiResponse<ProductDTO> getProduct(@PathVariable("productId") UUID productId);
+
+    // 주문에 의한 판매 재고 차감
+    @PutMapping("/order/sale/{productId}")
+    ApiResponse<ProductStockDecreaseDTO> decreaseProductStock(
+            @PathVariable("productId") UUID productId,
+            @RequestParam("quantity") Integer quantity
+    );
+
+    // 주문 취소에 의한 재고 복구
+    @PutMapping("/order/cancel/{productId}")
+    ApiResponse<ProductStockRestoreDTO> restoreProductStock(
+            @PathVariable("productId") UUID productId,
+            @RequestParam("quantity") Integer quantity
+    );
+
+    // TODO: 판매자 id로 판매자 상품 목록 API 호출 구현
+    @GetMapping("/order//seller/{companyUserId}")
+    List<UUID> getProductIdsByCompanyUserId(@PathVariable("companyUserId") UUID companyUserId);
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/ProductAdapter.java
@@ -1,8 +1,12 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
+import com.palja.common.exception.BusinessException;
 import com.palja.order_service.application.dto.response.ProductRes;
+import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.ProductService;
+import com.palja.order_service.infrastructure.external.ProductClient;
 import com.palja.order_service.infrastructure.external.dto.response.ProductDTO;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,56 +14,85 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.UUID;
 
-// 상품 서비스 클라이언트 구현
-// FeignClient를 통한 외부 서비스 호출
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProductAdapter implements ProductService {
 
-    // TODO: 상품 서비스 연동 시 productClient 주입 및 구현 추가
-     //private final ProductClient productClient;
+    private final ProductClient productClient;
 
     @Override
     public ProductRes getProduct(UUID productId) {
-        log.debug("상품 정보 조회: productId={}", productId);
-
-        // TODO: 실제 상품 API 호출 (Feign)
-        // ProductDTO response = productClient.getProduct(productId).data();
-        // TODO: 실제 상품 서비스 연동 시 위의 코드로 교체
-        // 임시 더미 데이터
-        ProductDTO response = ProductDTO.dummy(productId);
-
-        return toProductRes(response);
-    }
-
-    private ProductRes toProductRes(ProductDTO dto) {
-        return ProductRes.of(
-                UUID.fromString("11111111-1111-1111-1111-111111111111"),
-                dto.getProductId(),
-                dto.getName(),
-                dto.getPrice(),
-                dto.getStock()
-        );
+        log.debug("상품 정보 조회 요청: productId={}", productId);
+        try {
+            ProductDTO dto = productClient.getProduct(productId).data();
+            log.info("상품 정보 조회 성공: productId={}", productId);
+            return dto.toResponse();
+        } catch (FeignException.NotFound e) {
+            log.error("상품 정보 없음: productId={}", productId, e);
+            throw new BusinessException(OrderErrorCode.PRODUCT_NOT_FOUND);
+        } catch (FeignException e) {
+            log.error("상품 서비스 호출 실패: productId={}, status={}, message={}",
+                    productId, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.PRODUCT_SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("상품 정보 조회 중 예상치 못한 오류: productId={}, error={}",
+                    productId, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.PRODUCT_SERVICE_UNAVAILABLE);
+        }
     }
 
     @Override
     public void deductProductStock(UUID productId, int quantity) {
-        log.debug("재고 차감 요청: productId={}, quantity={}", productId, quantity);
-        // TODO: 상품 재고 차감 API 호출 구현
-        log.error("재고 차감 실패: productId={}, quantity={}", productId, quantity);
+        log.info("상품 재고 차감 요청 시작: productId={}, quantity={}", productId, quantity);
+        try {
+            productClient.decreaseProductStock(productId, quantity);
+            log.info("상품 재고 차감 성공: productId={}, quantity={}", productId, quantity);
+        } catch (FeignException e) {
+            log.error("상품 재고 차감 서비스 호출 실패: productId={}, quantity={}, status={}, message={}",
+                    productId, quantity, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.PRODUCT_SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("상품 재고 차감 중 예상치 못한 오류: productId={}, quantity={}, error={}",
+                    productId, quantity, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.PRODUCT_STOCK_DEDUCTION_FAILED);
+        }
     }
 
     @Override
     public void restoreProductStock(UUID productId, int quantity) {
-        log.debug("재고 복구 요청: productId={}, quantity={}", productId, quantity);
-        // TODO: 상품 재고 차감 API 호출 구현
-        log.error("재고 복구 실패: productId={}, quantity={}", productId, quantity);
+        log.info("상품 재고 복구 요청 시작: productId={}, quantity={}", productId, quantity);
+        try {
+            productClient.restoreProductStock(productId, quantity);
+            log.info("상품 재고 복구 성공: productId={}, quantity={}", productId, quantity);
+        } catch (FeignException e) {
+            log.error("상품 재고 복구 서비스 호출 실패: productId={}, quantity={}, status={}, message={}",
+                    productId, quantity, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.PRODUCT_SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("상품 재고 복구 중 예상치 못한 오류: productId={}, quantity={}, error={}",
+                    productId, quantity, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.PRODUCT_STOCK_RESTORE_FAILED);
+        }
     }
 
     @Override
     public List<UUID> getProductIdsByCompanyUserId(UUID companyUserId) {
-        // TODO: 판매자 id로 판매자 상품 목록 API 호출 구현
-        return null;
+        log.debug("판매자 상품 목록 조회 요청: companyUserId={}", companyUserId);
+        try {
+            // TODO: 판매자 id로 판매자 상품 목록 API 호출 구현
+            List<UUID> productIds = productClient.getProductIdsByCompanyUserId(companyUserId);
+            log.info("판매자 상품 목록 조회 성공: companyUserId={}, count={}",
+                    companyUserId, productIds.size());
+            return productIds;
+        } catch (FeignException e) {
+            log.error("상품 목록 조회 서비스 호출 실패: companyUserId={}, status={}, message={}",
+                    companyUserId, e.status(), e.getMessage(), e);
+            throw new BusinessException(OrderErrorCode.PRODUCT_SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("판매자 상품 목록 조회 중 예상치 못한 오류: companyUserId={}, error={}",
+                    companyUserId, e.getClass().getName(), e);
+            throw new BusinessException(OrderErrorCode.PRODUCT_SERVICE_UNAVAILABLE);
+        }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductDTO.java
@@ -1,5 +1,6 @@
 package com.palja.order_service.infrastructure.external.dto.response;
 
+import com.palja.order_service.application.dto.response.ProductRes;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,25 +12,19 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductDTO {
-    // TODO: 상품 단건 조회 시 companyUserId 반환하도록 수정되면 companyUserId 값 추가.
     private UUID productId;
-    private String name;
-    private String description;
-    private String companyName;
-    private int stock;
+    private UUID companyUserId;
+    private String productName;
     private BigDecimal price;
-    private String category;
+    private int stockQuantity;
 
-    // TODO: 상품 서비스 연동 전까지 사용하는 더미 데이터. product-service 연결 후 삭제.
-    public static ProductDTO dummy(UUID productId) {
-        return new ProductDTO(
-                productId,
-                "샘플 상품",
-                "샘플 상품 설명입니다.",
-                "팔자컴퍼니",
-                100,
-                BigDecimal.valueOf(10000),
-                "FOOD"
-        );
+    public  ProductRes toResponse() {
+        return ProductRes.builder()
+                .companyUserId(companyUserId)
+                .productId(productId)
+                .productName(productName)
+                .price(price)
+                .stockQuantity(stockQuantity)
+                .build();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductStockDecreaseDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductStockDecreaseDTO.java
@@ -1,0 +1,15 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductStockDecreaseDTO {
+    private UUID productId;
+    private Boolean status;
+}

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductStockRestoreDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/response/ProductStockRestoreDTO.java
@@ -1,0 +1,15 @@
+package com.palja.order_service.infrastructure.external.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductStockRestoreDTO {
+    private UUID productId;
+    private boolean status;
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #145 

<br>

## 📌 개요
- 주문 생성 및 취소 과정에서 필요한 상품 검증·재고 차감·재고 복구 로직을 상품 서비스(Product Service) API 기반으로 연동했습니다

<br>

## 🔁 변경 사항
- 상품 서비스 연동을 위한 ProductClient 추가 (Feign)
- 주문 생성 시 상품 정보 조회 API 연동
- 주문 생성 시 재고 차감 API 적용
- 주문 취소 시 재고 복구 API 연동
- 상품/재고 연동 과정에서 발생하는 예외 처리 보완
- 기존 dummy 처리 제거 및 실제 API 기반 구조로 전환
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
