### PR TITLE
FEAT/타임딜 논리 삭제 API 구현

### DIFF
--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/DeleteTimeDealCommand.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/DeleteTimeDealCommand.java
@@ -1,0 +1,15 @@
+package com.palja.timedeal_service.application.command;
+
+import com.palja.common.vo.UserRole;
+
+import java.util.UUID;
+
+public record DeleteTimeDealCommand (
+        UUID timeDealId,
+        String loginId,
+        UserRole role
+) {
+    public static DeleteTimeDealCommand of(UUID timeDealId, String loginId, UserRole role) {
+        return new DeleteTimeDealCommand(timeDealId, loginId, role);
+    }
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
@@ -13,6 +13,7 @@ public interface TimeDealService {
     PageResponse<TimeDealDetailRes> getTimeDeals(Pageable pageable);
     TimeDealDetailRes updateTimeDeal(UpdateTimeDealCommand command);
     TimeDealDetailRes changeTimeDealStatus(ChangeTimeDealStatusCommand command);
+    void deleteTimeDeal(DeleteTimeDealCommand command);
     void decreaseRemainingQuantity(DecreaseRemainingQuantityCommand command);
     void restoreRemainingQuantity(RestoreRemainingQuantityCommand command);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Time;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Slf4j
@@ -126,6 +127,28 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         log.info("타임딜 상태 수정 완료");
         return TimeDealDetailRes.from(timeDeal);
+    }
+
+    @Override
+    @Transactional
+    public void deleteTimeDeal(DeleteTimeDealCommand command) {
+        log.info("타임딜 삭제 시작");
+
+        TimeDeal timeDeal = getActiveTimeDeal(command.timeDealId());
+
+        validateCompanyUser(command.role(), command.loginId(), timeDeal.getCompanyUserId());
+
+        timeDeal.validateDeletableStatus();
+
+        timeDeal.validateDeletablePeriod(LocalDateTime.now());
+
+        long restoreQuantity = timeDeal.getRestoreQuantityOnDelete();
+
+        timeDeal.softDeleteTimeDeal();
+
+        productClient.restoreStock(timeDeal.getProductId(), restoreQuantity);
+
+        log.info("타임딜 삭제 완료");
     }
 
     @Override

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -144,7 +144,7 @@ public class TimeDealServiceImpl implements TimeDealService {
 
         long restoreQuantity = timeDeal.getRestoreQuantityOnDelete();
 
-        timeDeal.softDeleteTimeDeal();
+        timeDeal.softDelete();
 
         productClient.restoreStock(timeDeal.getProductId(), restoreQuantity);
 

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/common/TimeDealErrorCode.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/common/TimeDealErrorCode.java
@@ -43,6 +43,8 @@ public enum TimeDealErrorCode implements ErrorCode {
     TIME_DEAL_STATUS_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "현재 상태와 동일한 상태로는 변경할 수 없습니다."),
     TIME_DEAL_INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "허용되지 않은 상태 변경입니다."),
     TIME_DEAL_STATUS_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "상태 변경 사유는 필수입니다."),
+    TIME_DEAL_NOT_DELETABLE_STATUS(HttpStatus.BAD_REQUEST, "현재 상태에서는 타임딜을 삭제할 수 없습니다. PENDING 상태에서만 삭제 가능합니다."),
+    TIME_DEAL_NOT_DELETABLE_PERIOD(HttpStatus.BAD_REQUEST, "타임딜 시작 시간이 지난 이후에는 삭제할 수 없습니다. 시작 전 상태에서만 삭제가 가능합니다."),
 
     // 외부 관련
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
@@ -171,7 +171,8 @@ public class TimeDeal extends BaseEntity {
         }
     }
 
-    public void softDeleteTimeDeal() {
+    @Override
+    public void softDelete() {
         super.softDelete();
         timeDealStock.softDelete();
         statusHistories.forEach(TimeDealStatusHistory::softDelete);

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
@@ -2,6 +2,7 @@ package com.palja.timedeal_service.domain.entity;
 
 import com.palja.common.entity.BaseEntity;
 import com.palja.common.exception.BusinessException;
+import com.palja.common.exception.ErrorCode;
 import com.palja.timedeal_service.common.TimeDealErrorCode;
 import com.palja.timedeal_service.domain.vo.Amount;
 import com.palja.timedeal_service.domain.vo.Period;
@@ -170,6 +171,16 @@ public class TimeDeal extends BaseEntity {
         }
     }
 
+    public void softDeleteTimeDeal() {
+        super.softDelete();
+        timeDealStock.softDelete();
+        statusHistories.forEach(TimeDealStatusHistory::softDelete);
+    }
+
+    public long getRestoreQuantityOnDelete() {
+        return timeDealStock.getQuantity().getRemainingQuantity();
+    }
+
     public boolean isClosed() {
         return this.timeDealStatus == TimeDealStatus.CLOSED;
     }
@@ -231,6 +242,18 @@ public class TimeDeal extends BaseEntity {
 
         if (reason == null || reason.isBlank()) {
             throw new BusinessException(TimeDealErrorCode.TIME_DEAL_STATUS_REASON_REQUIRED);
+        }
+    }
+
+    public void validateDeletableStatus() {
+        if (!this.timeDealStatus.canDelete()) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_NOT_DELETABLE_STATUS);
+        }
+    }
+
+    public void validateDeletablePeriod(LocalDateTime now) {
+        if (!this.period.isBeforeStartAt(now)) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_NOT_DELETABLE_PERIOD);
         }
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/Period.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/Period.java
@@ -41,8 +41,12 @@ public class Period {
     }
 
     public boolean isNowWithin(LocalDateTime now) {
-        return (now.isEqual(startAt) || now.isAfter(startAt))
-                && (now.isEqual(endAt) || now.isBefore(endAt));
+        return (now.isEqual(this.startAt) || now.isAfter(this.startAt))
+                && (now.isEqual(this.endAt) || now.isBefore(this.endAt));
+    }
+
+    public boolean isBeforeStartAt(LocalDateTime now) {
+        return now.isBefore(this.startAt);
     }
 
     private void validate(LocalDateTime startAt, LocalDateTime endAt) {

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/TimeDealStatus.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/TimeDealStatus.java
@@ -13,6 +13,11 @@ public enum TimeDealStatus {
         public boolean canTransitTo(TimeDealStatus newStatus) {
             return newStatus == OPEN || newStatus == CLOSED;
         }
+
+        @Override
+        public boolean canDelete() {
+            return true;
+        }
     },
 
     OPEN("진행중") {
@@ -24,6 +29,11 @@ public enum TimeDealStatus {
         @Override
         public boolean canTransitTo(TimeDealStatus newStatus) {
             return newStatus == CLOSED;
+        }
+
+        @Override
+        public boolean canDelete() {
+            return false;
         }
     },
 
@@ -37,6 +47,11 @@ public enum TimeDealStatus {
         public boolean canTransitTo(TimeDealStatus newStatus) {
             return false;
         }
+
+        @Override
+        public boolean canDelete() {
+            return false;
+        }
     },
 
     CLOSED("종료") {
@@ -47,6 +62,11 @@ public enum TimeDealStatus {
 
         @Override
         public boolean canTransitTo(TimeDealStatus newStatus) {
+            return false;
+        }
+
+        @Override
+        public boolean canDelete() {
             return false;
         }
     };
@@ -64,4 +84,6 @@ public enum TimeDealStatus {
     public abstract boolean canEditField(TimeDealEditableField field);
 
     public abstract boolean canTransitTo(TimeDealStatus newStatus);
+
+    public abstract boolean canDelete();
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
@@ -103,7 +103,7 @@ public class TimeDealController {
         return ResponseEntity.ok(ApiResponse.success(res, "타임딜 상태 변경에 성공했습니다."));
     }
 
-    @DeleteMapping("{timeDealId}")
+    @DeleteMapping("/{timeDealId}")
     public ResponseEntity<Void> deleteTimeDeal(@PathVariable UUID timeDealId) {
         log.info("DELETE api/v1/time-deals/{} 타임딜 삭제 요청", timeDealId);
 

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
@@ -103,6 +103,18 @@ public class TimeDealController {
         return ResponseEntity.ok(ApiResponse.success(res, "타임딜 상태 변경에 성공했습니다."));
     }
 
+    @DeleteMapping("{timeDealId}")
+    public ResponseEntity<Void> deleteTimeDeal(@PathVariable UUID timeDealId) {
+        log.info("DELETE api/v1/time-deals/{} 타임딜 삭제 요청", timeDealId);
+
+        DeleteTimeDealCommand command = DeleteTimeDealCommand.of(timeDealId, CurrentUser.getLoginId(), CurrentUser.getRole());
+
+        timeDealService.deleteTimeDeal(command);
+
+        log.info("타임딜 삭제 완료");
+        return ResponseEntity.noContent().build();
+    }
+
     @PutMapping("/{timeDealId}/stock/decrease")
     public ResponseEntity<Void> decreaseRemainingQuantity(
             @PathVariable UUID timeDealId,


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #168

<br>

## 📌 개요
- 타임딜 논리 삭제 API 구현

<br>

## 🔁 변경 사항
- 타임딜 삭제 로직 구현
  - MANAGER, 담당 COMPANY_USER만 삭제 가능하도록 권한 검증 추가
  - PENDING 상태에서만 삭제 허용, 그 외 상태는 삭제 불가 처리
  - 타임딜 시작 시간 이전에만 삭제 가능하도록 기간 검증 로직 추가
 
- 타임딜 삭제 시 연관 엔티티까지 함께 논리 삭제 처리
  - TimeDealStock, TimeDealStatusHistory에 대해 soft delete 적용
  - BaseEntity.softDelete()를 활용
  
- 타임딜 삭제 시 상품 재고 복구 처리
  - 삭제 대상 타임딜의 남은 재고 기준으로 ProductService 재고 복구 요청

<br>

## 📸 스크린샷

<details>
  <summary>타임딜 논리 삭제 성공</summary>
<img width="1164" height="382" alt="화면 캡처 2025-12-11 122736" src="https://github.com/user-attachments/assets/4c857a4b-5142-4c92-9e59-abb500d2e12b" />
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
