### PR TITLE
CHORE/Docker Compose에 Redis Insight 추가

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -28,6 +28,16 @@ services:
     networks:
       - msa-network
 
+  # Redis UI (RedisInsight)
+  redis-insight:
+    image: redis/redisinsight:latest
+    container_name: redisinsight
+    ports:
+      - "5540:5540"
+    restart: always
+    networks:
+      - msa-network
+
   # Kafka & Zookeeper
   zookeeper:
     image: wurstmeister/zookeeper:latest


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #181 

<br>

## 📌 개요
- Docker Compose 환경에 Redis Insight를 추가하여, Redis 조회 및 모니터링을 위한 개발 편의성을 향상했습니다.

<br>

## 🔁 변경 사항
- redis/redisinsight:latest 컨테이너 추가
- 포트 매핑 5540:5540 설정
- msa-network 네트워크 연결
- restart: always 옵션 적용
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
- Redis Insight에서 Redis 접속 시 Host는 Docker Compose 서비스명인 `redis` 를 사용하면 정상 연결됩니다.
- 두 컨테이너가 동일한 msa-network 내에 존재해야 합니다.
<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
