### PR TITLE
FEAT/주문 생성 AFTER_COMMIT 이벤트 기반 외부 연동 로직 구현

### DIFF
--- a/order-service/src/main/java/com/palja/order_service/application/event/OrderCreatedEvent.java
+++ b/order-service/src/main/java/com/palja/order_service/application/event/OrderCreatedEvent.java
@@ -1,0 +1,61 @@
+package com.palja.order_service.application.event;
+
+import com.palja.order_service.domain.entity.Order;
+import com.palja.order_service.domain.vo.OrderStatus;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * 주문 생성 완료 이벤트
+ * - 트랜잭션 커밋 후 외부 시스템 처리를 위한 이벤트
+ * - Order 엔티티에서 필요한 모든 정보를 조회 가능
+ */
+public record OrderCreatedEvent(
+        Order order
+) {
+    public static OrderCreatedEvent from(Order order) {
+        return new OrderCreatedEvent(order);
+    }
+
+    // 편의 메서드
+    public UUID getOrderId() {
+        return order.getOrderId();
+    }
+
+    public UUID getProductId() {
+        return order.requireOrderItem().getProductId();
+    }
+
+    public int getQuantity() {
+        return order.requireOrderItem().getQuantity();
+    }
+
+    public UUID getTimeDealId() {
+        return order.requireOrderItem().getTimeDealId();
+    }
+
+    public boolean isTimeDealOrder() {
+        return order.isTimeDealOrder();
+    }
+
+    public UUID getCouponUserId() {
+        return order.getCouponUserId();
+    }
+
+    public Long getUserId() {
+        return order.getUserId();
+    }
+
+    public BigDecimal getFinalAmount() {
+        return order.getOrderAmount().getFinalAmount();
+    }
+
+    public OrderStatus getStatus() {
+        return order.getStatus();
+    }
+
+    public BigDecimal getCouponDiscountAmount() {
+        return order.getOrderAmount().getCouponDiscountAmount();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/event/listener/OrderCreatedEventListener.java
+++ b/order-service/src/main/java/com/palja/order_service/application/event/listener/OrderCreatedEventListener.java
@@ -1,0 +1,121 @@
+package com.palja.order_service.application.event.listener;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.order_service.application.dto.external.PaymentCreateRes;
+import com.palja.order_service.application.event.OrderCreatedEvent;
+import com.palja.order_service.application.exception.OrderErrorCode;
+import com.palja.order_service.application.port.CouponClient;
+import com.palja.order_service.application.port.PaymentClient;
+import com.palja.order_service.application.port.ProductClient;
+import com.palja.order_service.application.port.TimeDealClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.UUID;
+
+/**
+ * 주문 생성 이벤트 리스너
+ * - 트랜잭션 커밋 후(AFTER_COMMIT) 외부 시스템 처리
+ * - 재고 차감, 쿠폰 사용, 결제 생성
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCreatedEventListener {
+
+    private final ProductClient productClient;
+    private final TimeDealClient timeDealClient;
+    private final CouponClient couponClient;
+    private final PaymentClient paymentClient;
+
+    /**
+     * 주문 생성 완료 후 외부 시스템 처리
+     * - 주문 생성 트랜잭션이 커밋된 후에 실행
+     * - 주문 데이터가 DB에 확실히 저장된 상태
+     * - 이 메서드에서 예외 발생 시 주문 생성 트랜잭션은 영향 받지 않음
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCreated(OrderCreatedEvent event) {
+        log.info("[AFTER_COMMIT] 주문 생성 이벤트 처리 시작: orderId={}", event.getOrderId());
+
+        try {
+            reserveInventory(event);
+            applyCoupon(event);
+            createPayment(event);
+
+            log.info("[AFTER_COMMIT] 주문 생성 이벤트 처리 완료: orderId={}", event.getOrderId());
+        } catch (Exception e) {
+            log.error("[AFTER_COMMIT] 주문 생성 이벤트 처리 실패: orderId={}", event.getOrderId(), e);
+            // TODO: 실패 시 보상 트랜잭션 처리
+        }
+    }
+
+    /**
+     * 재고 차감
+     * - 타임딜 주문: 타임딜 재고만 차감
+     * - 일반 주문: 상품 재고만 차감
+     */
+    private void reserveInventory(OrderCreatedEvent event) {
+        try {
+            if (event.isTimeDealOrder()) {
+                UUID timeDealId = event.getTimeDealId();
+                timeDealClient.deductTimeDealStock(timeDealId, (long) event.getQuantity());
+                log.info("타임딜 재고 차감 완료: orderId={}, timeDealId={}, quantity={}",
+                        event.getOrderId(), timeDealId, event.getQuantity());
+            } else {
+                productClient.deductProductStock(event.getProductId(), event.getQuantity());
+                log.info("상품 재고 차감 완료: orderId={}, productId={}, quantity={}",
+                        event.getOrderId(), event.getProductId(), event.getQuantity());
+            }
+        } catch (Exception e) {
+            log.error("재고 차감 실패: orderId={}, productId={}, isTimeDeal={}",
+                    event.getOrderId(), event.getProductId(), event.isTimeDealOrder(), e);
+            // TODO: 보상 트랜잭션 처리
+            throw new BusinessException(OrderErrorCode.INVENTORY_DEDUCTION_FAILED);
+        }
+    }
+
+    // 쿠폰 사용
+    private void applyCoupon(OrderCreatedEvent event) {
+        UUID couponUserId = event.getCouponUserId();
+        if (couponUserId == null) {
+            return;
+        }
+
+        try {
+            couponClient.useCoupon(couponUserId, event.getOrderId(), event.getCouponDiscountAmount());
+            log.info("쿠폰 사용 완료: orderId={}, couponUserId={}", event.getOrderId(), couponUserId);
+        } catch (Exception e) {
+            log.error("쿠폰 사용 실패: orderId={}, couponUserId={}", event.getOrderId(), couponUserId, e);
+            // TODO: 보상 트랜잭션 처리 (재고 복구)
+            throw new BusinessException(OrderErrorCode.COUPON_APPLICATION_FAILED);
+        }
+    }
+
+    /**
+     * 결제 생성 (결제 완료 아님)
+     * - 결제 엔티티만 생성 (paymentId는 결제 완료 시 저장)
+     * - 주문 상태는 CREATED 유지
+     */
+    private void createPayment(OrderCreatedEvent event) {
+        try {
+            PaymentCreateRes payment = paymentClient.createPayment(
+                    event.getOrderId(),
+                    event.getUserId(),
+                    event.getFinalAmount(),
+                    event.getStatus()
+            );
+
+            log.info("결제 생성 완료: orderId={}, paymentId={}, amount={}",
+                    event.getOrderId(), payment.getPaymentId(), payment.getAmount());
+        } catch (Exception e) {
+            log.error("결제 생성 실패: orderId={}, amount={}",
+                    event.getOrderId(), event.getFinalAmount(), e);
+            // TODO: 보상 트랜잭션 처리 (재고 복구, 쿠폰 복구)
+            throw new BusinessException(OrderErrorCode.PAYMENT_CREATION_FAILED);
+        }
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -5,12 +5,15 @@ import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CancelOrderCommand;
 import com.palja.order_service.application.command.CreateOrderCommand;
-import com.palja.order_service.application.dto.PaymentMethod;
 import com.palja.order_service.application.dto.external.*;
-import com.palja.order_service.application.dto.response.*;
+import com.palja.order_service.application.dto.response.CustomerOrderSummaryRes;
+import com.palja.order_service.application.dto.response.OrderCancelRes;
+import com.palja.order_service.application.dto.response.OrderCreateRes;
+import com.palja.order_service.application.dto.response.OrderDetailRes;
+import com.palja.order_service.application.event.OrderCreatedEvent;
 import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.port.*;
-import com.palja.order_service.application.service.*;
+import com.palja.order_service.application.service.OrderService;
 import com.palja.order_service.application.service.calculator.OrderPriceCalculator;
 import com.palja.order_service.application.service.validator.OrderValidator;
 import com.palja.order_service.domain.entity.Order;
@@ -21,6 +24,7 @@ import com.palja.order_service.domain.vo.Recipient;
 import com.palja.order_service.presentation.dto.request.CustomerOrderSearchReq;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -50,6 +54,8 @@ public class OrderServiceImpl implements OrderService {
     private final OrderValidator orderValidator;
     private final OrderPriceCalculator orderPriceCalculator;
 
+    private final ApplicationEventPublisher eventPublisher;
+
     // ====== Order Creation Workflow ======
     /**
      * 주문 생성
@@ -74,12 +80,11 @@ public class OrderServiceImpl implements OrderService {
 
         Order order = createOrderEntity(command, context, amountResult);
         orderRepository.save(order);
-        log.info("주문 엔티티 생성 및 임시 저장 완료 (외부 시스템 처리 전): orderId={}", order.getOrderId());
+        log.info("주문 엔티티 저장 완료: orderId={}, status={}", order.getOrderId(), order.getStatus());
 
         // TODO: Kafka Event 발행으로 전환
-        processOrderCreationExternalEvents(order, context);
+        publishOrderCreatedEvent(order);
 
-        orderRepository.save(order);
         log.info("주문 생성 완료: orderId={}, status={}, finalAmount={}",
                 order.getOrderId(), order.getStatus(), order.getOrderAmount().getFinalAmount());
 
@@ -177,81 +182,14 @@ public class OrderServiceImpl implements OrderService {
         );
     }
 
-    // 외부 시스템 처리 (재고, 쿠폰, 결제 생성)
-    private void processOrderCreationExternalEvents(Order order, OrderCreationContext context) {
-        // TODO: 이벤트 발행으로 대체
-        reserveInventory(order, context.timeDeal());
-        applyCoupon(order.getCouponUserId(), order.getOrderId(), order.getOrderAmount().getCouponDiscountAmount());
-        createPayment(order, context.customer().getUserId());
-    }
-
     /**
-     * 재고 차감
-     * - 타임딜 주문: 타임딜 재고만 차감
-     * - 일반 주문: 상품 재고만 차감
+     * 주문 생성 이벤트 발행
+     * - 트랜잭션이 커밋된 후 리스너가 실행됨
      */
-    // TODO: 이벤트 기반 처리
-    private void reserveInventory(Order order, Optional<TimeDealRes> timeDeal) {
-        UUID productId = order.getOrderItem().getProductId();
-        int quantity = order.getOrderItem().getQuantity();
-
-        try {
-            if (timeDeal.isPresent()) {
-                TimeDealRes deal = timeDeal.get();
-                timeDealClient.deductTimeDealStock(deal.getTimeDealId(), (long) quantity);
-                log.info("타임딜 재고 차감 완료: timeDealId={}, quantity={}",
-                        deal.getTimeDealId(), quantity);
-            } else {
-                productClient.deductProductStock(productId, quantity);
-                log.info("상품 재고 차감 완료: productId={}, quantity={}", productId, quantity);
-            }
-        } catch (Exception e) {
-            log.error("재고 차감 실패: orderId={}, productId={}, isTimeDeal={}",
-                    order.getOrderId(), productId, timeDeal.isPresent(), e);
-            // TODO: 보상 트랜잭션 처리
-            throw new BusinessException(OrderErrorCode.INVENTORY_DEDUCTION_FAILED);
-        }
-    }
-
-    // 쿠폰 사용
-    // TODO: 이벤트 기반 처리
-    private void applyCoupon(UUID couponUserId, UUID orderId, BigDecimal couponDiscountAmount) {
-        if (couponUserId == null) {
-            return;
-        }
-
-        try {
-            couponClient.useCoupon(couponUserId, orderId, couponDiscountAmount);
-            log.info("쿠폰 사용 완료: couponUserId={}, orderId={}", couponUserId, orderId);
-        } catch (Exception e) {
-            log.error("쿠폰 사용 실패: orderId={}, couponUserId={}", orderId, couponUserId, e);
-            // TODO: 보상 트랜잭션 처리 (재고 복구)
-            throw new BusinessException(OrderErrorCode.COUPON_APPLICATION_FAILED);
-        }
-    }
-
-    /**
-     * 결제 생성 (결제 완료 아님)
-     * - 결제 엔티티만 생성
-     * - 주문 상태는 CREATED 유지
-     * - 결제 완료는 별도 API를 통해 처리
-     */
-    // TODO: 이벤트 기반 처리
-    private void createPayment(Order order, Long userId) {
-        try {
-            PaymentCreateRes payment = paymentClient.createPayment(
-                    order.getOrderId(), userId, order.getOrderAmount().getFinalAmount(), order.getStatus()
-            );
-
-            order.registerPaymentId(payment.getPaymentId());
-            log.info("결제 생성 완료: orderId={}, paymentId={}, amount={}, orderStatus={}",
-                    order.getOrderId(), payment.getPaymentId(), payment.getAmount(), order.getStatus());
-        } catch (Exception e) {
-            log.error("결제 생성 실패: orderId={}, amount={}",
-                    order.getOrderId(), order.getOrderAmount().getFinalAmount(), e);
-            // TODO: 보상 트랜잭션 처리 (재고 복구, 쿠폰 복구)
-            throw new BusinessException(OrderErrorCode.PAYMENT_CREATION_FAILED);
-        }
+    private void publishOrderCreatedEvent(Order order) {
+        OrderCreatedEvent event = OrderCreatedEvent.from(order);
+        eventPublisher.publishEvent(event);
+        log.debug("주문 생성 이벤트 발행 완료: orderId={}", order.getOrderId());
     }
 
     // 결제 실행


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #219 

<br>

## 📌 개요
- 주문 생성 시점에 동기적으로 처리하던 재고 차감, 쿠폰 사용, 결제 생성 로직을  **AFTER_COMMIT 주문 생성 이벤트 기반**으로 분리했습니다.

<br>

## 🔁 변경 사항
- `OrderCreatedEvent` 발행 구조 추가
- `OrderCreatedEventListener` 구현
  - `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)` 적용
  - 주문 생성 트랜잭션 커밋 이후에만 외부 시스템 호출 수행
- 재고 차감 로직 분리
  - 타임딜 주문: `TimeDealClient.deductTimeDealStock` 호출
  - 일반 주문: `ProductClient.deductProductStock` 호출
- 쿠폰 사용 로직 분리
  - `CouponClient.useCoupon(couponUserId, orderId, discountAmount)` 호출
- 결제 생성 로직 분리
  - `PaymentClient.createPayment(orderId, userId, finalAmount, status)` 호출
  - 결제 엔티티만 생성하며, 주문 상태는 CREATED 유지
- 외부 연동 실패 시 `BusinessException` 처리 및 보상 트랜잭션 TODO 추가
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
- 현재는 AFTER_COMMIT 이벤트 리스너에서 실패 시 예외만 던지고 있으며,
  재고/쿠폰/결제 생성 실패에 대한 **보상 트랜잭션 정책**은 추후 별도 이슈로 정리할 예정입니다.
<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
