### PR TITLE
FEAT/주문 생성 시 결제 완료 처리 제거 및 결제 생성 로직 적용

### DIFF
--- a/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
@@ -13,8 +13,6 @@ public record CreateOrderCommand(
         int quantity,
         UUID timeDealId,
         UUID couponUserId,
-        String paymentKey,
-        String paymentMethod,
         DeliveryCommand delivery
 ) {
 }

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -79,6 +79,7 @@ public enum OrderErrorCode implements ErrorCode {
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "결제 시간이 초과되었습니다."),
     INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 수단입니다."),
     INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 키입니다."),
+    PAYMENT_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 생성에 실패했습니다."),
 
     // ===== 권한 관련 =====
     USER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "접근 권한이 없는 사용자입니다."),

--- a/order-service/src/main/java/com/palja/order_service/application/port/PaymentClient.java
+++ b/order-service/src/main/java/com/palja/order_service/application/port/PaymentClient.java
@@ -1,15 +1,15 @@
 package com.palja.order_service.application.port;
 
-import com.palja.order_service.application.dto.PaymentMethod;
 import com.palja.order_service.application.dto.external.PaymentCancelRes;
 import com.palja.order_service.application.dto.external.PaymentCreateRes;
+import com.palja.order_service.domain.vo.OrderStatus;
 
 import java.math.BigDecimal;
 import java.util.UUID;
 
 public interface PaymentClient {
 
-    PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, String paymentKey, PaymentMethod paymentMethod);
+    PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, OrderStatus orderStatus);
 
     PaymentCancelRes cancelPayment(UUID orderId, UUID paymentId, BigDecimal cancelAmount, String cancelReason);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -57,7 +57,7 @@ public class OrderServiceImpl implements OrderService {
      * - 데이터 수집 및 검증
      * - 금액 계산
      * - 주문 엔티티 생성
-     * - 외부 시스템 처리 (재고, 쿠폰, 결제)
+     * - 외부 시스템 처리 (재고, 쿠폰, 결제 생성)
      * - 영속화
      */
     // TODO: Kafka Event 기반 비동기 처리 및 Saga 패턴 적용
@@ -74,14 +74,14 @@ public class OrderServiceImpl implements OrderService {
 
         Order order = createOrderEntity(command, context, amountResult);
         orderRepository.save(order);
-        log.info("주문 엔티티 생성 및 임시 저장 완료 (결제 전): orderId={}", order.getOrderId());
+        log.info("주문 엔티티 생성 및 임시 저장 완료 (외부 시스템 처리 전): orderId={}", order.getOrderId());
 
         // TODO: Kafka Event 발행으로 전환
         processOrderCreationExternalEvents(order, context);
 
         orderRepository.save(order);
-        log.info("주문 생성 완료: orderId={}, finalAmount={}",
-                order.getOrderId(), order.getOrderAmount().getFinalAmount());
+        log.info("주문 생성 완료: orderId={}, status={}, finalAmount={}",
+                order.getOrderId(), order.getStatus(), order.getOrderAmount().getFinalAmount());
 
         return OrderCreateRes.from(order);
     }
@@ -177,12 +177,12 @@ public class OrderServiceImpl implements OrderService {
         );
     }
 
-    // 외부 시스템 처리 (재고, 쿠폰, 결제)
+    // 외부 시스템 처리 (재고, 쿠폰, 결제 생성)
     private void processOrderCreationExternalEvents(Order order, OrderCreationContext context) {
         // TODO: 이벤트 발행으로 대체
         reserveInventory(order, context.timeDeal());
         applyCoupon(order.getCouponUserId(), order.getOrderId(), order.getOrderAmount().getCouponDiscountAmount());
-        executePayment(order, context.customer().getUserId());
+        createPayment(order, context.customer().getUserId());
     }
 
     /**
@@ -227,6 +227,30 @@ public class OrderServiceImpl implements OrderService {
             log.error("쿠폰 사용 실패: orderId={}, couponUserId={}", orderId, couponUserId, e);
             // TODO: 보상 트랜잭션 처리 (재고 복구)
             throw new BusinessException(OrderErrorCode.COUPON_APPLICATION_FAILED);
+        }
+    }
+
+    /**
+     * 결제 생성 (결제 완료 아님)
+     * - 결제 엔티티만 생성
+     * - 주문 상태는 CREATED 유지
+     * - 결제 완료는 별도 API를 통해 처리
+     */
+    // TODO: 이벤트 기반 처리
+    private void createPayment(Order order, Long userId) {
+        try {
+            PaymentCreateRes payment = paymentClient.createPayment(
+                    order.getOrderId(), userId, order.getOrderAmount().getFinalAmount(), order.getStatus()
+            );
+
+            order.registerPaymentId(payment.getPaymentId());
+            log.info("결제 생성 완료: orderId={}, paymentId={}, amount={}, orderStatus={}",
+                    order.getOrderId(), payment.getPaymentId(), payment.getAmount(), order.getStatus());
+        } catch (Exception e) {
+            log.error("결제 생성 실패: orderId={}, amount={}",
+                    order.getOrderId(), order.getOrderAmount().getFinalAmount(), e);
+            // TODO: 보상 트랜잭션 처리 (재고 복구, 쿠폰 복구)
+            throw new BusinessException(OrderErrorCode.PAYMENT_CREATION_FAILED);
         }
     }
 

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -114,23 +114,12 @@ public class OrderServiceImpl implements OrderService {
             log.debug("쿠폰 검증 완료: couponUserId={}", command.couponUserId());
         }
 
-        // paymentKey 검증
-        if (command.paymentKey() == null || command.paymentKey().isBlank()) {
-            throw new BusinessException(OrderErrorCode.INVALID_PAYMENT_KEY);
-        }
-        log.debug("결제 키 검증 완료: paymentKey={}", command.paymentKey());
-
-        PaymentMethod paymentMethod = PaymentMethod.from(command.paymentMethod());
-        log.debug("결제 수단 검증 완료: paymentMethod={}", paymentMethod);
-
         return new OrderCreationContext(
                 customer,
                 product,
                 timeDeal,
                 coupon,
-                command.quantity(),
-                command.paymentKey(),
-                paymentMethod
+                command.quantity()
         );
     }
 
@@ -193,7 +182,7 @@ public class OrderServiceImpl implements OrderService {
         // TODO: 이벤트 발행으로 대체
         reserveInventory(order, context.timeDeal());
         applyCoupon(order.getCouponUserId(), order.getOrderId(), order.getOrderAmount().getCouponDiscountAmount());
-        executePayment(order, context.customer().getUserId(), context.paymentKey(), context.paymentMethod());
+        executePayment(order, context.customer().getUserId());
     }
 
     /**
@@ -243,10 +232,10 @@ public class OrderServiceImpl implements OrderService {
 
     // 결제 실행
     // TODO: 이벤트 기반 처리
-    private void executePayment(Order order, Long userId, String paymentKey, PaymentMethod paymentMethod) {
+    private void executePayment(Order order, Long userId) {
         try {
             PaymentCreateRes payment = paymentClient.createPayment(
-                    order.getOrderId(), userId, order.getOrderAmount().getFinalAmount(), paymentKey, paymentMethod
+                    order.getOrderId(), userId, order.getOrderAmount().getFinalAmount(), order.getStatus()
             );
 
             order.markAsPaid(payment.getPaymentId());
@@ -528,9 +517,7 @@ public class OrderServiceImpl implements OrderService {
             ProductRes product,
             Optional<TimeDealRes> timeDeal,
             Optional<CouponUserRes> coupon,
-            int quantity,
-            String paymentKey,
-            PaymentMethod paymentMethod
+            int quantity
     ) {}
 
     // 권한 검증 컨텍스트

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
@@ -270,4 +270,22 @@ public class Order extends BaseEntity {
         // 직접 상태 변경 (일반 전환 규칙 무시)
         this.status = targetStatus;
     }
+
+    /**
+     * 결제 ID 등록 (결제 생성 시)
+     * - 결제 완료 전 상태
+     */
+    public void registerPaymentId(UUID paymentId) {
+        registerPaymentIdRegistration(paymentId);
+        this.paymentId = paymentId;
+    }
+
+    private void registerPaymentIdRegistration(UUID paymentId) {
+        if (paymentId == null) {
+            throw new IllegalArgumentException("결제 ID는 필수입니다.");
+        }
+        if (this.paymentId != null) {
+            throw new IllegalStateException("이미 결제 ID가 할당된 주문입니다.");
+        }
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/PaymentAdapter.java
@@ -1,11 +1,11 @@
 package com.palja.order_service.infrastructure.external.adapter;
 
 import com.palja.common.exception.BusinessException;
-import com.palja.order_service.application.dto.PaymentMethod;
 import com.palja.order_service.application.dto.external.PaymentCancelRes;
 import com.palja.order_service.application.dto.external.PaymentCreateRes;
 import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.port.PaymentClient;
+import com.palja.order_service.domain.vo.OrderStatus;
 import com.palja.order_service.infrastructure.external.PaymentFeignClient;
 import com.palja.order_service.infrastructure.external.dto.request.CancelPaymentDTO;
 import com.palja.order_service.infrastructure.external.dto.request.CreatePaymentDTO;
@@ -27,11 +27,11 @@ public class PaymentAdapter implements PaymentClient {
     private final PaymentFeignClient paymentFeignClient;
 
     @Override
-    public PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, String paymentKey, PaymentMethod paymentMethod) {
-        log.debug("결제 생성 요청: orderId={}, userId={}, amount={}, paymentMethod={}",
-                orderId, userId, amount, paymentMethod);
+    public PaymentCreateRes createPayment(UUID orderId, Long userId, BigDecimal amount, OrderStatus orderStatus) {
+        log.debug("결제 생성 요청: orderId={}, userId={}, amount={}, orderStatus={}",
+                orderId, userId, amount, orderStatus);
         try {
-            CreatePaymentDTO request = new CreatePaymentDTO(orderId, amount, paymentMethod, "KRW", paymentKey);
+            CreatePaymentDTO request = new CreatePaymentDTO(orderId, userId, amount, orderStatus);
             PaymentCreateDTO dto = paymentFeignClient.createPayment(request).data();
             log.info("결제 생성 성공: paymentId={}", dto.getPaymentId());
             return dto.toResponse();

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CreatePaymentDTO.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/dto/request/CreatePaymentDTO.java
@@ -1,6 +1,6 @@
 package com.palja.order_service.infrastructure.external.dto.request;
 
-import com.palja.order_service.application.dto.PaymentMethod;
+import com.palja.order_service.domain.vo.OrderStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +12,8 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreatePaymentDTO {
-
     private UUID orderId;
+    private Long userId;
     private BigDecimal amount;
-    private PaymentMethod paymentMethod;
-    private String currency;
-    private String paymentKey;
+    private OrderStatus orderStatus;
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
@@ -28,12 +28,6 @@ public class CreateOrderReq {
 
     private UUID couponUserId;
 
-    @NotBlank(message = "결제 Key는 필수입니다.")
-    private String paymentKey;
-
-    @NotBlank(message = "결제 수단은 필수입니다.")
-    private String paymentMethod;
-
     @NotNull(message = "배송 정보는 필수입니다.")
     @Valid
     private DeliveryReq delivery;
@@ -46,8 +40,6 @@ public class CreateOrderReq {
                 .quantity(quantity)
                 .timeDealId(timeDealId)
                 .couponUserId(couponUserId)
-                .paymentKey(paymentKey)
-                .paymentMethod(paymentMethod)
                 .delivery(delivery.toCommand())
                 .build();
     }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #195 

<br>

## 📌 개요
- 주문 생성 시 처리되던 결제 완료 로직을 제거하고,
주문 생성 단계에서는 결제 생성만 수행하도록 구조를 변경했습니다.

<br>

## 🔁 변경 사항
- 주문 생성 요청 DTO에서 불필요한 결제 관련 필드 제거
- 주문 생성 시 결제 생성(createPayment) 로직 적용
- 결제 생성 성공 시 paymentId만 주문에 등록
- 주문 상태는 항상 CREATED 상태로 유지
- 기존 “주문 생성 시 즉시 PAID로 변경” 로직 제거
- 결제 생성 실패 시 예외 처리 및 보상 트랜잭션 TODO 추가
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
- 결제 완료 처리는 별도 API에서 담당할 예정입니다.
<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.