### PR TITLE
FEAT/OrderService 결제 완료 API 구현 및 주문 상태 PAID 전환 처리

### DIFF
--- a/order-service/src/main/java/com/palja/order_service/application/command/CompleteOrderPaymentCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/CompleteOrderPaymentCommand.java
@@ -1,0 +1,14 @@
+package com.palja.order_service.application.command;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Builder
+public record CompleteOrderPaymentCommand(
+        UUID orderId,
+        UUID paymentId,
+        BigDecimal paidAmount
+) {
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/OrderPaymentCompleteRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/OrderPaymentCompleteRes.java
@@ -1,0 +1,31 @@
+package com.palja.order_service.application.dto.response;
+
+import com.palja.order_service.domain.entity.Order;
+import com.palja.order_service.domain.vo.OrderStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+// 결제 완료 응답
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderPaymentCompleteRes {
+        private UUID orderId;
+        private UUID paymentId;
+        private OrderStatus status;
+        private BigDecimal finalAmount;
+
+    public static OrderPaymentCompleteRes from(Order order) {
+        return OrderPaymentCompleteRes.builder()
+                .orderId(order.getOrderId())
+                .paymentId(order.getOrderId())
+                .status(order.getStatus())
+                .finalAmount(order.getOrderAmount().getFinalAmount())
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -75,11 +75,14 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_TRACKING_NUMBER(HttpStatus.BAD_REQUEST, "운송장 번호가 유효하지 않습니다."),
 
     // ===== 결제 관련 =====
-    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "결제 시간이 초과되었습니다."),
     INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 수단입니다."),
     INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 키입니다."),
     PAYMENT_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 생성에 실패했습니다."),
+    INVALID_ORDER_STATUS_FOR_PAYMENT(HttpStatus.BAD_REQUEST, "결제 완료 가능한 주문 상태가 아닙니다."),
+    PAYMENT_NOT_ASSIGNED(HttpStatus.BAD_REQUEST, "주문에 결제가 할당되지 않았습니다."),
+    PAYMENT_ID_MISMATCH(HttpStatus.BAD_REQUEST, "결제 ID가 일치하지 않습니다."),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 주문 금액과 일치하지 않습니다."),
 
     // ===== 권한 관련 =====
     USER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "접근 권한이 없는 사용자입니다."),

--- a/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
@@ -3,16 +3,13 @@ package com.palja.order_service.application.service;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CancelOrderCommand;
+import com.palja.order_service.application.command.CompleteOrderPaymentCommand;
 import com.palja.order_service.application.command.CreateOrderCommand;
-import com.palja.order_service.application.dto.response.CustomerOrderSummaryRes;
-import com.palja.order_service.application.dto.response.OrderCancelRes;
-import com.palja.order_service.application.dto.response.OrderCreateRes;
-import com.palja.order_service.application.dto.response.OrderDetailRes;
+import com.palja.order_service.application.dto.response.*;
 import com.palja.order_service.domain.entity.Order;
 import com.palja.order_service.presentation.dto.request.CustomerOrderSearchReq;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDate;
 import java.util.UUID;
 
 public interface OrderService {
@@ -29,4 +26,6 @@ public interface OrderService {
     PageResponse<CustomerOrderSummaryRes> getMyOrdersByCustomer(
             String loginId, CustomerOrderSearchReq request, Pageable pageable
     );
+
+    OrderPaymentCompleteRes completeOrderPayment(CompleteOrderPaymentCommand command);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -4,13 +4,11 @@ import com.palja.common.exception.BusinessException;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CancelOrderCommand;
+import com.palja.order_service.application.command.CompleteOrderPaymentCommand;
 import com.palja.order_service.application.command.CreateOrderCommand;
-import com.palja.order_service.application.dto.external.*;
-import com.palja.order_service.application.dto.response.CustomerOrderSummaryRes;
-import com.palja.order_service.application.dto.response.OrderCancelRes;
-import com.palja.order_service.application.dto.response.OrderCreateRes;
-import com.palja.order_service.application.dto.response.OrderDetailRes;
 import com.palja.order_service.application.dto.event.OrderCreatedEvent;
+import com.palja.order_service.application.dto.external.*;
+import com.palja.order_service.application.dto.response.*;
 import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.port.*;
 import com.palja.order_service.application.service.OrderService;
@@ -220,25 +218,6 @@ public class OrderServiceImpl implements OrderService {
         OrderCreatedEvent event = OrderCreatedEvent.from(order);
         eventPublisher.publishEvent(event);
         log.debug("주문 생성 이벤트 발행 완료: orderId={}", order.getOrderId());
-    }
-
-    // 결제 실행
-    // TODO: 이벤트 기반 처리
-    private void executePayment(Order order, Long userId) {
-        try {
-            PaymentCreateRes payment = paymentClient.createPayment(
-                    order.getOrderId(), userId, order.getOrderAmount().getFinalAmount(), order.getStatus()
-            );
-
-            order.markAsPaid(payment.getPaymentId());
-            log.info("결제 완료: paymentId={}, amount={}",
-                    payment.getPaymentId(), payment.getAmount());
-        } catch (Exception e) {
-            log.error("결제 실패: orderId={}, amount={}",
-                    order.getOrderId(), order.getOrderAmount().getFinalAmount(), e);
-            // TODO: 보상 트랜잭션 처리 (재고 복구, 쿠폰 복구)
-            throw new BusinessException(OrderErrorCode.PAYMENT_FAILED);
-        }
     }
 
     /**
@@ -466,6 +445,31 @@ public class OrderServiceImpl implements OrderService {
             return LocalDate.now().atTime(23, 59, 59);
         }
         return date.atTime(23, 59, 59);
+    }
+
+    // ====== Order Payment Completion Workflow ======
+    /**
+     * 결제 완료 처리
+     * - 결제 도메인에서 결제 완료 후 호출
+     * - 주문 상태를 CREATED -> PAID로 변경
+     * - 결제 ID 및 금액 검증
+     */
+    @Override
+    @Transactional
+    public OrderPaymentCompleteRes completeOrderPayment(CompleteOrderPaymentCommand command) {
+        log.info("주문 결제 완료 처리 시작: orderId={}, paymentId={}, amount={}",
+                command.orderId(), command.paymentId(), command.paidAmount());
+
+        Order order = findByOrderIdAndDeletedAtIsNull(command.orderId());
+
+        orderValidator.validateOrderForPaymentCompletion(order, command);
+
+        order.completePayment(command.paymentId(), command.paidAmount());
+
+        log.info("주문 결제 완료: orderId={}, paymentId={}, status={}, paidAmount={}",
+                order.getOrderId(), order.getPaymentId(), order.getStatus(), command.paidAmount());
+
+        return OrderPaymentCompleteRes.from(order);
     }
 
     // ===== Private: Authorization Context =====

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
@@ -2,6 +2,7 @@ package com.palja.order_service.application.service.validator;
 
 import com.palja.common.exception.BusinessException;
 import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.command.CompleteOrderPaymentCommand;
 import com.palja.order_service.application.command.CreateOrderCommand;
 import com.palja.order_service.application.command.DeliveryCommand;
 import com.palja.order_service.application.dto.CouponDiscountType;
@@ -464,5 +465,30 @@ public class OrderValidator {
     // 관리자 권한 검증 (유효한 관리자)
     public void validateManager(String loginId) {
         userClient.getMyManager(loginId);
+    }
+
+    // ===== Order Payment Complete Validation (결제 완료 검증) =====
+    // 결제 완료 검증
+    public void validateOrderForPaymentCompletion(Order order, CompleteOrderPaymentCommand command) {
+
+        // 주문 상태 검증
+        if (!order.getStatus().isCreated()) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS_FOR_PAYMENT);
+        }
+        // 결제 ID 일치 검증
+        if (order.getPaymentId() == null) {
+            throw new BusinessException(OrderErrorCode.PAYMENT_NOT_ASSIGNED);
+        }
+        if (!order.getPaymentId().equals(command.paymentId())) {
+            throw new BusinessException(OrderErrorCode.PAYMENT_ID_MISMATCH);
+        }
+        // 결제 금액 일치 검증
+        BigDecimal orderAmount = order.getOrderAmount().getFinalAmount();
+        if (orderAmount.compareTo(command.paidAmount()) != 0) {
+            throw new BusinessException(OrderErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+
+        log.debug("결제 완료 검증 성공: orderId={}, paymentId={}, amount={}",
+                order.getOrderId(), command.paymentId(), command.paidAmount());
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
@@ -203,15 +203,9 @@ public class Order extends BaseEntity {
         transitionTo(OrderStatus.SHIPPED);
     }
 
+    // 배송 완료로 상태 변경
     public void markAsDelivered() {
         transitionTo(OrderStatus.DELIVERED);
-    }
-
-    // 배송 완료로 상태 변경
-    public void markAsPaid(UUID paymentId) {
-        validatePaymentId(paymentId);
-        this.paymentId = paymentId;
-        transitionTo(OrderStatus.PAID);
     }
 
     // 타임딜 주문인지 확인
@@ -225,7 +219,6 @@ public class Order extends BaseEntity {
     }
 
     // ===== Validation ===== //
-
     private static void validateUserId(Long userId) {
         if (userId == null) {
             throw new IllegalArgumentException("주문자 ID는 필수입니다.");
@@ -276,16 +269,48 @@ public class Order extends BaseEntity {
      * - 결제 완료 전 상태
      */
     public void registerPaymentId(UUID paymentId) {
-        registerPaymentIdRegistration(paymentId);
+        validatePaymentRegistration(paymentId);
         this.paymentId = paymentId;
     }
 
-    private void registerPaymentIdRegistration(UUID paymentId) {
+    private void validatePaymentRegistration(UUID paymentId) {
         if (paymentId == null) {
             throw new IllegalArgumentException("결제 ID는 필수입니다.");
         }
         if (this.paymentId != null) {
             throw new IllegalStateException("이미 결제 ID가 할당된 주문입니다.");
+        }
+    }
+
+    /**
+     * 결제 완료 처리
+     * - 상태를 PAID로 변경
+     */
+    public void completePayment(UUID paymentId, BigDecimal paidAmount) {
+        validatePaymentCompletion(paymentId, paidAmount);
+        transitionTo(OrderStatus.PAID);
+    }
+
+    private void validatePaymentCompletion(UUID paymentId, BigDecimal paidAmount) {
+        if (paymentId == null) {
+            throw new IllegalArgumentException("결제 ID는 필수입니다.");
+        }
+        if (paidAmount == null || paidAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("결제 금액은 0보다 커야 합니다.");
+        }
+        if (!this.status.isCreated()) {
+            throw new IllegalStateException(
+                    String.format("결제 완료 가능한 상태가 아닙니다. 현재 상태: %s", this.status));
+        }
+        if (!this.paymentId.equals(paymentId)) {
+            throw new IllegalStateException(
+                    String.format("결제 ID가 일치하지 않습니다. 주문 결제 ID: %s, 요청 결제 ID: %s",
+                            this.paymentId, paymentId));
+        }
+        if (this.orderAmount.getFinalAmount().compareTo(paidAmount) != 0) {
+            throw new IllegalStateException(
+                    String.format("결제 금액이 주문 금액과 일치하지 않습니다. 주문 금액: %s, 결제 금액: %s",
+                            this.orderAmount.getFinalAmount(), paidAmount));
         }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
@@ -1,16 +1,15 @@
 package com.palja.order_service.presentation.controller;
 
+import com.palja.common.annotation.RequiredInternal;
 import com.palja.common.annotation.RequiredRole;
 import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
 import com.palja.common.vo.UserRole;
-import com.palja.order_service.application.dto.response.CustomerOrderSummaryRes;
-import com.palja.order_service.application.dto.response.OrderCancelRes;
-import com.palja.order_service.application.dto.response.OrderCreateRes;
-import com.palja.order_service.application.dto.response.OrderDetailRes;
+import com.palja.order_service.application.dto.response.*;
 import com.palja.order_service.application.service.OrderService;
 import com.palja.order_service.presentation.dto.request.CancelOrderReq;
+import com.palja.order_service.presentation.dto.request.CompleteOrderPaymentReq;
 import com.palja.order_service.presentation.dto.request.CreateOrderReq;
 import com.palja.order_service.presentation.dto.request.CustomerOrderSearchReq;
 import jakarta.validation.Valid;
@@ -79,4 +78,14 @@ public class OrderController {
         );
     }
 
+    // 주문 결제 완료
+    @RequiredInternal
+    @PutMapping("/{orderId}/payment/complete")
+    public ResponseEntity<ApiResponse<OrderPaymentCompleteRes>> completeOrderPayment(
+            @PathVariable UUID orderId,
+            @RequestBody @Valid CompleteOrderPaymentReq request
+    ) {
+        OrderPaymentCompleteRes response = orderService.completeOrderPayment(request.toCommand(orderId));
+        return ResponseEntity.ok(ApiResponse.success(response, "주문이 결제 완료되었습니다."));
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CompleteOrderPaymentReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CompleteOrderPaymentReq.java
@@ -1,0 +1,32 @@
+package com.palja.order_service.presentation.dto.request;
+
+import com.palja.order_service.application.command.CompleteOrderPaymentCommand;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+// 주문 결제 완료 요청 DTO
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompleteOrderPaymentReq {
+    @NotNull(message = "결제 ID는 필수입니다.")
+    private UUID paymentId;
+
+    @NotNull(message = "결제 금액은 필수입니다.")
+    @DecimalMin(value = "0.01", message = "결제 금액은 0보다 커야 합니다.")
+    private BigDecimal paidAmount;
+
+    public CompleteOrderPaymentCommand toCommand(UUID orderId) {
+        return CompleteOrderPaymentCommand.builder()
+                .orderId(orderId)
+                .paymentId(paymentId)
+                .paidAmount(paidAmount)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #198 

<br>

## 📌 개요
- 결제 서비스에서 **결제 승인 완료 시 호출하는 결제 완료 API**를 구현했습니다.
- 결제 완료 요청을 통해 주문 상태를 `CREATED → PAID`로 전환하도록 처리했습니다.

<br>

## 🔁 변경 사항
- 결제 완료 API 추가 (PUT `/api/v1/orders/{orderId}/payment/complete` )
- 결제 완료 시 주문 상태를 `PAID`로 전환하는 비즈니스 로직 구현
- 결제 완료 요청에 대한 주문 상태 검증 및 예외 처리 추가
- 결제 완료 요청/응답 DTO 추가
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
