### PR TITLE
REFACTOR/ PaymentService 중복 DB 저장 문제 수정 & 로깅 작업

### DIFF
--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentLogServiceImpl.java
@@ -13,6 +13,7 @@ import com.palja.payment_service.domain.repository.PaymentLogRepository;
 import com.palja.payment_service.domain.vo.PaymentStatus;
 import com.palja.payment_service.exception.PaymentErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentLogServiceImpl implements PaymentLogService {
@@ -37,12 +39,25 @@ public class PaymentLogServiceImpl implements PaymentLogService {
         String loginId = CurrentUser.getLoginId();
         UserRes user = userClient.getUserByLoginId(loginId);
 
+        log.info("결제 로그 조회 시작: paymentId={}, requestUserId={}, role={}",
+                paymentId,
+                user != null ? user.getUserId() : null,
+                user != null ? user.getRole() : null);
+
         paymentValidator.validateGetPaymentLogs(paymentId, user);
 
         List<PaymentLog> logs = paymentLogRepository.findByPaymentId(paymentId);
         if (logs.isEmpty()) {
+            log.warn("결제 로그 없음: paymentId={}, requestUserId={}",
+                    paymentId,
+                    user != null ? user.getUserId() : null);
             throw new BusinessException(PaymentErrorCode.PAYMENT_LOG_NOT_FOUND);
         }
+        log.info("결제 로그 조회 완료(paymentId 기준): paymentId={}, count={}, requestUserId={}, role={}",
+                paymentId, logs.size(),
+                user != null ? user.getUserId() : null,
+                user != null ? user.getRole() : null);
+
         return logs.stream()
                 .map(ReadPaymentLogRes::from)
                 .toList();
@@ -56,6 +71,17 @@ public class PaymentLogServiceImpl implements PaymentLogService {
         String loginId = CurrentUser.getLoginId();
         UserRes user = userClient.getUserByLoginId(loginId);
 
+        log.info("결제 로그 검색 시작: paymentId={}, orderId={}, status={}, startDate={}, endDate={}, page={}, size={}, requestUserId={}, role={}",
+                command.paymentId(),
+                command.orderId(),
+                command.status(),
+                command.startDate(),
+                command.endDate(),
+                pageRequest.getPageNumber(),
+                pageRequest.getPageSize(),
+                user != null ? user.getUserId() : null,
+                user != null ? user.getRole() : null);
+
         paymentValidator.validateSearchPaymentLogs(command.startDate(), command.endDate(), user);
 
         PaymentStatus status = null;
@@ -63,6 +89,9 @@ public class PaymentLogServiceImpl implements PaymentLogService {
             try {
                 status = PaymentStatus.valueOf(command.status());
             } catch (IllegalArgumentException e) {
+                log.warn("결제 로그 검색 실패: 유효하지 않은 status 값. status={}, paymentId={}, orderId={}, requestUserId={}",
+                        command.status(), command.paymentId(), command.orderId(),
+                        user != null ? user.getUserId() : null);
                 throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
             }
         }
@@ -76,6 +105,10 @@ public class PaymentLogServiceImpl implements PaymentLogService {
                 pageRequest
         );
 
+        log.info("결제 로그 검색 완료: totalElements={}, totalPages={}, page={}, size={}, requestUserId={}",
+                logs.getTotalElements(), logs.getTotalPages(), logs.getNumber(), logs.getSize(),
+                user != null ? user.getUserId() : null);
+
         return logs.map(ReadPaymentLogRes::from);
     }
 
@@ -84,8 +117,11 @@ public class PaymentLogServiceImpl implements PaymentLogService {
     public void deleteOldLogs(){
         LocalDateTime oneYearAgo = LocalDateTime.now().minusYears(1);
 
-        paymentValidator.validateDeleteOldLogs(oneYearAgo);
+        log.info("결제 로그 삭제 시작: cutoffDate={}", oneYearAgo);
 
+        paymentValidator.validateDeleteOldLogs(oneYearAgo);
         paymentLogRepository.deleteLogsOlder(oneYearAgo);
+
+        log.info("결제 로그 삭제 완료: cutoffDate={}", oneYearAgo);
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
@@ -32,6 +32,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
 import java.util.UUID;
 
 @Slf4j
@@ -54,18 +55,24 @@ public class PaymentServiceImpl implements PaymentService {
       - Toss API 호출은 하지 않음
      */
     public CreatePaymentRes createPayment(CreatePaymentCommand command) {
-        log.info("결제 생성 시작: orderId={}, userId={}, loginId={}, orderStatus={}",
-                command.orderId(), command.userId(), command.loginId(), command.orderStatus());
+        log.info("결제 생성 시작: orderId={}, userId={}, loginId={}, orderStatus={}, amount={}",
+                command.orderId(), command.userId(), command.loginId(), command.orderStatus(), command.amount());
+
+        Payment existing = paymentRepository.findByOrderId(command.orderId()).orElse(null);
+        if (existing != null) {
+            log.warn("결제 생성 스킵(이미 결제 존재): orderId={}, paymentId={}, status={}, amount={}",
+                    command.orderId(), existing.getId(), existing.getStatus(), command.amount());
+            return CreatePaymentRes.from(existing);
+        }
 
         OrderRes order = orderClient.getOrderByOrderId(command.orderId());
+        UserRes user = userClient.getUserByLoginId(command.loginId());
 
         if (command.userId() != null && !command.userId().equals(order.getUserId())) {
             log.error("주문의 userId와 요청 userId가 일치하지 않음: orderUserId={}, requestUserId={}",
                     order.getUserId(), command.userId());
             throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_INFO);
         }
-
-        UserRes user = userClient.getUserByLoginId(command.loginId());
 
         paymentValidator.validateCreatePayment(command, order, user);
 
@@ -76,9 +83,7 @@ public class PaymentServiceImpl implements PaymentService {
         );
 
         paymentRepository.save(payment);
-
-        PaymentLog requestLog = createRequestLog(payment);
-        paymentLogRepository.save(requestLog);
+        paymentLogRepository.save(PaymentLog.createPendingLog(payment));
 
         log.info("결제 생성 완료 (PENDING 상태): paymentId={}, orderId={}, userId={}",
                 payment.getId(), payment.getOrderId(), payment.getUserId());
@@ -90,8 +95,8 @@ public class PaymentServiceImpl implements PaymentService {
     /*
       결제 완료 처리
       - paymentKey를 받아서 Toss API 호출
-      - 결제 확인 후 APPROVED 상태로 변경
-      - TODO: 주문 상태를 PAID로 변경하는 API 호출 필요
+      - Payment 상태를 APPROVED/FAILED로 업데이트
+      - PaymentLog 결과는 상태에 따라 1번 저장
      */
     public CreatePaymentRes completePayment(CompletePaymentCommand command) {
         log.info("결제 완료 처리 시작: paymentId={}, paymentKey={}, loginId={}",
@@ -100,40 +105,42 @@ public class PaymentServiceImpl implements PaymentService {
         Payment payment = paymentRepository.findById(command.paymentId())
                 .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
-        if (payment.getStatus() != PaymentStatus.PENDING) {
-            log.error("PENDING 상태가 아닌 결제는 완료 처리할 수 없습니다. paymentId={}, status={}",
+        if (!payment.isPending()) {
+            log.warn("결제 완료 처리 불가(이미 처리 완료 상태): paymentId={}, status={}",
                     payment.getId(), payment.getStatus());
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
         }
 
-        // paymentKey 업데이트하고 Toss API 호출해서 결제 확인
         payment.updatePaymentKey(command.paymentKey());
 
         PGPaymentRes pgRes;
         try {
+            log.info("Toss 결제 확인 요청: paymentId={}, orderId={}, amount={}",
+                    payment.getId(), payment.getOrderId(), payment.getAmount());
+
             pgRes = pgPaymentService.requestPayment(payment);
+
+            log.info("Toss 결제 확인 응답: paymentId={}, reason={}, pgMessage={}",
+                    payment.getId(), pgRes.isSuccess(), pgRes.getPgResponseMessage());
         } catch (Exception e) {
             log.error("Toss 결제 확인 API 호출 실패: paymentId={}, paymentKey={}",
                     payment.getId(), command.paymentKey(), e);
             throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
         }
 
-        PaymentLog requestLog = createRequestLog(payment);
-        paymentLogRepository.save(requestLog);
-
         if (pgRes.isSuccess()) {
-            approvePayment(payment, pgRes.getPaymentKey());
+            payment.approve(resolvePaymentKey(pgRes, payment));
             log.info("결제 완료 성공: paymentId={}, orderId={}", payment.getId(), payment.getOrderId());
-
-            // TODO: order-service API 호출하여 주문 상태를 PAID로 변경
         } else {
-            failPayment(payment, pgRes.getPgResponseMessage());
+            payment.fail(pgRes.getPgResponseMessage());
             log.warn("결제 완료 실패: paymentId={}, reason={}", payment.getId(), pgRes.getPgResponseMessage());
         }
 
         paymentRepository.save(payment);
 
-        PaymentLog resultLog = createResultLog(payment, pgRes);
+        PaymentLog resultLog = pgRes.isSuccess()
+                ? PaymentLog.createApprovedLog(payment, pgRes)
+                : PaymentLog.createFailedLog(payment, pgRes);
         paymentLogRepository.save(resultLog);
 
         if (!pgRes.isSuccess()) {
@@ -156,31 +163,40 @@ public class PaymentServiceImpl implements PaymentService {
 
         paymentValidator.validateCancelPayment(payment, command, user);
 
-        PaymentLog requestLog = createRequestLog(payment);
-        paymentLogRepository.save(requestLog);
-
         PGPaymentRes pgRes;
         try {
+            log.info("Toss 결제 취소 요청: paymentId={}, cancelAmount={}, reason={}",
+                    payment.getId(), command.cancelAmount(), command.cancelReason());
+
             pgRes = pgPaymentService.cancelPayment(
                     payment,
                     command.cancelAmount(),
                     command.cancelReason()
             );
+
+            log.info("Toss 결제 취소 응답: paymentId={}, reason={}, pgMessage={}",
+                    payment.getId(), pgRes.isSuccess(), pgRes.getPgResponseMessage());
+
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
+            log.error("Toss 결제 취소 API 호출 실패: paymentId={}", payment.getId(), e);
             throw new BusinessException(CommonErrorCode.FEIGN_ERROR);
         }
 
         if (pgRes.isSuccess()) {
             payment.cancel(command.cancelReason());
+            log.info("결제 취소 상태 변경 완료: paymentId={}, status={}", payment.getId(), payment.getStatus());
         } else {
             payment.fail(pgRes.getPgResponseMessage());
+            log.warn("결제 취소 실패 처리 완료: paymentId={}, reason={}", payment.getId(), pgRes.getPgResponseMessage());
         }
 
         paymentRepository.save(payment);
 
-        PaymentLog resultLog = createResultLog(payment, pgRes);
+        PaymentLog resultLog = pgRes.isSuccess()
+                ? PaymentLog.createCanceledLog(payment, pgRes)
+                : PaymentLog.createFailedLog(payment, pgRes);
         paymentLogRepository.save(resultLog);
 
         if (!pgRes.isSuccess()) {
@@ -252,32 +268,16 @@ public class PaymentServiceImpl implements PaymentService {
 
         paymentValidator.validateDeletePayment(payment, user);
 
-        if(payment.getStatus() == PaymentStatus.PENDING) {
+        if (payment.isPending()) {
             payment.softDelete();
             paymentRepository.save(payment);
-        }else {
+            log.info("결제 삭제 완료: paymentId={}", payment.getId());
+        } else {
             throw new BusinessException(PaymentErrorCode.PAYMENT_CANNOT_BE_DELETED);
         }
     }
 
-    private void approvePayment(Payment payment, String paymentKey) {
-        payment.approve(paymentKey);
-    }
-
-    private void failPayment(Payment payment, String reason) {
-        payment.fail(reason);
-    }
-
-    private PaymentLog createRequestLog(Payment payment) {
-        return PaymentLog.createRequestLog(payment);
-    }
-
-    private PaymentLog createResultLog(Payment payment, PGPaymentRes pgRes) {
-        return PaymentLog.createResultLog(
-                payment,
-                pgRes.getPaymentKey(),
-                pgRes.getPgResponseCode(),
-                pgRes.getPgResponseMessage()
-        );
+    private String resolvePaymentKey(PGPaymentRes pgRes, Payment payment) {
+        return Objects.toString(pgRes.getPaymentKey(), Objects.toString(payment.getPaymentKey(), ""));
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/application/validator/PaymentValidator.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/validator/PaymentValidator.java
@@ -28,6 +28,8 @@ public class PaymentValidator {
         validateCreatePaymentCommand(command);
         validateOrderForPayment(order, command, user);
         validateUserForPayment(user);
+        log.debug("validateCreatePayment 완료: orderId={}, userId={}",
+                command.orderId(), user != null ? user.getUserId() : null);
     }
 
     private void validateCreatePaymentCommand(CreatePaymentCommand command) {
@@ -40,15 +42,18 @@ public class PaymentValidator {
 
     private void validateOrderId(UUID orderId) {
         if (orderId == null) {
+            log.error("validateOrderId 실패: orderId가 null");
             throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_INFO);
         }
     }
 
     private void validateAmount(BigDecimal amount) {
         if (amount == null) {
+            log.error("validateAmount 실패: amount가 null");
             throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_INFO);
         }
         if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            log.error("validateAmount 실패: amount가 0 이하 amount={}", amount);
             throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_INFO);
         }
     }
@@ -69,10 +74,13 @@ public class PaymentValidator {
         validateOrderStatusForPayment(order, command.orderStatus());
         validateOrderAmount(order, command.amount());
         validateOrderUserId(order, user);
+        log.debug("validateOrderForPayment 완료: orderId={}, orderStatus={}, finalAmount={}",
+                order.getOrderId(), order.getStatus(), order.getFinalAmount());
     }
 
     private void validateOrderExists(OrderRes order) {
         if (order == null) {
+            log.error("validateOrderExists 실패: 주문이 존재하지 않음");
             throw new BusinessException(PaymentErrorCode.ORDER_NOT_FOUND);
         }
     }
@@ -83,19 +91,19 @@ public class PaymentValidator {
                 order.getOrderId(), orderStatus, requestedOrderStatus);
 
         if (orderStatus == null || orderStatus.isBlank()) {
-            log.error("[에러 발생 위치 1] 주문 상태가 null이거나 비어있습니다: orderId={}", order.getOrderId());
+            log.error("[에러 발생 위치 1] 주문 상태가 null이거나 비어있음: orderId={}", order.getOrderId());
             throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
         }
 
         if (!"CREATED".equalsIgnoreCase(orderStatus)) {
-            log.error("[에러 발생 위치 2] 결제 가능한 주문 상태가 아닙니다: orderId={}, orderStatus={}, requiredStatus=CREATED",
+            log.error("[에러 발생 위치 2] 결제 가능한 주문 상태가 아님: orderId={}, orderStatus={}, requiredStatus=CREATED",
                     order.getOrderId(), orderStatus);
             throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
         }
 
         if (requestedOrderStatus != null && !requestedOrderStatus.isBlank()) {
             if (!"CREATED".equalsIgnoreCase(requestedOrderStatus)) {
-                log.error("[에러 발생 위치 3] 요청된 주문 상태가 CREATED가 아닙니다: orderId={}, requestedOrderStatus={}",
+                log.error("[에러 발생 위치 3] 요청된 주문 상태가 CREATED가 아님: orderId={}, requestedOrderStatus={}",
                         order.getOrderId(), requestedOrderStatus);
                 throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
             }
@@ -106,12 +114,12 @@ public class PaymentValidator {
 
     private void validateOrderAmount(OrderRes order, BigDecimal paymentAmount) {
         if (paymentAmount == null || paymentAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            log.error("결제 금액이 null 이거나 0 이하입니다. paymentAmount={}", paymentAmount);
+            log.error("결제 금액이 null 이거나 0 이하: paymentAmount={}", paymentAmount);
             throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_INFO);
         }
 
         if (order.getFinalAmount().compareTo(paymentAmount) != 0) {
-            log.error("주문 금액과 결제 금액이 일치하지 않습니다. orderId={}, orderFinalAmount={}, paymentAmount={}",
+            log.error("주문 금액과 결제 금액이 일치하지 않음: orderId={}, orderFinalAmount={}, paymentAmount={}",
                     order.getOrderId(), order.getFinalAmount(), paymentAmount);
             throw new BusinessException(PaymentErrorCode.INSUFFICIENT_FUNDS);
         }
@@ -119,10 +127,15 @@ public class PaymentValidator {
 
 
     private void validateOrderUserId(OrderRes order, UserRes user) {
+        if (user == null) {
+            log.error("validateOrderUserId 실패: user가 null. orderId={}", order.getOrderId());
+            throw new BusinessException(PaymentErrorCode.USER_NOT_FOUND);
+        }
+
         if (!order.getUserId().equals(user.getUserId())) {
             log.error("[에러 발생 위치 4] 주문의 userId와 사용자 userId가 일치하지 않음: orderId={}, orderUserId={}, userUserId={}",
                     order.getOrderId(), order.getUserId(), user.getUserId());
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_INFO);
         }
     }
 
@@ -133,13 +146,16 @@ public class PaymentValidator {
 
     private void validateUserExists(UserRes user) {
         if (user == null) {
+            log.error("validateUserExists 실패: user가 null");
             throw new BusinessException(PaymentErrorCode.USER_NOT_FOUND);
         }
     }
 
     private void validateUserStatus(UserRes user) {
         if (!"ACTIVE".equals(user.getStatus())) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("validateUserStatus 실패: userStatus={}, required=ACTIVE. userId={}, loginId={}",
+                    user.getStatus(), user.getUserId(), user.getLoginId());
+            throw new BusinessException(PaymentErrorCode.USER_INACTIVE);
         }
     }
 
@@ -148,22 +164,29 @@ public class PaymentValidator {
         validatePaymentStatusForCancel(payment);
         validateCancelAmount(payment, command.cancelAmount());
         validateUserForCancel(user, payment);
+        log.debug("validateCancelPayment 완료: paymentId={}", payment.getId());
     }
 
     private void validatePaymentStatusForCancel(Payment payment) {
         if (payment.getStatus() != PaymentStatus.APPROVED) {
+            log.error("결제 취소 불가 상태: paymentId={}, status={}, required=APPROVED",
+                    payment.getId(), payment.getStatus());
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_APPROVED);
         }
     }
 
     private void validateCancelAmount(Payment payment, BigDecimal cancelAmount) {
         if (cancelAmount == null) {
+            log.error("취소 금액이 null: paymentId={}", payment.getId());
             throw new BusinessException(PaymentErrorCode.PAYMENT_EXCEED_AMOUNT);
         }
         if (cancelAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            log.error("취소 금액이 0 이하: paymentId={}, cancelAmount={}", payment.getId(), cancelAmount);
             throw new BusinessException(PaymentErrorCode.PAYMENT_EXCEED_AMOUNT);
         }
         if (cancelAmount.compareTo(payment.getAmount()) > 0) {
+            log.error("취소 금액이 결제 금액을 초과: paymentId={}, cancelAmount={}, paymentAmount={}",
+                    payment.getId(), cancelAmount, payment.getAmount());
             throw new BusinessException(PaymentErrorCode.PAYMENT_EXCEED_AMOUNT);
         }
         validateFullRefundOnly(payment, cancelAmount);
@@ -171,6 +194,8 @@ public class PaymentValidator {
 
     private void validateFullRefundOnly(Payment payment, BigDecimal cancelAmount) {
         if (cancelAmount.compareTo(payment.getAmount()) != 0) {
+            log.error("부분 환불 불가: paymentId={}, cancelAmount={}, paymentAmount={}",
+                    payment.getId(), cancelAmount, payment.getAmount());
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_PARTIAL_REFUND);
         }
     }
@@ -187,12 +212,15 @@ public class PaymentValidator {
 
         if (UserRole.CUSTOMER.equals(user.getRole())) {
             if (!payment.getUserId().equals(user.getUserId())) {
-                throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+                log.error("취소 권한 없음: paymentUserId={}, requestUserId={}",
+                        payment.getUserId(), user.getUserId());
+                throw new BusinessException(PaymentErrorCode.PAYMENT_CANCEL_FORBIDDEN);
             }
             return;
         }
 
-        throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+        log.error("취소 권한 없는 role: role={}, userId={}", user.getRole(), user.getUserId());
+        throw new BusinessException(PaymentErrorCode.PAYMENT_CANCEL_FORBIDDEN);
 
     }
 
@@ -201,39 +229,47 @@ public class PaymentValidator {
         validatePaymentExists(payment);
         validatePaymentStatusForDelete(payment);
         validateUserRoleForDelete(user);
+        log.debug("validateDeletePayment 완료: paymentId={}", payment.getId());
     }
 
     private void validatePaymentExists(Payment payment) {
         if (payment == null) {
+            log.error("validatePaymentExists 실패: payment가 null");
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND);
         }
     }
 
     private void validatePaymentStatusForDelete(Payment payment) {
         if (payment.getStatus() != PaymentStatus.PENDING) {
+            log.error("삭제 불가 상태: paymentId={}, status={}, required=PENDING",
+                    payment.getId(), payment.getStatus());
             throw new BusinessException(PaymentErrorCode.PAYMENT_CANNOT_BE_DELETED);
         }
     }
 
     private void validateUserRoleForDelete(UserRes user) {
         if (user == null) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("validateUserRoleForDelete 실패: user가 null");
+            throw new BusinessException(PaymentErrorCode.USER_NOT_FOUND);
         }
 
         if (!UserRole.MASTER.equals(user.getRole()) && !UserRole.MANAGER.equals(user.getRole())) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("삭제 권한 없음: userId={}, role={}", user.getUserId(), user.getRole());
+            throw new BusinessException(PaymentErrorCode.PAYMENT_DELETE_FORBIDDEN);
         }
     }
 
     // ===== 결제 조회/검색 검증 =====
     public void validateSearchPayments(FindPaymentListByConditionCommand command, UserRes user) {
         validateDateRange(command.startDate(), command.endDate());
+        log.debug("validateSearchPayments 완료");
     }
 
     private void validateDateRange(LocalDateTime startDate, LocalDateTime endDate) {
         if (startDate != null && endDate != null) {
             if (startDate.isAfter(endDate)) {
-                throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+                log.error("기간 범위 오류: startDate={}, endDate={}", startDate, endDate);
+                throw new BusinessException(PaymentErrorCode.INVALID_DATE_RANGE);
             }
         }
     }
@@ -241,11 +277,13 @@ public class PaymentValidator {
     public void validateGetPayment(Payment payment, UserRes user) {
         validatePaymentExists(payment);
         validateUserAccessToPayment(user, payment);
+        log.debug("validateGetPayment 완료: paymentId={}", payment.getId());
     }
 
     private void validateUserAccessToPayment(UserRes user, Payment payment) {
         if (user == null) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("validateUserAccessToPayment 실패: user가 null. paymentId={}", payment.getId());
+            throw new BusinessException(PaymentErrorCode.USER_NOT_FOUND);
         }
 
         if (UserRole.MASTER.equals(user.getRole()) || UserRole.MANAGER.equals(user.getRole())) {
@@ -257,14 +295,17 @@ public class PaymentValidator {
 
     private void validateCustomerOwnership(UserRes user, Payment payment) {
         if (!user.getUserId().equals(payment.getUserId())) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("조회 권한 없음: paymentId={}, paymentUserId={}, requestUserId={}",
+                    payment.getId(), payment.getUserId(), user.getUserId());
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ACCESS_DENIED);
         }
     }
 
     // ===== PaymentLog 관련 검증=====
     public void validateSearchPaymentLogs(LocalDateTime startDate, LocalDateTime endDate) {
         if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("PaymentLog 검색 기간 오류: startDate={}, endDate={}", startDate, endDate);
+            throw new BusinessException(PaymentErrorCode.INVALID_DATE_RANGE);
         }
     }
 
@@ -277,28 +318,40 @@ public class PaymentValidator {
         if (user == null ||
                 (!UserRole.MASTER.equals(user.getRole()) &&
                         !UserRole.MANAGER.equals(user.getRole()))) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("PaymentLog 검색 권한 없음: userId={}, role={}",
+                    user != null ? user.getUserId() : null,
+                    user != null ? user.getRole() : null);
+            throw new BusinessException(PaymentErrorCode.PAYMENT_LOG_ACCESS_DENIED);
         }
+        log.debug("validateSearchPaymentLogs 완료");
     }
 
     public void validateGetPaymentLogs(UUID paymentId, UserRes user) {
         if (paymentId == null) {
+            log.error("PaymentLog 단건 조회 실패: paymentId가 null");
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND);
         }
 
         if (user == null ||
                 (!UserRole.MASTER.equals(user.getRole()) && !UserRole.MANAGER.equals(user.getRole()))) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("PaymentLog 단건 조회 권한 없음: userId={}, role={}",
+                    user != null ? user.getUserId() : null,
+                    user != null ? user.getRole() : null);
+            throw new BusinessException(PaymentErrorCode.PAYMENT_LOG_ACCESS_DENIED);
         }
+        log.debug("validateGetPaymentLogs 완료: paymentId={}", paymentId);
     }
 
     public void validateDeleteOldLogs(LocalDateTime cutoffDate) {
         if (cutoffDate == null) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("cutoffDate가 null");
+            throw new BusinessException(PaymentErrorCode.INVALID_CUTOFF_DATE);
         }
 
         if (cutoffDate.isAfter(LocalDateTime.now())) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+            log.error("cutoffDate가 미래: cutoffDate={}", cutoffDate);
+            throw new BusinessException(PaymentErrorCode.INVALID_CUTOFF_DATE);
         }
+        log.debug("validateDeleteOldLogs 완료: cutoffDate={}", cutoffDate);
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/application/validator/PaymentValidator.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/validator/PaymentValidator.java
@@ -30,7 +30,6 @@ public class PaymentValidator {
         validateUserForPayment(user);
     }
 
-    //currency, paymentMethod 제거
     private void validateCreatePaymentCommand(CreatePaymentCommand command) {
         validateOrderId(command.orderId());
         validateAmount(command.amount());
@@ -109,13 +108,6 @@ public class PaymentValidator {
         if (paymentAmount == null || paymentAmount.compareTo(BigDecimal.ZERO) <= 0) {
             log.error("결제 금액이 null 이거나 0 이하입니다. paymentAmount={}", paymentAmount);
             throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_INFO);
-        }
-
-        if (order.getFinalAmount() == null) {
-            log.warn("Order.finalAmount 가 null 입니다. 금액 일치 검증을 스킵합니다. " +
-                            "orderId={}, requestAmount={}",
-                    order.getOrderId(), paymentAmount);
-            return;
         }
 
         if (order.getFinalAmount().compareTo(paymentAmount) != 0) {

--- a/payment-service/src/main/java/com/palja/payment_service/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/entity/Payment.java
@@ -91,14 +91,16 @@ public class Payment extends BaseEntity {
         if (this.status != PaymentStatus.APPROVED) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_APPROVED);
         }
-
         this.status = PaymentStatus.CANCELED;
         this.cancelReason = reason;
         this.completedAt = LocalDateTime.now();
     }
 
-    //paymentKey추가
     public void updatePaymentKey(String paymentKey) {
         this.paymentKey = paymentKey;
+    }
+
+    public boolean isPending() {
+        return this.status == PaymentStatus.PENDING;
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/entity/Payment.java
@@ -97,6 +97,12 @@ public class Payment extends BaseEntity {
     }
 
     public void updatePaymentKey(String paymentKey) {
+        if(!isPending()){
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+        }
+        if (paymentKey == null || paymentKey.isBlank()) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_INFO);
+        }
         this.paymentKey = paymentKey;
     }
 

--- a/payment-service/src/main/java/com/palja/payment_service/domain/entity/PaymentLog.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/entity/PaymentLog.java
@@ -1,6 +1,7 @@
 package com.palja.payment_service.domain.entity;
 
 import com.palja.common.entity.BaseEntity;
+import com.palja.payment_service.application.dto.response.PGPaymentRes;
 import com.palja.payment_service.domain.vo.PaymentStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -69,34 +70,66 @@ public class PaymentLog extends BaseEntity {
         this.processedAt = processedAt;
     }
 
-    public static PaymentLog createRequestLog(Payment payment) {
+    public static PaymentLog createPendingLog(Payment payment) {
         return PaymentLog.builder()
                 .payment(payment)
                 .orderId(payment.getOrderId())
                 .userId(payment.getUserId())
                 .amount(payment.getAmount())
-                .status(payment.getStatus())
+                .status(PaymentStatus.PENDING)
                 .paymentKey(Objects.toString(payment.getPaymentKey(), ""))
-                .pgResponseCode(null)
-                .pgResponseMessage(null)
+                .pgResponseCode("PENDING")
+                .pgResponseMessage("결제 생성(PENDING), 결제 완료 X")
                 .processedAt(LocalDateTime.now())
                 .build();
     }
 
-    public static PaymentLog createResultLog(Payment payment,
-                                             String paymentKey,
-                                             String pgResponseCode,
-                                             String pgResponseMessage) {
+    public static PaymentLog createApprovedLog(Payment payment, PGPaymentRes pgRes) {
         return PaymentLog.builder()
                 .payment(payment)
                 .orderId(payment.getOrderId())
                 .userId(payment.getUserId())
                 .amount(payment.getAmount())
-                .status(payment.getStatus())
-                .paymentKey(paymentKey != null ? paymentKey : "")
-                .pgResponseCode(pgResponseCode)
-                .pgResponseMessage(pgResponseMessage)
+                .status(PaymentStatus.APPROVED)
+                .paymentKey(resolvePaymentKey(pgRes, payment))
+                .pgResponseCode(pgRes.getPgResponseCode())
+                .pgResponseMessage(pgRes.getPgResponseMessage())
                 .processedAt(LocalDateTime.now())
                 .build();
+    }
+
+    public static PaymentLog createFailedLog(Payment payment, PGPaymentRes pgRes) {
+        return PaymentLog.builder()
+                .payment(payment)
+                .orderId(payment.getOrderId())
+                .userId(payment.getUserId())
+                .amount(payment.getAmount())
+                .status(PaymentStatus.FAILED)
+                .paymentKey(resolvePaymentKey(pgRes, payment))
+                .pgResponseCode(pgRes.getPgResponseCode())
+                .pgResponseMessage(pgRes.getPgResponseMessage())
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static PaymentLog createCanceledLog(Payment payment, PGPaymentRes pgRes) {
+        return PaymentLog.builder()
+                .payment(payment)
+                .orderId(payment.getOrderId())
+                .userId(payment.getUserId())
+                .amount(payment.getAmount())
+                .status(PaymentStatus.CANCELED)
+                .paymentKey(resolvePaymentKey(pgRes, payment))
+                .pgResponseCode(pgRes.getPgResponseCode())
+                .pgResponseMessage(pgRes.getPgResponseMessage())
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static String resolvePaymentKey(PGPaymentRes pgRes, Payment payment) {
+        return Objects.toString(
+                pgRes != null ? pgRes.getPaymentKey() : null,
+                Objects.toString(payment.getPaymentKey(), "")
+        );
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/domain/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/repository/PaymentRepository.java
@@ -14,9 +14,9 @@ public interface PaymentRepository {
 
     Optional<Payment> findById(UUID id);
 
-    Page<Payment> findAll(PageRequest pageRequest);
-
     Page<Payment> findPayments(PaymentStatus status, Long userId, UUID orderId, LocalDateTime startDate, LocalDateTime endDate, PageRequest pageRequest);
 
     void deleteById(UUID id);
+
+    Optional<Payment> findByOrderId(UUID orderId);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/exception/PaymentErrorCode.java
+++ b/payment-service/src/main/java/com/palja/payment_service/exception/PaymentErrorCode.java
@@ -21,10 +21,20 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제를 찾을 수 없습니다."),
     PAYMENT_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 로그를 찾을 수 없습니다."),
 
+    // 권한
+    PAYMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 결제에 접근할 권한이 없습니다."),
+    PAYMENT_CANCEL_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 결제를 취소할 권한이 없습니다."),
+    PAYMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "결제를 삭제할 권한이 없습니다."),
+    PAYMENT_LOG_ACCESS_DENIED(HttpStatus.FORBIDDEN, "결제 로그에 접근할 권한이 없습니다."),
+    USER_INACTIVE(HttpStatus.FORBIDDEN, "비활성화된 사용자입니다."),
+
     // 검증
     INVALID_PAYMENT_INFO(HttpStatus.BAD_REQUEST, "결제 정보가 일치하지 않습니다."),
     INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 상태입니다."),
     INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 방법입니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "조회 기간이 올바르지 않습니다."),
+    INVALID_CUTOFF_DATE(HttpStatus.BAD_REQUEST, "삭제 기준일이 올바르지 않습니다."),
+
     INSUFFICIENT_FUNDS(HttpStatus.BAD_REQUEST, "결제에 필요한 금액이 부족합니다."),
     PAYMENT_EXCEED_AMOUNT(HttpStatus.BAD_REQUEST, "취소 금액이 결제 금액을 초과할 수 없습니다."),
     PAYMENT_NOT_PARTIAL_REFUND(HttpStatus.BAD_REQUEST, "부분 환불이 불가합니다."),

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/adapter/OrderAdapter.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/adapter/OrderAdapter.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Slf4j
@@ -56,13 +57,18 @@ public class OrderAdapter implements OrderClient {
     }
 
     private OrderRes toOrderRes(OrderDTO dto) {
+        BigDecimal finalAmount = dto.getPricing() != null
+                ? dto.getPricing().getFinalAmount()
+                : null;
+
         log.info("OrderAdapter mapping: orderId={}, userId={}, status={}, finalAmount={}",
-                dto.getOrderId(), dto.getUserId(), dto.getStatus(), dto.getFinalAmount());
+                dto.getOrderId(), dto.getUserId(), dto.getStatus(), finalAmount);
+
         return OrderRes.of(
                 dto.getOrderId(),
                 dto.getUserId(),
                 dto.getStatus(),
-                dto.getFinalAmount()
+                finalAmount
         );
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/dto/response/OrderDTO.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/dto/response/OrderDTO.java
@@ -14,5 +14,16 @@ public class OrderDTO {
     private UUID orderId;
     private Long userId;
     private String status;
-    private BigDecimal finalAmount;
+    private Pricing pricing;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Pricing {
+        private BigDecimal finalAmount;
+    }
+
+    public BigDecimal getFinalAmount() {
+        return pricing != null ? pricing.finalAmount : null;
+    }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/dto/response/OrderPricingDTO.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/dto/response/OrderPricingDTO.java
@@ -4,14 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
+import java.math.BigDecimal;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class OrderDTO {
-    private UUID orderId;
-    private Long userId;
-    private String status;
-    private OrderPricingDTO pricing;
+public class OrderPricingDTO {
+    private BigDecimal finalAmount;
 }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentJpaRepository.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentJpaRepository.java
@@ -3,7 +3,9 @@ package com.palja.payment_service.infrastructure.repository;
 import com.palja.payment_service.domain.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
+    Optional<Payment> findByOrderId(UUID orderId);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentRepositoryImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/repository/PaymentRepositoryImpl.java
@@ -30,11 +30,6 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
-    public Page<Payment> findAll(PageRequest pageRequest) {
-        return paymentJpaRepository.findAll(pageRequest);
-    }
-
-    @Override
     public Page<Payment> findPayments(
             PaymentStatus status,
             Long userId,
@@ -49,5 +44,10 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     @Override
     public void deleteById(UUID id) {
         paymentJpaRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<Payment> findByOrderId(UUID orderId) {
+        return paymentJpaRepository.findByOrderId(orderId);
     }
 }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/service/TossPaymentService.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/service/TossPaymentService.java
@@ -49,7 +49,7 @@ public class TossPaymentService implements PGPaymentService {
             } else if (!amountOk) {
                 message = "토스 승인 금액과 요청 금액이 다릅니다. approved=" + approvedAmount + ", requested=" + payment.getAmount();
             } else {
-                message = "토스 결제 조회 성공";
+                message = "토스 결제 성공";
             }
 
             log.info("Toss getPayment response. paymentKey={}, status={}, totalAmount={}",

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentController.java
@@ -21,14 +21,12 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Tag(name = "Payment-Controller", description = "결제 관련 API")
-@RequestMapping("/api/v1/payments")
 public interface PaymentController {
 
     @Operation(
             summary = "결제 생성",
             description = "사용자의 주문에 대해 PENDING 상태로 결제를 생성합니다."
     )
-    @PostMapping
     ResponseEntity<ApiResponse<CreatePaymentRes>> createPayment(
             @Valid @RequestBody CreatePaymentReq req
     );
@@ -37,7 +35,6 @@ public interface PaymentController {
             summary = "결제 완료",
             description = "paymentKey를 받아서 Toss API를 호출하여 결제를 확인하고, 성공 시 APPROVED 상태로 변경합니다."
     )
-    @PostMapping("/{paymentId}/complete")
     ResponseEntity<ApiResponse<CreatePaymentRes>> completePayment(
             @Parameter(description = "결제 ID", example = "660e8400-e29b-41d4-a716-446655440001")
             @PathVariable UUID paymentId,
@@ -48,7 +45,6 @@ public interface PaymentController {
             summary = "결제 취소",
             description = "승인된 결제에 대해 PG 취소 요청을 보내고, 성공 시 결제 상태를 취소로 변경합니다."
     )
-    @PostMapping("/{paymentId}/cancel")
     ResponseEntity<ApiResponse<CancelPaymentRes>> cancelPayment(
             @Parameter(description = "결제 ID", example = "660e8400-e29b-41d4-a716-446655440001")
             @PathVariable UUID paymentId,
@@ -59,7 +55,6 @@ public interface PaymentController {
             summary = "결제 단건 조회",
             description = "특정 결제 ID에 대한 상세 정보를 조회합니다."
     )
-    @GetMapping("/{paymentId}")
     ResponseEntity<ApiResponse<ReadPaymentDetailRes>> getPayment(
             @Parameter(description = "결제 ID", example = "660e8400-e29b-41d4-a716-446655440001")
             @PathVariable UUID paymentId
@@ -69,7 +64,6 @@ public interface PaymentController {
             summary = "결제 목록 조회(검색)",
             description = "결제 상태, 기간, 사용자, 주문ID 등의 조건으로 검색하고, 페이징된 목록을 조회합니다."
     )
-    @GetMapping
     ResponseEntity<ApiResponse<PageResponse<ReadPaymentSummaryRes>>> getPayments(
             @Parameter(description = "결제 상태", example = "APPROVED")
             @RequestParam(required = false) String status,
@@ -93,7 +87,6 @@ public interface PaymentController {
             summary = "내 결제 목록 조회",
             description = "로그인한 사용자 자신의 결제 목록을 조회합니다."
     )
-    @GetMapping("/me")
     ResponseEntity<ApiResponse<PageResponse<ReadPaymentSummaryRes>>> getMyPayments(
             @Parameter(description = "결제 상태", example = "APPROVED")
             @RequestParam(required = false) String status,
@@ -113,7 +106,6 @@ public interface PaymentController {
             summary = "결제 삭제",
             description = "(관리자)결제 데이터를 삭제합니다. (마스터/매니저만 삭제가 가능합니다.)"
     )
-    @DeleteMapping("/manager/{paymentId}")
     ResponseEntity<ApiResponse<String>> deletePayment(
             @Parameter(description = "결제 ID", example = "660e8400-e29b-41d4-a716-446655440001")
             @PathVariable UUID paymentId

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentController.java
@@ -33,7 +33,6 @@ public interface PaymentController {
             @Valid @RequestBody CreatePaymentReq req
     );
 
-    //결제 완료 API 생성
     @Operation(
             summary = "결제 완료",
             description = "paymentKey를 받아서 Toss API를 호출하여 결제를 확인하고, 성공 시 APPROVED 상태로 변경합니다."

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/PaymentLogController.java
@@ -8,9 +8,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
@@ -24,7 +22,6 @@ public interface PaymentLogController {
             summary = "결제 로그 단건 조회",
             description = "특정 결제ID에 대한 PG 요청/응답 정보를 조회합니다."
     )
-    @GetMapping("/api/v1/payments/{paymentId}/logs")
     ResponseEntity<ApiResponse<List<ReadPaymentLogRes>>> getPaymentLogsByPaymentId(
             @Parameter(description = "결제 ID", example = "660e8400-e29b-41d4-a716-446655440001")
             @PathVariable UUID paymentId
@@ -34,7 +31,6 @@ public interface PaymentLogController {
             summary = "결제 로그 목록 조회(검색)",
             description = "결제 ID, 기간, 상태 등의 조건으로 결제 로그를 검색 및 조회합니다."
     )
-    @GetMapping("/api/v1/payment-logs")
     ResponseEntity<ApiResponse<PageResponse<ReadPaymentLogRes>>> getPaymentLogs(
             @Parameter(description = "결제 ID", example = "660e8400-e29b-41d4-a716-446655440001")
             @RequestParam(required = false) UUID paymentId,
@@ -58,6 +54,5 @@ public interface PaymentLogController {
             summary = "결제 로그 삭제",
             description = "결제 로그 데이터를 삭제합니다. (스케줄러 사용해서 1년 뒤)"
     )
-    @PostMapping("/api/v1/payment-logs/delete")
     ResponseEntity<ApiResponse<String>> deleteOldLogs();
 }

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/impl/PaymentControllerImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/impl/PaymentControllerImpl.java
@@ -47,7 +47,6 @@ public class PaymentControllerImpl implements PaymentController {
                 .body(ApiResponse.success(detail, "결제가 생성되었습니다. (PENDING 상태)"));
     }
 
-    //결제 완료 API
     @Override
     @PostMapping("/{paymentId}/complete")
     @RequiredInternal

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/dto/request/CompletePaymentReq.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/dto/request/CompletePaymentReq.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 @NoArgsConstructor
 public class CompletePaymentReq {
 
-    //toss에서 paymentKey 받아서 결제 완료
     @NotBlank(message = "paymentKey는 필수입니다.")
     private String paymentKey;
 

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/dto/request/CreatePaymentReq.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/dto/request/CreatePaymentReq.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 @NoArgsConstructor
 public class CreatePaymentReq {
 
-    //currency, PaymentKey, PaymentMethod 제거
     private UUID orderId;
     private Long userId;
     private BigDecimal amount;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #232 

<br>

## 📌 개요
- 주문 당 결제 정보 DB는 1건만 저장되도록 변경 (결제 생성과 완료를 분리하면서 PENDING 상태를 2번 저장하고 있었음)
- 결제 상태 변화에 따라 결제 로그가 1건씩 저장되도록 변경
- 검증 로깅 작업 & ErrorCode 명확하게 변경

<br>

## 🔁 변경 사항
### 1. 결제 중복 생성 수정
- orderId 기준으로 결제를 조회하도록 PaymentJpaRepository.findByOrderId() 사용
- **결제 생성 API (createPayment)**
PG 호출 없이 PENDING 상태의 결제만 생성
결제 생성 시 PENDING 상태의 결제 로그 1건 저장
- **결제 완료 API (completePayment)**
Toss 결제 확인 API 호출
결제 상태를 APPROVED 또는 FAILED로 변경
결과에 따른 결제 로그를 1건만 저장

### 2. 주문 금액 검증 및 DTO 매핑 수정
- order-service 응답에서 pricing.finalAmount가 내려오는데,
OrderDTO가 이를 매핑하지 못해 finalAmount == null이던 문제 수정
- 주문 금액과 결제 요청 금액이 다를 경우 결제(PENDING)가 생성되지 않도록 검증

### 3. PaymentValidator 로깅 작업 & 의미에 맞는 에러코드 추가
- 권한 / 기간 / 사용자 상태 관련 신규 에러 코드 추가

### 4. PaymentLogServiceImpl 로깅 작업
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
