### PR TITLE
FEAT/쿠폰 서비스 사용자 쿠폰 전체 삭제 기능 구현

### DIFF
--- a/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/DeleteAllCouponUserRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/dto/couponUser/DeleteAllCouponUserRes.java
@@ -1,0 +1,21 @@
+package com.palja.coupon_service.application.dto.couponUser;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DeleteAllCouponUserRes {
+    List<UUID> deletedCouponUserIds;
+    int deletedCount;
+
+    public static DeleteAllCouponUserRes from(List<UUID> deletedCouponUserIds, int deleteCount) {
+        return DeleteAllCouponUserRes.builder()
+                .deletedCouponUserIds(deletedCouponUserIds)
+                .deletedCount(deleteCount)
+                .build();
+    }
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/CouponService.java
@@ -22,6 +22,8 @@ public interface CouponService {
 
     DeleteCouponUserRes deleteCoupon(UUID couponUserId, String loginId);
 
+    DeleteAllCouponUserRes deleteAllCoupons(String loginId);
+
     Page<ReadCouponUserRes> getCouponList(String userId, Pageable pageable);
 
     ReadCouponUserDetailRes getCouponDetail(UUID couponUserId, String userId);

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -159,15 +160,34 @@ public class CouponServiceImpl implements CouponService {
     @Override
     @Transactional
     public DeleteCouponUserRes deleteCoupon(UUID couponUserId, String userId) {
-        log.info("쿠폰 삭제 시작 - couponId={} status={}", couponUserId, userId);
+        log.info("쿠폰 삭제 시작 - couponId={} userId={}", couponUserId, userId);
 
         CouponUser couponUser = couponUserRepository.findByIdAndUserIdAndDeletedAtIsNull(couponUserId, userId)
                 .orElseThrow(() -> new BusinessException(CouponErrorCode.USER_COUPON_NOT_FOUND));
 
         couponUser.softDelete();
 
-        log.info("쿠폰 삭제 완료 - couponId={} status={}", couponUserId, userId);
+        log.info("쿠폰 삭제 완료 - couponId={} userId={}", couponUserId, userId);
         return DeleteCouponUserRes.from(couponUser);
+    }
+
+    @Override
+    @Transactional
+    public DeleteAllCouponUserRes deleteAllCoupons(String userId) {
+        log.info("쿠폰 전체 삭제 시작 - userId={}", userId);
+
+        List<CouponUser> couponUsers = couponUserRepository.findAllByUserIdAndDeletedAtIsNull(userId);
+
+        List<UUID> deletedCouponUserIds = couponUsers.stream()
+                .map(CouponUser::getId)
+                .toList();
+
+        couponUsers.forEach(CouponUser::softDelete);
+
+        int deleteCount = deletedCouponUserIds.size();
+
+        log.info("쿠폰 전체 삭제 완료 - userId={}", userId);
+        return DeleteAllCouponUserRes.from(deletedCouponUserIds, deleteCount);
     }
 
     @Override

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponUserRepository.java
@@ -4,6 +4,7 @@ import com.palja.coupon_service.domain.entity.CouponUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,4 +17,6 @@ public interface CouponUserRepository {
     Page<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId, Pageable pageable);
 
     Optional<CouponUser> findByIdAndUserIdAndDeletedAtIsNull(UUID couponUserId, String userId);
+
+    List<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponUserRepositoryAdaptor.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -34,5 +35,10 @@ public class CouponUserRepositoryAdaptor implements CouponUserRepository {
     @Override
     public Optional<CouponUser> findByIdAndUserIdAndDeletedAtIsNull(UUID couponUserId, String userId) {
         return jpaCouponUserRepository.findByIdAndUserIdAndDeletedAtIsNull(couponUserId, userId);
+    }
+
+    @Override
+    public List<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId) {
+        return jpaCouponUserRepository.findAllByUserIdAndDeletedAtIsNull(userId);
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponUserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -27,4 +28,6 @@ public interface JpaCouponUserRepository extends JpaRepository<CouponUser, UUID>
             "AND cu.deletedAt IS NULL " +
             "ORDER BY cu.expireAt")
     Optional<CouponUser> findByIdAndUserIdAndDeletedAtIsNull(UUID couponUserId, String userId);
+
+    List<CouponUser> findAllByUserIdAndDeletedAtIsNull(String userId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/CouponController.java
@@ -64,6 +64,12 @@ public interface CouponController {
     ResponseEntity<ApiResponse<DeleteCouponUserRes>> deleteCoupon(@PathVariable UUID couponUserId);
 
     @Operation(
+            summary = "쿠폰 전체 삭제",
+            description = "사용자의 쿠폰 전체를 삭제합니다."
+    )
+    ResponseEntity<ApiResponse<DeleteAllCouponUserRes>> deleteAllCoupons();
+
+    @Operation(
             summary = "쿠폰 목록 조회",
             description = "사용자의 보유 쿠폰 목록을 조회합니다."
     )

--- a/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponControllerImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/presentation/controller/impl/CouponControllerImpl.java
@@ -104,6 +104,16 @@ public class CouponControllerImpl implements CouponController {
     }
 
     @Override
+    @DeleteMapping("/me/all")
+    public ResponseEntity<ApiResponse<DeleteAllCouponUserRes>> deleteAllCoupons() {
+        log.info("DELETE /api/v1/coupons/me/all - 전체 쿠폰 삭제 요청 userId={}", CurrentUser.getLoginId());
+
+        DeleteAllCouponUserRes response = couponService.deleteAllCoupons(CurrentUser.getLoginId());
+
+        return ResponseEntity.ok(ApiResponse.success(response, "모든 쿠폰이 삭제되었습니다."));
+    }
+
+    @Override
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<PageResponse<ReadCouponUserRes>>> getCouponList(Pageable pageable) {
         log.info("GET /api/v1/coupons/me - 사용자 쿠폰 목록 조회 요청 userId={}", CurrentUser.getLoginId());


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #230 
<br>

## 📌 개요
사용자가 보유한 모든 쿠폰을 한 번에 삭제할 수 있는 기능을 구현했습니다.

<br>

## 🔁 변경 사항

### 1. 애플리케이션 계층
- **DeleteAllCouponUserRes 추가**: 전체 삭제 결과 응답 DTO
  - `deletedCouponUserIds`: 삭제된 쿠폰 ID 목록
  - `deletedCount`: 삭제된 쿠폰 개수
- **CouponService**: `deleteAllCoupons()` 메서드 추가
- **CouponServiceImpl**: 전체 삭제 로직 구현

### 2. 도메인 계층
- **CouponUserRepository**: `findAllByUserIdAndDeletedAtIsNull(String userId)` 메서드 추가

### 3. 인프라 계층
- **JpaCouponUserRepository**: 전체 조회 쿼리 메서드 추가
- **CouponUserRepositoryAdaptor**: 도메인 리포지토리 인터페이스 구현

### 4. 프레젠테이션 계층
- **CouponController Interface**: `deleteAllCoupons()` API 명세 추가
- **CouponControllerImpl**: `DELETE /api/v1/coupons/me/all` 엔드포인트 구현

<br>

## 📸 스크린샷

<details>
  <summary>쿠폰 전체 삭제 API 요청/응답 예시</summary>
  
<img width="1013" height="259" alt="image" src="https://github.com/user-attachments/assets/f5201d43-4fbe-489a-9213-bc4234d258af" />
 
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.