### PR TITLE
FEAT/ProductService 회원 삭제로 인한 상품 삭제 구현

### DIFF
--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -38,4 +38,6 @@ public interface ProductService {
     IncreaseStockForTimeDealRes increaseStockForTimeDeal(UUID productId, Integer quantity);
 
     void deleteProduct(UUID productId);
+
+    void deleteProductForUser(UUID companyUserId);
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -38,13 +38,6 @@ public class ProductServiceImpl implements ProductService {
     private final ProductRepository repository;
     private final UserClient userClient;
 
-    @Value("${redis-key.map0}")
-    private String map0Key;
-
-    @Value("${redis-key.map1}")
-    private String map1Key;
-
-
     @Override
     @Transactional
     public CreateProductRes createProduct(CreateProductCommand createCommand) {
@@ -114,9 +107,7 @@ public class ProductServiceImpl implements ProductService {
         Product product = repository.findProduct(productId);
         CompanyUserInfoRes myInfo = userClient.getMyInfo();
 
-        if (isDifferCompanyUser(product.getCompanyUserId(), myInfo.getCompanyUserId())) {
-            throw new BusinessException(ProductErrorCode.FORBIDDEN_REQUEST);
-        }
+        validateIsSameUser(product.getCompanyUserId(), myInfo.getCompanyUserId());
 
         if(repository.isNotUnique(
                 product.getCompanyName(),
@@ -141,9 +132,7 @@ public class ProductServiceImpl implements ProductService {
         Product product = repository.findProduct(productId);
         CompanyUserInfoRes myInfo = userClient.getMyInfo();
 
-        if (isDifferCompanyUser(product.getCompanyUserId(), myInfo.getCompanyUserId())) {
-            throw new BusinessException(ProductErrorCode.FORBIDDEN_REQUEST);
-        }
+        validateIsSameUser(product.getCompanyUserId(), myInfo.getCompanyUserId());
 
         if (Objects.isNull(stock)) {
             throw new BusinessException(CommonErrorCode.BAD_REQUEST);
@@ -169,12 +158,10 @@ public class ProductServiceImpl implements ProductService {
     public SaleProductRes saleProduct(UUID productId,
                                       Integer quantity) {
 
-        String hashKey = createRedisHashKey(productId);
-
         ProductStock stock = repository.findProductStock(productId);
 
         boolean result = repository.decreaseStockBySale(
-                hashKey, productId.toString(), stock.getQuantity(), quantity);
+                productId.toString(), stock.getQuantity(), quantity);
         validateRedisOperation(result);
 
         return new SaleProductRes(productId, Boolean.TRUE);
@@ -198,9 +185,8 @@ public class ProductServiceImpl implements ProductService {
 
         ProductStock restoredStock = repository.findProduct(productId).increaseStock(quantity);
 
-        String hashKey = createRedisHashKey(productId);
         boolean result = repository.adjustStock(
-                hashKey, productId.toString(), restoredStock.getQuantity());
+                productId.toString(), restoredStock.getQuantity());
         validateRedisOperation(result);
 
         return new RestoreStockRes(productId, Boolean.TRUE);
@@ -214,9 +200,8 @@ public class ProductServiceImpl implements ProductService {
         Product product = repository.findProduct(productId);
         product.decreaseStock(quantity);
 
-        String hashKey = createRedisHashKey(productId);
         boolean result = repository.adjustStock(
-                hashKey, productId.toString(), product.getProductStock().getQuantity());
+                productId.toString(), product.getProductStock().getQuantity());
         validateRedisOperation(result);
 
         return new DecreaseStockForTimeDealRes(productId, Boolean.TRUE);
@@ -230,9 +215,8 @@ public class ProductServiceImpl implements ProductService {
         Product product = repository.findProduct(productId);
         product.increaseStock(quantity);
 
-        String hashKey = createRedisHashKey(productId);
         boolean result = repository.adjustStock(
-                hashKey, productId.toString(), product.getProductStock().getQuantity());
+                productId.toString(), product.getProductStock().getQuantity());
         validateRedisOperation(result);
 
         return new IncreaseStockForTimeDealRes(productId, Boolean.TRUE);
@@ -245,30 +229,32 @@ public class ProductServiceImpl implements ProductService {
         Product product = repository.findProduct(productId);
         CompanyUserInfoRes myInfo = userClient.getMyInfo();
 
-        if (isDifferCompanyUser(product.getCompanyUserId(), myInfo.getCompanyUserId())) {
-            throw new BusinessException(ProductErrorCode.FORBIDDEN_REQUEST);
-        }
+        validateIsSameUser(product.getCompanyUserId(), myInfo.getCompanyUserId());
 
         product.delete();
 
-        String hashKey = createRedisHashKey(productId);
-        boolean result = repository.deleteStockFromRedis(hashKey, productId.toString());
+        boolean result = repository.deleteStockFromRedis(productId.toString());
         validateRedisOperation(result);
     }
 
-    private boolean isDifferCompanyUser(UUID productCompanyUserId,
-                                        UUID myId) {
+    @Override
+    @Transactional
+    public void deleteProductForUser(UUID companyUserId) {
 
-        return !productCompanyUserId.equals(myId);
+        List<UUID> idList = repository.findAllIdsByCompanyUserId(companyUserId);
+        repository.deleteProductForUser(companyUserId);
+        boolean result = repository.deleteAllStockFromRedis(idList);
+        validateRedisOperation(result);
+
     }
 
-    private String createRedisHashKey(UUID productId) {
+    private boolean validateIsSameUser(UUID productCompanyUserId,
+                                       UUID myId) {
 
-        String substring = productId.toString().substring(0, 8);
-        int hash = substring.hashCode();
-        if(hash % 2 == 0)
-            return map0Key;
-        else return map1Key;
+        if(!productCompanyUserId.equals(myId)) {
+            throw new BusinessException(ProductErrorCode.FORBIDDEN_REQUEST);
+        }
+        return true;
     }
 
     private void validateRedisOperation(boolean redisResult) {

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
@@ -31,13 +31,19 @@ public interface ProductRepository {
 
     ProductInfoForOrderDto findProductForOrder(UUID productId);
 
-    boolean decreaseStockBySale(String hashKey, String productId, Integer stock, Integer quantity);
+    boolean decreaseStockBySale(String productId, Integer stock, Integer quantity);
 
-    boolean adjustStock(String hashKey, String productId, Integer quantity);
+    boolean adjustStock(String productId, Integer quantity);
 
     void stockBulkUpdateForSchedule(Collection<StockScheduleDto> dtos);
 
-    boolean deleteStockFromRedis(String hashKey, String productId);
+    boolean deleteStockFromRedis(String productId);
 
     Product findByIdFetchStockWithLock(UUID productId, Integer quantity);
+
+    List<UUID> findAllIdsByCompanyUserId(UUID companyUserId);
+
+    boolean deleteAllStockFromRedis(List<UUID> productIds);
+
+    void deleteProductForUser(UUID companyUserId);
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/RedisProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/RedisProductRepository.java
@@ -1,10 +1,15 @@
 package com.palja.product_service.domain.repository;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface RedisProductRepository {
 
-    boolean decreaseStockBySale(String key, String productId, Integer stock, Integer quantity);
+    boolean decreaseStockBySale(String productId, Integer stock, Integer quantity);
 
-    boolean adjustStock(String hashKey, String productId, Integer quantity);
+    boolean adjustStock(String productId, Integer quantity);
 
-    boolean deleteProductStock(String hashKey, String productId);
+    boolean deleteProductStock(String productId);
+
+    boolean deleteAllStockFromRedis(List<UUID> productIds);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
@@ -6,9 +6,11 @@ import com.palja.product_service.domain.vo.Category;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,7 +19,7 @@ public interface JpaProductRepository extends JpaRepository<Product, UUID> {
     @Query("SELECT p FROM Product p JOIN FETCH p.productStock WHERE p.id = :productId AND p.deletedAt IS null")
     Optional<Product> findByIdFetchStock(@Param("productId") UUID productId);
 
-    @Query("SELECT ps FROM ProductStock ps JOIN Product p WHERE ps.id = :productId AND p.deletedAt IS NULL")
+    @Query("SELECT ps FROM ProductStock ps JOIN Product p ON ps.id = :productId AND p.deletedAt IS NULL")
     Optional<ProductStock> findStockByProductId(@Param("productId") UUID productId);
 
     Boolean existsByCompanyNameAndCategoryAndNameAndDeletedAtIsNull(String companyName, Category category, String name);
@@ -25,4 +27,11 @@ public interface JpaProductRepository extends JpaRepository<Product, UUID> {
     @Lock(value = LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Product p JOIN FETCH p.productStock WHERE p.id = :productId AND p.deletedAt IS null")
     Optional<Product> findByIdFetchStockWithLock(@Param("productId") UUID productId);
+
+    @Query("SELECT p.id FROM Product p WHERE p.companyUserId = :companyUserId")
+    List<UUID> findAllIdsByCompanyUserId(@Param("companyUserId")UUID companyUserId);
+
+    @Modifying
+    @Query("UPDATE Product p SET p.deletedAt = local datetime WHERE p.companyUserId = :companyUserId")
+    void deleteAllByCompanyUserId(@Param("companyUserId") UUID companyUserId);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -94,15 +94,15 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public boolean decreaseStockBySale(String hashKey, String productId, Integer stock, Integer quantity) {
+    public boolean decreaseStockBySale(String productId, Integer stock, Integer quantity) {
 
-        return redisRepository.decreaseStockBySale(hashKey, productId, stock, quantity);
+        return redisRepository.decreaseStockBySale(productId, stock, quantity);
     }
 
     @Override
-    public boolean adjustStock(String hashKey, String productId, Integer quantity) {
+    public boolean adjustStock(String productId, Integer quantity) {
 
-        return redisRepository.adjustStock(hashKey, productId, quantity);
+        return redisRepository.adjustStock(productId, quantity);
     }
 
     @Override
@@ -113,9 +113,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public boolean deleteStockFromRedis(String hashKey, String productId) {
+    public boolean deleteStockFromRedis(String productId) {
 
-        return redisRepository.deleteProductStock(hashKey, productId);
+        return redisRepository.deleteProductStock(productId);
     }
 
     @Override
@@ -125,5 +125,23 @@ public class ProductRepositoryImpl implements ProductRepository {
         return jpaProductRepository
                 .findByIdFetchStockWithLock(productId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Override
+    public List<UUID> findAllIdsByCompanyUserId(UUID companyUserId) {
+
+        return jpaProductRepository.findAllIdsByCompanyUserId(companyUserId);
+
+    }
+
+    @Override
+    public boolean deleteAllStockFromRedis(List<UUID> productIds) {
+        return redisRepository.deleteAllStockFromRedis(productIds);
+    }
+
+    @Override
+    public void deleteProductForUser(UUID companyUserId) {
+
+        jpaProductRepository.deleteAllByCompanyUserId(companyUserId);
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisProductRepositoryImpl.java
@@ -160,7 +160,7 @@ public class RedisProductRepositoryImpl implements RedisProductRepository {
         return true;
     }
 
-    private String createRedisHashKey(String productId) {
+    protected String createRedisHashKey(String productId) {
 
         String substring = productId.substring(0, 8);
         int hash = substring.hashCode();

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/RedisProductRepositoryImpl.java
@@ -2,31 +2,42 @@ package com.palja.product_service.infrastructure.repository.impl;
 
 import com.palja.product_service.domain.repository.RedisProductRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class RedisProductRepositoryImpl implements RedisProductRepository {
 
     private final RedissonClient redissonClient;
 
+    @Value("${redis-key.map0}")
+    private String hashKey0;
+
+    @Value("${redis-key.map1}")
+    private String hashKey1;
+
     @Value("${redis-key.time-suffix}")
     private String timeSuffix;
 
     @Override
-    public boolean decreaseStockBySale(String key, String productId, Integer stock, Integer quantity) {
+    public boolean decreaseStockBySale(String productId, Integer stock, Integer quantity) {
 
         //상품의 아이디의 이름으로 락을 건다.
         RLock lock = redissonClient.getLock(productId);
-
+        String hashKey = createRedisHashKey(productId);
         RTransaction transaction = null;
+
         try {
             //락을 10초동안 얻지 못한다면 실패 반환
             if (!lock.tryLock(10, 10, TimeUnit.SECONDS)) {
@@ -39,7 +50,7 @@ public class RedisProductRepositoryImpl implements RedisProductRepository {
             );
 
             // 레디스에 key로 매핑된 Hash(자바의 Map)을 가져온다.
-            RMap<String, Integer> map = transaction.getMap(key);
+            RMap<String, Integer> map = transaction.getMap(hashKey);
 
             //값이 있으면 가져오고 없으면 DB의 재고로 잡는다
             Integer remainStock = map.getOrDefault(productId, stock);
@@ -52,7 +63,7 @@ public class RedisProductRepositoryImpl implements RedisProductRepository {
 
             //레디스에 새로운 재고를 넣고, DB 재고차감 스케줄링에 사용할 값을 넣는다.
             map.fastPut(productId, resultStock);
-            setTime(key+timeSuffix, productId);
+            setTime(hashKey+timeSuffix, productId);
 
             //예외 없이 모든 작업이 끝난다면 커밋해 레디스에 적용시킨다
             transaction.commit();
@@ -68,9 +79,10 @@ public class RedisProductRepositoryImpl implements RedisProductRepository {
     }
 
     @Override
-    public boolean adjustStock(String hashKey, String productId, Integer quantity) {
+    public boolean adjustStock(String productId, Integer quantity) {
 
         RLock lock = redissonClient.getLock(productId);
+        String hashKey = createRedisHashKey(productId);
 
         try {
             //락을 10초동안 얻지 못한다면 실패 반환
@@ -92,10 +104,12 @@ public class RedisProductRepositoryImpl implements RedisProductRepository {
     }
 
     @Override
-    public boolean deleteProductStock(String hashKey, String productId) {
+    public boolean deleteProductStock(String productId) {
 
         RLock lock = redissonClient.getLock(productId);
+        String hashKey = createRedisHashKey(productId);
         RTransaction transaction = null;
+
         try {
             //락을 10초동안 얻지 못한다면 실패 반환
             if (!lock.tryLock(10, 10, TimeUnit.SECONDS)) {
@@ -121,6 +135,38 @@ public class RedisProductRepositoryImpl implements RedisProductRepository {
             lock.unlock();
         }
         return true;
+    }
+
+    @Override
+    public boolean deleteAllStockFromRedis(List<UUID> productIds) {
+
+        for (UUID productId : productIds) {
+            RLock lock = redissonClient.getLock(productId.toString());
+
+            try {
+                if (!lock.tryLock(10, 10, TimeUnit.SECONDS)) {
+                    continue;
+                }
+
+                RMap<String, Integer> map =
+                        redissonClient.getMap(createRedisHashKey(productId.toString()));
+
+                map.fastRemove(productId.toString());
+
+            } catch (Exception e) {
+                log.error("Please Retry Delete this Id = {}", productId);
+            }
+        }
+        return true;
+    }
+
+    private String createRedisHashKey(String productId) {
+
+        String substring = productId.substring(0, 8);
+        int hash = substring.hashCode();
+        if(hash % 2 == 0)
+            return hashKey0;
+        else return hashKey1;
     }
 
     private void setTime(String setKey, String productId) {

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/Impl/ProductControllerImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/Impl/ProductControllerImpl.java
@@ -146,7 +146,7 @@ public class ProductControllerImpl {
         return new ResponseEntity<>(ApiResponse.success("상품 삭제 성공"), HttpStatus.OK);
     }
 
-    @RequiredRole(UserRole.COMPANY_USER)
+    @RequiredInternal
     @DeleteMapping("/user/{companyUserId}")
     public ResponseEntity<ApiResponse<String>> deleteProductForUser(@PathVariable UUID companyUserId) {
 

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/Impl/ProductControllerImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/Impl/ProductControllerImpl.java
@@ -96,7 +96,7 @@ public class ProductControllerImpl {
         return new ResponseEntity<>(ApiResponse.success(res, "상품 재고 수정 성공"), HttpStatus.OK);
     }
 
-//    @RequiredInternal
+    @RequiredInternal
     @PutMapping("/order/sale/{productId}")
     public ResponseEntity<ApiResponse<SaleProductRes>> saleProduct(@PathVariable UUID productId,
                                                                    @RequestParam Integer quantity) {

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/Impl/ProductControllerImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/Impl/ProductControllerImpl.java
@@ -76,7 +76,7 @@ public class ProductControllerImpl {
     }
 
     @RequiredRole(UserRole.COMPANY_USER)
-    @PutMapping("/manager/{productId}")
+    @PutMapping("/{productId}")
     public ResponseEntity<ApiResponse<UpdateProductInfoRes>> updateProductInfo(@RequestBody @Valid UpdateProductInfoReq req,
                                                                                @PathVariable UUID productId) {
 
@@ -87,7 +87,7 @@ public class ProductControllerImpl {
     }
 
     @RequiredRole(UserRole.COMPANY_USER)
-    @PutMapping("/manager/modifyStock/{productId}")
+    @PutMapping("/modifyStock/{productId}")
     public ResponseEntity<ApiResponse<UpdateStockRes>> updateProductStock(@PathVariable UUID productId,
                                                                           @RequestParam Integer stock) {
 
@@ -96,13 +96,13 @@ public class ProductControllerImpl {
         return new ResponseEntity<>(ApiResponse.success(res, "상품 재고 수정 성공"), HttpStatus.OK);
     }
 
-    @RequiredInternal
+//    @RequiredInternal
     @PutMapping("/order/sale/{productId}")
     public ResponseEntity<ApiResponse<SaleProductRes>> saleProduct(@PathVariable UUID productId,
                                                                    @RequestParam Integer quantity) {
 
-        SaleProductRes res = service.saleProductV1(productId, quantity);
-//        SaleProductRes res = service.saleProduct(productId, quantity);
+//        SaleProductRes res = service.saleProductV1(productId, quantity);
+        SaleProductRes res = service.saleProduct(productId, quantity);
 
         return new ResponseEntity<>(ApiResponse.success(res, "판매 재고 차감 성공"), HttpStatus.OK);
     }
@@ -139,10 +139,18 @@ public class ProductControllerImpl {
     }
 
     @RequiredRole(UserRole.COMPANY_USER)
-    @DeleteMapping("/manager/{productId}")
+    @DeleteMapping("/{productId}")
     public ResponseEntity<ApiResponse<String>> deleteProduct(@PathVariable UUID productId) {
 
         service.deleteProduct(productId);
+        return new ResponseEntity<>(ApiResponse.success("상품 삭제 성공"), HttpStatus.OK);
+    }
+
+    @RequiredRole(UserRole.COMPANY_USER)
+    @DeleteMapping("/user/{companyUserId}")
+    public ResponseEntity<ApiResponse<String>> deleteProductForUser(@PathVariable UUID companyUserId) {
+
+        service.deleteProductForUser(companyUserId);
         return new ResponseEntity<>(ApiResponse.success("상품 삭제 성공"), HttpStatus.OK);
     }
 }

--- a/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
+++ b/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
@@ -75,7 +75,7 @@ class RedisRepositoryImplTest {
         for (int i = 1; i <= numOfThreads; i++) {
             executorService.submit(() -> {
                 try {
-                    redisRepository.decreaseStockBySale(hashName, productId, dbStock, saleQuantity);
+                    redisRepository.decreaseStockBySale(productId, dbStock, saleQuantity);
                 } finally {
                     latch.countDown();
                 }
@@ -110,8 +110,8 @@ class RedisRepositoryImplTest {
 
         //when
 
-        redisRepository.adjustStock(hashName, productId, afterStock);
-        redisRepository.adjustStock(hashName, productId2, afterStock);
+        redisRepository.adjustStock(productId, afterStock);
+        redisRepository.adjustStock(productId2, afterStock);
 
         //then
         RMap<String, Integer> map = redissonClient.getMap(hashName);

--- a/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
+++ b/product-service/src/test/java/com/palja/product_service/infrastructure/repository/impl/RedisRepositoryImplTest.java
@@ -17,6 +17,8 @@ import org.testcontainers.junit.jupiter.Container;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -50,7 +52,7 @@ class RedisRepositoryImplTest {
     @Autowired
     private RedissonClient redissonClient;
 
-    private final String hashKey = "test:stock";
+    private String hashKey;
 
     @AfterEach
     void clean() {
@@ -61,8 +63,8 @@ class RedisRepositoryImplTest {
     @DisplayName("판매에 의한 재고 차감시, 동시성 이슈가 없어야한다")
     void decreaseStockBySale() throws InterruptedException {
         //given
-        String hashName = hashKey;
         String productId = UUID.randomUUID().toString();
+        hashKey = redisRepository.createRedisHashKey(productId);
         Integer dbStock = 100;
         Integer saleQuantity = 1;
         long beforeTime = LocalDateTime.now().plusMinutes(1).toEpochSecond(ZoneOffset.UTC);
@@ -87,8 +89,8 @@ class RedisRepositoryImplTest {
         long afterTime = LocalDateTime.now().plusMinutes(1).toEpochSecond(ZoneOffset.UTC);
 
         //then
-        RMap<String, Integer> map = redissonClient.getMap(hashName);
-        RScoredSortedSet<String> timeSet = redissonClient.getScoredSortedSet(hashName + "Time");
+        RMap<String, Integer> map = redissonClient.getMap(hashKey);
+        RScoredSortedSet<String> timeSet = redissonClient.getScoredSortedSet(hashKey + "Time");
 
         assertThat(map.get(productId)).isEqualTo(0);
         assertThat(timeSet.size()).isEqualTo(1);
@@ -100,24 +102,48 @@ class RedisRepositoryImplTest {
     @DisplayName("재고 수량 변경에 성공한다")
     void adjustStock() {
         //given
-        String hashName = hashKey;
         String productId = UUID.randomUUID().toString();
-        String productId2 = UUID.randomUUID().toString();
+        hashKey = redisRepository.createRedisHashKey(productId);
         Integer beforeStock = 100;
         Integer afterStock = 200;
 
-        redissonClient.getMap(hashName).fastPut(productId, beforeStock);
+        redissonClient.getMap(hashKey).fastPut(productId, beforeStock);
 
         //when
-
         redisRepository.adjustStock(productId, afterStock);
-        redisRepository.adjustStock(productId2, afterStock);
 
         //then
-        RMap<String, Integer> map = redissonClient.getMap(hashName);
+        RMap<String, Integer> map = redissonClient.getMap(hashKey);
 
-        assertThat(map.size()).isEqualTo(2);
+        assertThat(map.size()).isEqualTo(1);
         assertThat(map.get(productId)).isEqualTo(afterStock);
-        assertThat(map.get(productId2)).isEqualTo(afterStock);
+    }
+
+    @Test
+    @DisplayName("ID리스트에 해당하는 수량데이터를 삭제한다")
+    void deleteAllStockFromRedis() throws InterruptedException {
+        //given
+        List<UUID> ids = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            ids.add(UUID.randomUUID());
+        }
+
+        List<String> hashKeys = new ArrayList<>();
+        for (UUID id : ids) {
+            hashKey = redisRepository.createRedisHashKey(id.toString());
+            hashKeys.add(hashKey);
+            RMap<String, Integer> map = redissonClient.getMap(hashKey);
+            map.fastPut(id.toString(), 100);
+        }
+
+        //when
+        boolean result = redisRepository.deleteAllStockFromRedis(ids);
+
+        //then
+        assertThat(result).isTrue();
+        for (String hashKey : hashKeys) {
+            assertThat(redissonClient.getMap(hashKey)).isEmpty();
+            redissonClient.getMap(hashKey).clear();
+        }
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #234 

<br>

## 📌 개요
- 회원이 탈퇴할때, DB에 존재하는 해당 회원의 companyUserId를 가진 모든 상품들의 논리적 삭제
- 회원이 탈퇴할때, 레디스에 존재하는 해당 회원의 companyUserId를 가진 모든 상품 재고들의 삭제
- 그 외 리팩토링

<br>

## 🔁 변경 사항

1. 각 API에 manager가 잘못 쓰이고 있던 부분을 수정했습니다.
2. 레디스의 해시 키를 만드는 작업을 서비스 클래스가 아닌 RedisRepository에서 담당하도록 변경했고, 이에 따라 내부 코드들의 변경이 있습니다.
3. 테스트 코드에 재고변경을 하나의 상품으로만 테스트하도록 변경했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
