### PR TITLE
FEAT/업체 판매자 관련 타임딜 삭제 API 구현

### DIFF
--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
@@ -16,4 +16,5 @@ public interface TimeDealService {
     void deleteTimeDeal(DeleteTimeDealCommand command);
     void decreaseRemainingQuantity(DecreaseRemainingQuantityCommand command);
     void restoreRemainingQuantity(RestoreRemainingQuantityCommand command);
+    void deleteByCompanyUser(UUID companyUserId);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -27,6 +27,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Time;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Slf4j
@@ -139,7 +142,6 @@ public class TimeDealServiceImpl implements TimeDealService {
         validateCompanyUser(command.role(), command.loginId(), timeDeal.getCompanyUserId());
 
         timeDeal.validateDeletableStatus();
-
         timeDeal.validateDeletablePeriod(LocalDateTime.now());
 
         long restoreQuantity = timeDeal.getRestoreQuantityOnDelete();
@@ -177,6 +179,36 @@ public class TimeDealServiceImpl implements TimeDealService {
         }
 
         log.info("타임딜 남은 수량 복구 성공");
+    }
+
+    @Override
+    @Transactional
+    public void deleteByCompanyUser(UUID companyUserId) {
+        log.info("업체 판매자 관련 타임딜 삭제 시작");
+
+        LocalDateTime now = LocalDateTime.now();
+
+        Map<UUID, Long> totalRestoreQuantity = new HashMap<>();
+        List<TimeDeal> timeDeals = timeDealRepository.findAllByCompanyUserId(companyUserId, TimeDealStatus.PENDING, now);
+
+        for (TimeDeal timeDeal : timeDeals) {
+            if (!timeDeal.isDeletable(now)) {
+                continue;
+            }
+
+            long restoreQuantity = timeDeal.getRestoreQuantityOnDelete();
+            totalRestoreQuantity.merge(timeDeal.getProductId(), restoreQuantity, Long::sum);
+
+            timeDeal.softDelete();
+        }
+
+        if (!totalRestoreQuantity.isEmpty()) {
+            for (var e : totalRestoreQuantity.entrySet()) {
+                productClient.restoreStock(e.getKey(), e.getValue());
+            }
+        }
+
+        log.info("업체 판매자 관련 타임딜 삭제 완료");
     }
 
     private void updateTimeDealFields(TimeDeal timeDeal, UpdateTimeDealCommand command) {

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
@@ -2,7 +2,6 @@ package com.palja.timedeal_service.domain.entity;
 
 import com.palja.common.entity.BaseEntity;
 import com.palja.common.exception.BusinessException;
-import com.palja.common.exception.ErrorCode;
 import com.palja.timedeal_service.common.TimeDealErrorCode;
 import com.palja.timedeal_service.domain.vo.Amount;
 import com.palja.timedeal_service.domain.vo.Period;
@@ -175,11 +174,16 @@ public class TimeDeal extends BaseEntity {
     public void softDelete() {
         super.softDelete();
         timeDealStock.softDelete();
-        statusHistories.forEach(TimeDealStatusHistory::softDelete);
     }
 
     public long getRestoreQuantityOnDelete() {
         return timeDealStock.getQuantity().getRemainingQuantity();
+    }
+
+    public boolean isDeletable(LocalDateTime now) {
+        validateDeletableStatus();
+        validateDeletablePeriod(now);
+        return true;
     }
 
     public boolean isClosed() {

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/repository/TimeDealRepository.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/repository/TimeDealRepository.java
@@ -1,9 +1,12 @@
 package com.palja.timedeal_service.domain.repository;
 
 import com.palja.timedeal_service.domain.entity.TimeDeal;
+import com.palja.timedeal_service.domain.vo.TimeDealStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +14,5 @@ public interface TimeDealRepository {
     TimeDeal save(TimeDeal timeDeal);
     Optional<TimeDeal> findDetailByTimeDealId(UUID timeDealId);
     Page<TimeDeal> searchTimeDeals(Pageable pageable);
+    List<TimeDeal> findAllByCompanyUserId(UUID companyUserId, TimeDealStatus status, LocalDateTime now);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/JpaTimeDealRepository.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/JpaTimeDealRepository.java
@@ -1,12 +1,15 @@
 package com.palja.timedeal_service.infrastructure.repository;
 
 import com.palja.timedeal_service.domain.entity.TimeDeal;
+import com.palja.timedeal_service.domain.vo.TimeDealStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,4 +31,15 @@ public interface JpaTimeDealRepository extends JpaRepository<TimeDeal, UUID> {
         where td.deletedAt is null
     """)
     Page<TimeDeal> searchTimeDeals(Pageable pageable);
+
+    @Query("""
+    select td
+    from TimeDeal td
+    join fetch td.timeDealStock
+    where td.companyUserId = :companyUserId
+      and td.timeDealStatus = :status
+      and td.period.startAt > :now
+      and td.deletedAt is null
+""")
+    List<TimeDeal> findAllByCompanyUserId(UUID companyUserId, TimeDealStatus status, LocalDateTime now);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/adapter/TimeDealRepositoryAdapter.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/adapter/TimeDealRepositoryAdapter.java
@@ -2,11 +2,14 @@ package com.palja.timedeal_service.infrastructure.repository.adapter;
 
 import com.palja.timedeal_service.domain.entity.TimeDeal;
 import com.palja.timedeal_service.domain.repository.TimeDealRepository;
+import com.palja.timedeal_service.domain.vo.TimeDealStatus;
 import com.palja.timedeal_service.infrastructure.repository.JpaTimeDealRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,5 +31,10 @@ public class TimeDealRepositoryAdapter implements TimeDealRepository {
     @Override
     public Page<TimeDeal> searchTimeDeals(Pageable pageable) {
         return jpaTimeDealRepository.searchTimeDeals(pageable);
+    }
+
+    @Override
+    public List<TimeDeal> findAllByCompanyUserId(UUID companyUserId, TimeDealStatus status, LocalDateTime now) {
+        return jpaTimeDealRepository.findAllByCompanyUserId(companyUserId, status, now);
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/presentation/controller/TimeDealController.java
@@ -147,4 +147,15 @@ public class TimeDealController {
         log.info("타임딜 남은 재고 복구 완료");
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/company-users/{companyUserId}")
+    @RequiredInternal
+    public ResponseEntity<Void> deleteByCompanyUser(@PathVariable UUID companyUserId) {
+        log.info("DELETE api/v1/time-deals/{} 업체 판매자 관련 타임딜 삭제 요청", companyUserId);
+
+        timeDealService.deleteByCompanyUser(companyUserId);
+
+        log.info("업체 판매자 관련 타임딜 삭제 완료");
+        return ResponseEntity.noContent().build();
+    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #225

<br>

## 📌 개요
- 내부용 업체 판매자 관련 타임딜 삭제 API 구현

<br>

## 🔁 변경 사항
- 업체 판매자 관련 타임딜 삭제 로직 구현
  - PENDING 상태에서만 삭제 허용, 그 외 상태는 삭제 불가 처리
  - 타임딜 시작 시간 이전에만 삭제 가능하도록 기간 검증 로직 추가
 
- 타임딜 삭제 시 연관 엔티티까지 함께 논리 삭제 처리
  - TimeDealStock에 대해 soft delete 적용
  - BaseEntity.softDelete()를 활용
  
- 타임딜 삭제 시 상품 재고 복구 처리
  - 삭제 대상 타임딜의 남은 재고 기준으로 ProductService 재고 복구 요청

<br>

## 📸 스크린샷

<details>
  <summary>업체 판매자 관련 타임딜 삭제 성공</summary>
<img width="1374" height="138" alt="image" src="https://github.com/user-attachments/assets/598474ec-ffd4-44f2-8999-01cf059cdeea" />
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
