### PR TITLE
REFACTOR/CouponService Swagger 문서화 개선

### DIFF
--- a/coupon-service/build.gradle
+++ b/coupon-service/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ChangeStatusCouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ChangeStatusCouponRes.java
@@ -3,10 +3,12 @@ package com.palja.coupon_service.application.dto.coupon;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.vo.CouponStatus;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Getter
 @Builder
 public class ChangeStatusCouponRes {
     private UUID couponId;

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponDetailRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponDetailRes.java
@@ -1,5 +1,6 @@
 package com.palja.coupon_service.application.dto.coupon;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.vo.CouponStatus;
 import com.palja.coupon_service.domain.vo.DiscountType;
@@ -11,6 +12,7 @@ import java.util.UUID;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReadCouponDetailRes {
     private UUID couponId;
     private String couponName;

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponRes.java
@@ -4,10 +4,12 @@ import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.vo.CouponStatus;
 import com.palja.coupon_service.domain.vo.DiscountType;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Getter
 @Builder
 public class ReadCouponRes {
     private UUID couponId;

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/ReadCouponRes.java
@@ -1,5 +1,6 @@
 package com.palja.coupon_service.application.dto.coupon;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.vo.CouponStatus;
 import com.palja.coupon_service.domain.vo.DiscountType;
@@ -11,6 +12,7 @@ import java.util.UUID;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReadCouponRes {
     private UUID couponId;
     private String couponName;

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/UpdateCouponRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/coupon/UpdateCouponRes.java
@@ -2,10 +2,12 @@ package com.palja.coupon_service.application.dto.coupon;
 
 import com.palja.coupon_service.domain.entity.Coupon;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Getter
 @Builder
 public class UpdateCouponRes {
     private UUID couponId;

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/CancelCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/CancelCouponUserRes.java
@@ -3,9 +3,11 @@ package com.palja.coupon_service.application.dto.couponUser;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import com.palja.coupon_service.domain.vo.CouponUserStatus;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.util.UUID;
 
+@Getter
 @Builder
 public class CancelCouponUserRes {
     private UUID couponUserId;

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ChangeStatusCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ChangeStatusCouponUserRes.java
@@ -3,10 +3,12 @@ package com.palja.coupon_service.application.dto.couponUser;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import com.palja.coupon_service.domain.vo.CouponUserStatus;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Getter
 @Builder
 public class ChangeStatusCouponUserRes {
     private UUID couponUserId;

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/DeleteCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/DeleteCouponUserRes.java
@@ -2,10 +2,12 @@ package com.palja.coupon_service.application.dto.couponUser;
 
 import com.palja.coupon_service.domain.entity.CouponUser;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Getter
 @Builder
 public class DeleteCouponUserRes {
     private UUID couponUserId;

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ReadCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/ReadCouponUserRes.java
@@ -5,10 +5,12 @@ import com.palja.coupon_service.domain.entity.Coupon;
 import com.palja.coupon_service.domain.entity.CouponUser;
 import com.palja.coupon_service.domain.vo.CouponUserStatus;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReadCouponUserRes {

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
@@ -9,7 +9,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,7 +61,12 @@ public interface CouponController {
             summary = "쿠폰 목록 조회",
             description = "사용자의 보유 쿠폰 목록을 조회합니다."
     )
-    ResponseEntity<ApiResponse<PageResponse<ReadCouponUserRes>>> getCouponList(Pageable pageable);
+    ResponseEntity<ApiResponse<PageResponse<ReadCouponUserRes>>> getCouponList(@ParameterObject
+                                                                               @PageableDefault(
+                                                                                       size = 20,
+                                                                                       sort = "createdAt",
+                                                                                       direction = Sort.Direction.DESC)
+                                                                               Pageable pageable);
 
     @Operation(
             summary = "쿠폰 상세 조회",

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponManagerController.java
@@ -9,7 +9,10 @@ import com.palja.coupon_service.presentation.dto.request.UpdateCouponReq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,7 +45,12 @@ public interface CouponManagerController {
             summary = "쿠폰 목록 조회",
             description = "생성된 쿠폰 목록을 조회합니다."
     )
-    ResponseEntity<ApiResponse<PageResponse<ReadCouponRes>>> getCouponList(Pageable pageable);
+    ResponseEntity<ApiResponse<PageResponse<ReadCouponRes>>> getCouponList(@ParameterObject
+                                                                           @PageableDefault(
+                                                                                   size = 20,
+                                                                                   sort = "createdAt",
+                                                                                   direction = Sort.Direction.DESC)
+                                                                           Pageable pageable);
 
     @Operation(
             summary = "쿠폰 상세 조회",

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/ChangeCouponStatusReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/ChangeCouponStatusReq.java
@@ -2,17 +2,29 @@ package com.palja.coupon_service.presentation.dto.request;
 
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 import java.util.UUID;
 
 @Getter
 public class ChangeCouponStatusReq {
-    @NotNull(message = "변경할 상태를 입력해주세요.")
+    @NotBlank(message = "변경할 상태를 입력해주세요.")
     @Schema(
-            description = "쿠폰 상태",
-            allowableValues = {"ACTIVE", "INACTIVE", "EXPIRED"},
+            description = """
+                    상태값
+                    [쿠폰 상태]
+                    - ACTIVE: 활성
+                    - PAUSED: 일시정지
+                    - EXPIRED: 만료
+                    - DELETED: 삭제
+                    
+                    [사용자 쿠폰 상태]
+                    - ISSUED: 발행됨
+                    - USED: 사용 완료
+                    - EXPIRED: 만료됨
+                    """,
+            allowableValues = {"ACTIVE", "PAUSED", "EXPIRED", "DELETED", "ISSUED", "USED", "EXPIRED"},
             example = "ACTIVE"
     )
     private String status;

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/ChangeCouponStatusReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/ChangeCouponStatusReq.java
@@ -1,6 +1,7 @@
 package com.palja.coupon_service.presentation.dto.request;
 
 import com.palja.coupon_service.application.command.ChangeCouponStatusCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -9,6 +10,11 @@ import java.util.UUID;
 @Getter
 public class ChangeCouponStatusReq {
     @NotNull(message = "변경할 상태를 입력해주세요.")
+    @Schema(
+            description = "쿠폰 상태",
+            allowableValues = {"ACTIVE", "INACTIVE", "EXPIRED"},
+            example = "ACTIVE"
+    )
     private String status;
 
     public static ChangeCouponStatusCommand of(UUID couponId, ChangeCouponStatusReq request) {

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/CreateCouponReq.java
@@ -1,6 +1,7 @@
 package com.palja.coupon_service.presentation.dto.request;
 
 import com.palja.coupon_service.application.command.CreateCouponCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 
@@ -9,34 +10,45 @@ import java.time.LocalDateTime;
 @Getter
 public class CreateCouponReq {
 
-    @NotNull(message = "쿠폰명은 필수입니다.")
+    @NotBlank(message = "쿠폰명은 필수입니다.")
     @Size(max = 50, message = "쿠폰명은 최대 50자까지 입력 가능합니다.")
+    @Schema(description = "쿠폰명", example = "신규회원 환영 쿠폰")
     private String couponName;
 
+    @Schema(description = "쿠폰 설명", example = "신규 가입 회원에게 제공되는 할인 쿠폰입니다")
     private String description;
 
-    @NotNull(message = "쿠폰 타입은 필수입니다.")
+    @NotBlank(message = "쿠폰 할인 타입은 필수입니다.")
+    @Schema(description = "할인 타입", allowableValues = {"PERCENTAGE", "FIXED"}, example = "PERCENTAGE")
     private String discountType;
 
     @NotNull(message = "할인율은 필수입니다.")
     @Positive(message = "할인율은 0보다 커야합니다.")
+    @Schema(description = "할인율", defaultValue = "10")
     private Integer discountValue;
 
     @Positive(message = "발행 총 수량은 0보다 커야합니다.")
+    @Schema(description = "발행 총 수량", example = "1000")
     private Integer totalQuantity;
 
     @Positive(message = "최대 할인율은 0보다 커야합니다.")
+    @Schema(description = "최대 할인율", example = "10000")
     private Integer maxDiscountAmount;
 
     @Positive(message = "최소 주문 금액은 0보다 커야합니다.")
+    @Schema(description = "최소 주문 금액", example = "10000")
     private Integer minOrderAmount;
 
+    @Schema(description = "발행 시작일")
     private LocalDateTime issueStartAt;
 
     @Future(message = "발급 종료일은 현재 시간 이후여야 합니다")
+    @Schema(description = "발행 종료일")
     private LocalDateTime issueEndAt;
 
+    @NotNull(message = "사용 기간은 필수입니다.")
     @Positive(message = "사용 기간은 0보다 커야합니다.")
+    @Schema(description = "사용 기간", defaultValue = "7")
     private Integer usageDays;
 
     public static CreateCouponCommand of(CreateCouponReq request) {

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/UpdateCouponReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/UpdateCouponReq.java
@@ -1,9 +1,8 @@
 package com.palja.coupon_service.presentation.dto.request;
 
 import com.palja.coupon_service.application.command.UpdateCouponCommand;
-import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Size;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -12,26 +11,36 @@ import java.util.UUID;
 @Getter
 public class UpdateCouponReq {
 
+    @NotBlank(message = "쿠폰명은 필수입니다.")
     @Size(max = 50, message = "쿠폰명은 최대 50자까지 입력 가능합니다.")
+    @Schema(description = "쿠폰명", example = "신규회원 환영 쿠폰")
     private String couponName;
 
+    @Schema(description = "쿠폰 설명", example = "신규 가입 회원에게 제공되는 할인 쿠폰입니다")
     private String description;
 
     @Positive(message = "발행 총 수량은 0보다 커야합니다.")
+    @Schema(description = "발행 총 수량", example = "1000")
     private Integer totalQuantity;
 
     @Positive(message = "최대 할인율은 0보다 커야합니다.")
+    @Schema(description = "최대 할인율", example = "10000")
     private Integer maxDiscountAmount;
 
     @Positive(message = "최소 주문 금액은 0보다 커야합니다.")
+    @Schema(description = "최소 주문 금액", example = "10000")
     private Integer minOrderAmount;
 
+    @Schema(description = "발행 시작일")
     private LocalDateTime issueStartAt;
 
     @Future(message = "발급 종료일은 현재 시간 이후여야 합니다")
+    @Schema(description = "발행 종료일")
     private LocalDateTime issueEndAt;
 
+    @NotNull(message = "사용 기간은 필수입니다.")
     @Positive(message = "사용 기간은 0보다 커야합니다.")
+    @Schema(description = "사용 기간", defaultValue = "7")
     private Integer usageDays;
 
     public static UpdateCouponCommand of(UUID couponId, UpdateCouponReq request) {

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/UseCouponReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/dto/request/UseCouponReq.java
@@ -1,6 +1,7 @@
 package com.palja.coupon_service.presentation.dto.request;
 
 import com.palja.coupon_service.application.command.UseCouponCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
@@ -14,6 +15,7 @@ public class UseCouponReq {
     private UUID orderId;
 
     @Positive(message = "할인 금액은 0보다 커야합니다.")
+    @Schema(description = "할인된 금액", defaultValue = "10000")
     private Long discountAmount;
 
     public static UseCouponCommand of (UUID couponUserId, String userId, UseCouponReq request) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #183 

<br>

## 📌 개요
Swagger 문서화를 개선 및 Response DTO Getter 추가했습니다.

<br>

## 🔁 변경 사항

### 1. Swagger 문서화 개선
- **Request DTO 상세 명세**:
  - `@Schema` 어노테이션으로 각 필드에 설명, 예시값, 제약조건 추가
- **페이징 파라미터 설정**:
  - `@PageableDefault` 어노테이션으로 기본 페이징 설정 명시

### 2. Response DTO 수정
- **@Getter 추가**: 누락된 `@Getter` 어노테이션 추가
- **@JsonInclude 추가**:
  - `ReadCouponRes`, `ReadCouponDetailRes`에 `@JsonInclude(JsonInclude.Include.NON_NULL)` 추가

### 3. Validation 개선
- **@NotBlank 적용**: `@NotNull` → `@NotBlank`로 변경
- **@NotNull 추가**: `usageDays` 필드 필수 검증 추가

### 4. Redis 의존성 추가
- 분산 락 기능 구현 준비 (선착순 쿠폰 발급)

<br>

## 📸 스크린샷

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.