### PR TITLE
FEAT/PaymentService에서 결제 승인 완료 시 order-service 결제 완료 API 연동

### DIFF
--- a/payment-service/src/main/java/com/palja/payment_service/application/port/OrderClient.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/port/OrderClient.java
@@ -2,8 +2,11 @@ package com.palja.payment_service.application.port;
 
 import com.palja.payment_service.application.dto.external.OrderRes;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 public interface OrderClient {
     OrderRes getOrderByOrderId(UUID orderId);
+
+    void completeOrderPayment(UUID orderId, UUID paymentId, BigDecimal paidAmount);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
@@ -147,6 +147,12 @@ public class PaymentServiceImpl implements PaymentService {
             throw new BusinessException(PaymentErrorCode.PAYMENT_FAILED);
         }
 
+        orderClient.completeOrderPayment(
+                payment.getOrderId(),
+                payment.getId(),
+                payment.getAmount()
+        );
+
         log.info("결제 생성 완료: paymentId={}, userId={}", payment.getId(), payment.getUserId());
         return CreatePaymentRes.from(payment);
     }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/OrderFeignClient.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/OrderFeignClient.java
@@ -1,10 +1,13 @@
 package com.palja.payment_service.infrastructure.external;
 
 import com.palja.common.response.ApiResponse;
+import com.palja.payment_service.infrastructure.external.dto.request.CompleteOrderPaymentDTO;
 import com.palja.payment_service.infrastructure.external.dto.response.OrderDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.UUID;
 
@@ -12,4 +15,9 @@ import java.util.UUID;
 public interface OrderFeignClient {
     @GetMapping("/{orderId}")
     ApiResponse<OrderDTO> getOrderByOrderId(@PathVariable("orderId") UUID orderId);
+
+    @PutMapping("/{orderId}/payment/complete")
+    ApiResponse<Void> completeOrderPayment(
+            @PathVariable("orderId") UUID orderId,
+            @RequestBody CompleteOrderPaymentDTO dto);
 }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/adapter/OrderAdapter.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/adapter/OrderAdapter.java
@@ -6,6 +6,7 @@ import com.palja.payment_service.application.dto.external.OrderRes;
 import com.palja.payment_service.application.port.OrderClient;
 import com.palja.payment_service.exception.PaymentErrorCode;
 import com.palja.payment_service.infrastructure.external.OrderFeignClient;
+import com.palja.payment_service.infrastructure.external.dto.request.CompleteOrderPaymentDTO;
 import com.palja.payment_service.infrastructure.external.dto.response.OrderDTO;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +53,25 @@ public class OrderAdapter implements OrderClient {
         } catch (Exception e) {
             log.error("주문 조회 중 예상치 못한 오류: orderId={}, error={}",
                     orderId, e.getClass().getName(), e);
+            throw new BusinessException(PaymentErrorCode.ORDER_SERVICE_UNAVAILABLE);
+        }
+    }
+
+    @Override
+    public void completeOrderPayment(UUID orderId, UUID paymentId, BigDecimal paidAmount) {
+        try {
+            orderFeignClient.completeOrderPayment(
+                    orderId,
+                    CompleteOrderPaymentDTO.builder()
+                            .paymentId(paymentId)
+                            .paidAmount(paidAmount)
+                            .build()
+            );
+            log.info("주문 결제완료 연동 성공: orderId={}, paymentId={}, paidAmount={}",
+                    orderId, paymentId, paidAmount);
+        } catch (FeignException e) {
+            log.error("주문 결제완료 연동 실패: orderId={}, paymentId={}, status={}, msg={}",
+                    orderId, paymentId, e.status(), e.getMessage(), e);
             throw new BusinessException(PaymentErrorCode.ORDER_SERVICE_UNAVAILABLE);
         }
     }

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/dto/request/CompleteOrderPaymentDTO.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/dto/request/CompleteOrderPaymentDTO.java
@@ -1,0 +1,18 @@
+package com.palja.payment_service.infrastructure.external.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompleteOrderPaymentDTO {
+    private UUID paymentId;
+    private BigDecimal paidAmount;
+}

--- a/payment-service/src/main/java/com/palja/payment_service/presentation/controller/impl/PaymentControllerImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/presentation/controller/impl/PaymentControllerImpl.java
@@ -49,7 +49,6 @@ public class PaymentControllerImpl implements PaymentController {
 
     @Override
     @PostMapping("/{paymentId}/complete")
-    @RequiredInternal
     @RequiredRole({UserRole.MANAGER, UserRole.CUSTOMER})
     public ResponseEntity<ApiResponse<CreatePaymentRes>> completePayment(
             @PathVariable UUID paymentId,


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #244 

<br>

## 📌 개요
- PaymentService에서 결제 승인 완료 시 order-service 결제 완료 API를 호출하여 주문 상태를 CREATED->PAID로 동기화하도록 연동했습니다.

<br>

## 🔁 변경 사항
- order-service 결제 완료 API 호출을 위한 OrderClient 인터페이스 확장
- OrderFeignClient에 주문 결제 완료 PUT API 연동 추가
- OrderAdapter에서 결제 완료 요청 DTO 구성 및 예외 처리 로직 구현
- 결제 승인 성공 시 PaymentService.completePayment()에서 주문 결제 완료 API 호출

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
- 현재는 결제 승인 완료 후 order-service로 동기 호출 방식으로 연동했습니다.
- 주문 결제 완료 동기화 실패 시를 대비해, 추후 Outbox 패턴 + Kafka 기반 비동기 이벤트 발행으로 개선할 예정입니다.

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
