### PR TITLE
FEAT/주문 생성에 Manager 권한 허용 기능 추가

### DIFF
--- a/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/CreateOrderCommand.java
@@ -1,5 +1,6 @@
 package com.palja.order_service.application.command;
 
+import com.palja.common.vo.UserRole;
 import lombok.Builder;
 
 import java.util.UUID;
@@ -9,6 +10,7 @@ import java.util.UUID;
 @Builder
 public record CreateOrderCommand(
         String loginId,
+        UserRole userRole,
         UUID productId,
         int quantity,
         UUID timeDealId,

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -85,6 +85,9 @@ public enum OrderErrorCode implements ErrorCode {
     USER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "접근 권한이 없는 사용자입니다."),
     ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "주문에 접근할 권한이 없습니다."),
     ORDER_MODIFICATION_DENIED(HttpStatus.FORBIDDEN, "주문을 수정할 권한이 없습니다."),
+    USER_NOT_ACTIVE(HttpStatus.FORBIDDEN, "비활성 상태의 사용자입니다."),
+    ORDER_CREATION_NOT_ALLOWED_FOR_COMPANY_USER(HttpStatus.FORBIDDEN, "판매업체 사용자는 주문을 생성할 수 없습니다."),
+    INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 권한입니다."),
 
     // ===== 외부 서비스 연동 오류 =====
     PRODUCT_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "상품 서비스 연동 중 오류가 발생했습니다."),

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -83,6 +83,7 @@ public class OrderServiceImpl implements OrderService {
         log.info("주문 엔티티 저장 완료: orderId={}, status={}", order.getOrderId(), order.getStatus());
 
         // TODO: Kafka Event 발행으로 전환
+        // 이벤트 발행 (트랜잭션 커밋 후 실행)
         publishOrderCreatedEvent(order);
 
         log.info("주문 생성 완료: orderId={}, status={}, finalAmount={}",
@@ -93,9 +94,9 @@ public class OrderServiceImpl implements OrderService {
 
     // 주문 생성에 필요한 데이터 수집 및 검증
     private OrderCreationContext collectAndValidateOrderData(CreateOrderCommand command) {
-        CustomerUserRes customer = userClient.getMyCustomer(command.loginId());
-        orderValidator.validateCustomerForOrder(customer);
-        log.debug("고객 검증 완료: userId={}", customer.getUserId());
+        // 사용자 정보 조회 및 검증 (권한에 따라 다른 API 호출)
+        Long userId = resolveAndValidateUserId(command.loginId(), command.userRole());
+        log.debug("사용자 검증 완료: userId={}, userRole={}", userId, command.userRole());
 
         ProductRes product = productClient.getProduct(command.productId());
         orderValidator.validateProductForOrder(product, command.quantity());
@@ -120,12 +121,40 @@ public class OrderServiceImpl implements OrderService {
         }
 
         return new OrderCreationContext(
-                customer,
+                userId,
                 product,
                 timeDeal,
                 coupon,
                 command.quantity()
         );
+    }
+
+    /**
+     * 사용자 ID 조회 및 검증
+     * - CUSTOMER: 고객 정보 조회 및 검증
+     * - MANAGER: 매니저 정보 조회 및 검증
+     * - COMPANY_USER: 주문 생성 불가
+     */
+    private Long resolveAndValidateUserId(String loginId, UserRole userRole) {
+        switch (userRole) {
+            case CUSTOMER:
+                CustomerUserRes customer = userClient.getMyCustomer(loginId);
+                orderValidator.validateCustomerForOrder(customer);
+                return customer.getUserId();
+
+            case MANAGER:
+                ManagerUserRes manager = userClient.getMyManager(loginId);
+                orderValidator.validateManagerForOrder(manager);
+                return manager.getUserId();
+
+            case COMPANY_USER:
+                throw new BusinessException(
+                        OrderErrorCode.ORDER_CREATION_NOT_ALLOWED_FOR_COMPANY_USER
+                );
+
+            default:
+                throw new BusinessException(OrderErrorCode.INVALID_USER_ROLE);
+        }
     }
 
     // 주문 금액 계산
@@ -167,7 +196,7 @@ public class OrderServiceImpl implements OrderService {
         Recipient recipient = createRecipient(command);
 
         return Order.create(
-                context.customer().getUserId(),
+                context.userId(),
                 command.productId(),
                 context.product().getProductName(),
                 context.product().getPrice(),
@@ -475,7 +504,7 @@ public class OrderServiceImpl implements OrderService {
     // ===== Internal Context Objects =====
     // 주문 생성 컨텍스트
     private record OrderCreationContext(
-            CustomerUserRes customer,
+            Long userId,
             ProductRes product,
             Optional<TimeDealRes> timeDeal,
             Optional<CouponUserRes> coupon,

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
@@ -6,10 +6,7 @@ import com.palja.order_service.application.command.CreateOrderCommand;
 import com.palja.order_service.application.command.DeliveryCommand;
 import com.palja.order_service.application.dto.CouponDiscountType;
 import com.palja.order_service.application.dto.CouponUserStatus;
-import com.palja.order_service.application.dto.external.CouponUserRes;
-import com.palja.order_service.application.dto.external.CustomerUserRes;
-import com.palja.order_service.application.dto.external.ProductRes;
-import com.palja.order_service.application.dto.external.TimeDealRes;
+import com.palja.order_service.application.dto.external.*;
 import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.port.UserClient;
 import com.palja.order_service.domain.entity.Order;
@@ -135,13 +132,46 @@ public class OrderValidator {
     }
     private void validateCustomerStatus(CustomerUserRes customer) {
         if (!"ACTIVE".equals(customer.getStatus())) {
-            throw new BusinessException(OrderErrorCode.INVALID_USER_ID);
+            throw new BusinessException(OrderErrorCode.USER_NOT_ACTIVE);
         }
     }
 
     private void validateCustomerRole(CustomerUserRes customer) {
         if (UserRole.COMPANY_USER.equals(customer.getRole())) {
             throw new BusinessException(OrderErrorCode.USER_NOT_ALLOWED);
+        }
+    }
+
+// ===== Manager Validation (매니저 검증) =====
+    /**
+     * 주문 가능한 매니저인지 검증
+     */
+    public void validateManagerForOrder(ManagerUserRes manager) {
+        log.debug("매니저 검증 시작: userId={}, status={}, role={}",
+                manager.getUserId(), manager.getStatus(), manager.getRole());
+
+        validateManagerNotNull(manager);
+        validateManagerStatus(manager);
+        validateManagerRole(manager);
+
+        log.debug("매니저 검증 완료: userId={}", manager.getUserId());
+    }
+
+    private void validateManagerNotNull(ManagerUserRes manager) {
+        if (manager == null) {
+            throw new BusinessException(OrderErrorCode.INVALID_USER_ID);
+        }
+    }
+
+    private void validateManagerStatus(ManagerUserRes manager) {
+        if (!"ACTIVE".equals(manager.getStatus())) {
+            throw new BusinessException(OrderErrorCode.USER_NOT_ACTIVE);
+        }
+    }
+
+    private void validateManagerRole(ManagerUserRes manager) {
+        if (!UserRole.MANAGER.equals(manager.getRole())) {
+            throw new BusinessException(OrderErrorCode.INVALID_USER_ROLE);
         }
     }
 

--- a/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
+++ b/order-service/src/main/java/com/palja/order_service/infrastructure/external/adapter/UserAdapter.java
@@ -66,10 +66,10 @@ public class UserAdapter implements UserClient {
 
     @Override
     public ManagerUserRes getMyManager(String loginId) {
-        log.debug("MANAGER 사용자 조회 요청: loginId={}", loginId);
+        log.debug("매니저 사용자 조회 요청: loginId={}", loginId);
         try {
             ManagerUserDTO dto = userFeignClient.getMyManager().data();
-            log.info("MANAGER 사용자 조회 성공: userId={}", dto.getUserId());
+            log.info("매니저 사용자 조회 성공: userId={}", dto.getUserId());
             return dto.toResponse();
         } catch (FeignException.NotFound e) {
             log.error("사용자 정보 없음: loginId={}", loginId, e);
@@ -79,7 +79,7 @@ public class UserAdapter implements UserClient {
                     loginId, e.status(), e.getMessage(), e);
             throw new BusinessException(OrderErrorCode.USER_SERVICE_UNAVAILABLE);
         } catch (Exception e) {
-            log.error("MANAGER 사용자 조회 중 예상치 못한 오류: loginId={}, error={}",
+            log.error("매니저 사용자 조회 중 예상치 못한 오류: loginId={}, error={}",
                     loginId, e.getClass().getName(), e);
             throw new BusinessException(OrderErrorCode.USER_SERVICE_UNAVAILABLE);
         }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
@@ -37,10 +37,7 @@ public class OrderController {
     public ResponseEntity<ApiResponse<OrderCreateRes>> createOrder(
             @Valid @RequestBody CreateOrderReq request
         ) {
-
-        // Request → Command 변환
-        OrderCreateRes response = orderService.createOrder(request.toCommand(CurrentUser.getLoginId()));
-
+        OrderCreateRes response = orderService.createOrder(request.toCommand(CurrentUser.getLoginId(), CurrentUser.getRole()));
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response, "주문이 생성되었습니다."));

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
@@ -1,9 +1,9 @@
 package com.palja.order_service.presentation.dto.request;
 
+import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CreateOrderCommand;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -33,9 +33,10 @@ public class CreateOrderReq {
     private DeliveryReq delivery;
 
     // Request → Command 변환
-    public CreateOrderCommand toCommand(String loginId) {
+    public CreateOrderCommand toCommand(String loginId, UserRole userRole) {
         return CreateOrderCommand.builder()
                 .loginId(loginId)
+                .userRole(userRole)
                 .productId(productId)
                 .quantity(quantity)
                 .timeDealId(timeDealId)


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #223 

<br>

## 📌 개요
- 주문 생성 API에서 MANAGER 권한을 허용하도록 확장했습니다.
- 관리자(운영자)가 주문을 생성할 수 있도록 권한 검증 로직을 추가했습니다.

<br>

## 🔁 변경 사항
- 주문 생성 시 Manager 사용자 검증 로직 추가
- 사용자 권한(CUSTOMER / MANAGER)에 따른 분기 처리 적용
- Manager 사용자 조회 및 예외 처리 로직 보완

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
