### PR TITLE
FEAT/ UserService 단건 조회 API에 캐싱 적용

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
     implementation 'io.github.openfeign:feign-micrometer'
     implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 dependencyManagement {

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCompanyUserDetailRes.java
@@ -6,11 +6,15 @@ import java.util.UUID;
 import com.palja.user_service.domain.entity.CompanyUser;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReadCompanyUserDetailRes {
 
 	private Long userId;

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCustomerDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadCustomerDetailRes.java
@@ -5,11 +5,15 @@ import java.time.LocalDateTime;
 import com.palja.user_service.domain.entity.User;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReadCustomerDetailRes {
 
 	private Long userId;

--- a/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadManagerDetailRes.java
+++ b/user-service/src/main/java/com/palja/user_service/application/dto/response/ReadManagerDetailRes.java
@@ -5,11 +5,15 @@ import java.time.LocalDateTime;
 import com.palja.user_service.domain.entity.User;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReadManagerDetailRes {
 
 	private Long userId;

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -87,7 +87,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	}
 
 	@Override
-	@Cacheable(cacheNames = "user:companyUser", key = "'loginId:' + #loginId")
+	@Cacheable(cacheNames = COMPANY_USER_CACHE_PREFIX, key = "'loginId:' + #loginId")
 	public ReadCompanyUserDetailRes getCompanyUserByLoginId(String currentUserLoginId, String loginId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -95,7 +95,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	}
 
 	@Override
-	@Cacheable(cacheNames = "user:companyUser", key = "'companyUserId:' + #companyUserId")
+	@Cacheable(cacheNames = COMPANY_USER_CACHE_PREFIX, key = "'companyUserId:' + #companyUserId")
 	public ReadCompanyUserDetailRes getCompanyUserByCompanyUserId(String currentUserLoginId, UUID companyUserId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -103,7 +103,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	}
 
 	@Override
-	@Cacheable(cacheNames = "user:companyUser", key = "'loginId:' + #currentUserLoginId")
+	@Cacheable(cacheNames = COMPANY_USER_CACHE_PREFIX, key = "'loginId:' + #currentUserLoginId")
 	public ReadCompanyUserDetailRes getMe(String currentUserLoginId) {
 		return ReadCompanyUserDetailRes.from(getCompanyUserByLoginId(currentUserLoginId));
 	}
@@ -111,8 +111,8 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	@Override
 	@Transactional
 	@Caching(evict = {
-		@CacheEvict(cacheNames = "user:companyUser", key = "'loginId:' + #result.loginId"),
-		@CacheEvict(cacheNames = "user:companyUser", key = "'companyUserId:' + #result.companyUserId")
+		@CacheEvict(cacheNames = COMPANY_USER_CACHE_PREFIX, key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = COMPANY_USER_CACHE_PREFIX, key = "'companyUserId:' + #result.companyUserId")
 	})
 	public UpdateCompanyUserDetailRes updateCompanyUserByLoginId(
 		String currentUserLoginId, String loginId, UpdateCompanyUserCommand command
@@ -128,8 +128,8 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	@Override
 	@Transactional
 	@Caching(evict = {
-		@CacheEvict(cacheNames = "user:companyUser", key = "'loginId:' + #result.loginId"),
-		@CacheEvict(cacheNames = "user:companyUser", key = "'companyUserId:' + #result.companyUserId")
+		@CacheEvict(cacheNames = COMPANY_USER_CACHE_PREFIX, key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = COMPANY_USER_CACHE_PREFIX, key = "'companyUserId:' + #result.companyUserId")
 	})
 	public UpdateCompanyUserDetailRes updateMe(String currentUserLoginId, UpdateCompanyUserCommand command) {
 		CompanyUser companyUser = getCompanyUserByLoginId(currentUserLoginId);
@@ -248,7 +248,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	}
 
 	private void removeCache(CompanyUser companyUser) {
-		Cache cache = cacheManager.getCache("user:companyUser");
+		Cache cache = cacheManager.getCache(COMPANY_USER_CACHE_PREFIX);
 		if (cache != null) {
 			cache.evict("loginId:" + companyUser.getUser().getLoginId());
 			cache.evict("companyUserId:" + companyUser.getId());

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -4,6 +4,11 @@ import static com.palja.user_service.application.util.RedisKeyConstants.*;
 
 import java.util.UUID;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -48,6 +53,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtil jwtUtil;
+	private final CacheManager cacheManager;
 
 	@Override
 	@Transactional
@@ -81,6 +87,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "user:companyUser", key = "'loginId:' + #loginId")
 	public ReadCompanyUserDetailRes getCompanyUserByLoginId(String currentUserLoginId, String loginId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -88,6 +95,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "user:companyUser", key = "'companyUserId:' + #companyUserId")
 	public ReadCompanyUserDetailRes getCompanyUserByCompanyUserId(String currentUserLoginId, UUID companyUserId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -95,12 +103,17 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "user:companyUser", key = "'loginId:' + #currentUserLoginId")
 	public ReadCompanyUserDetailRes getMe(String currentUserLoginId) {
 		return ReadCompanyUserDetailRes.from(getCompanyUserByLoginId(currentUserLoginId));
 	}
 
 	@Override
 	@Transactional
+	@Caching(evict = {
+		@CacheEvict(cacheNames = "user:companyUser", key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = "user:companyUser", key = "'companyUserId:' + #result.companyUserId")
+	})
 	public UpdateCompanyUserDetailRes updateCompanyUserByLoginId(
 		String currentUserLoginId, String loginId, UpdateCompanyUserCommand command
 	) {
@@ -114,6 +127,10 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 
 	@Override
 	@Transactional
+	@Caching(evict = {
+		@CacheEvict(cacheNames = "user:companyUser", key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = "user:companyUser", key = "'companyUserId:' + #result.companyUserId")
+	})
 	public UpdateCompanyUserDetailRes updateMe(String currentUserLoginId, UpdateCompanyUserCommand command) {
 		CompanyUser companyUser = getCompanyUserByLoginId(currentUserLoginId);
 		companyUser.update(command.companyName(), command.address());
@@ -126,8 +143,14 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	public void updateCompanyUserStatus(String currentUserLoginId, String loginId, UpdateCompanyUserStatusCommand command) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
-		User companyUser = getUserByLoginId(loginId);
+		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
 		companyUser.updateStatus(command.status());
+
+		Cache cache = cacheManager.getCache("user:companyUser");
+		if (cache != null) {
+			cache.evict("loginId:" + companyUser.getUser().getLoginId());
+			cache.evict("companyUserId:" + companyUser.getId());
+		}
 	}
 
 	@Override
@@ -139,6 +162,12 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		companyUser.softDelete();
 		timeDealClient.deleteAllTimeDeals(companyUser.getId());
 		productClient.deleteAllProducts(companyUser.getId());
+
+		Cache cache = cacheManager.getCache("user:companyUser");
+		if (cache != null) {
+			cache.evict("loginId:" + companyUser.getUser().getLoginId());
+			cache.evict("companyUserId:" + companyUser.getId());
+		}
 	}
 
 	@Override
@@ -158,6 +187,12 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 			ACCESS_TOKEN_BLACKLIST_PREFIX + currentUserLoginId + ":" + hashKey, substringAccessToken, jwtUtil.getAccessKeyExpirationTime()
 		);
 		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + currentUserLoginId);
+
+		Cache cache = cacheManager.getCache("user:companyUser");
+		if (cache != null) {
+			cache.evict("loginId:" + companyUser.getUser().getLoginId());
+			cache.evict("companyUserId:" + companyUser.getId());
+		}
 	}
 
 	@Override
@@ -168,12 +203,6 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
 		validateStatusIsPending(companyUser);
 		companyUser.softDelete();
-	}
-
-	private User getUserByLoginId(String loginId) {
-		return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
-			() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
-		);
 	}
 
 	private CompanyUser getCompanyUserByLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CompanyUserServiceImpl.java
@@ -146,11 +146,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
 		companyUser.updateStatus(command.status());
 
-		Cache cache = cacheManager.getCache("user:companyUser");
-		if (cache != null) {
-			cache.evict("loginId:" + companyUser.getUser().getLoginId());
-			cache.evict("companyUserId:" + companyUser.getId());
-		}
+		removeCache(companyUser);
 	}
 
 	@Override
@@ -163,11 +159,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		timeDealClient.deleteAllTimeDeals(companyUser.getId());
 		productClient.deleteAllProducts(companyUser.getId());
 
-		Cache cache = cacheManager.getCache("user:companyUser");
-		if (cache != null) {
-			cache.evict("loginId:" + companyUser.getUser().getLoginId());
-			cache.evict("companyUserId:" + companyUser.getId());
-		}
+		removeCache(companyUser);
 	}
 
 	@Override
@@ -188,11 +180,7 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		);
 		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + currentUserLoginId);
 
-		Cache cache = cacheManager.getCache("user:companyUser");
-		if (cache != null) {
-			cache.evict("loginId:" + companyUser.getUser().getLoginId());
-			cache.evict("companyUserId:" + companyUser.getId());
-		}
+		removeCache(companyUser);
 	}
 
 	@Override
@@ -203,6 +191,8 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 		CompanyUser companyUser = getCompanyUserByLoginId(loginId);
 		validateStatusIsPending(companyUser);
 		companyUser.softDelete();
+
+		removeCache(companyUser);
 	}
 
 	private CompanyUser getCompanyUserByLoginId(String loginId) {
@@ -254,6 +244,14 @@ public class CompanyUserServiceImpl implements CompanyUserService {
 	private void validateTokenIsNotNull(String token) {
 		if (token == null) {
 			throw new BusinessException(AuthErrorCode.NOT_FOUND_TOKEN);
+		}
+	}
+
+	private void removeCache(CompanyUser companyUser) {
+		Cache cache = cacheManager.getCache("user:companyUser");
+		if (cache != null) {
+			cache.evict("loginId:" + companyUser.getUser().getLoginId());
+			cache.evict("companyUserId:" + companyUser.getId());
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -2,6 +2,11 @@ package com.palja.user_service.application.service.impl;
 
 import static com.palja.user_service.application.util.RedisKeyConstants.*;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -39,6 +44,7 @@ public class CustomerServiceImpl implements CustomerService {
 
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtil jwtUtil;
+	private final CacheManager cacheManager;
 
 	@Override
 	@Transactional
@@ -70,6 +76,7 @@ public class CustomerServiceImpl implements CustomerService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "user:customer", key = "'loginId:' + #loginId")
 	public ReadCustomerDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -77,6 +84,7 @@ public class CustomerServiceImpl implements CustomerService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "user:customer", key = "'userId:' + #userId")
 	public ReadCustomerDetailRes getCustomerByUserId(String currentUserLoginId, Long userId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -84,12 +92,17 @@ public class CustomerServiceImpl implements CustomerService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "user:customer", key = "'loginId:' + #currentUserLoginId")
 	public ReadCustomerDetailRes getMe(String currentUserLoginId) {
 		return ReadCustomerDetailRes.from(getCustomerByLoginId(currentUserLoginId));
 	}
 
 	@Override
 	@Transactional
+	@Caching(evict = {
+		@CacheEvict(cacheNames = "user:customer", key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = "user:customer", key = "'userId:' + #result.userId")
+	})
 	public UpdateCustomerDetailRes updateCustomerByLoginId(
 		String currentUserLoginId, String loginId, UpdateCustomerCommand command
 	) {
@@ -103,6 +116,10 @@ public class CustomerServiceImpl implements CustomerService {
 
 	@Override
 	@Transactional
+	@Caching(evict = {
+		@CacheEvict(cacheNames = "user:customer", key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = "user:customer", key = "'userId:' + #result.userId")
+	})
 	public UpdateCustomerDetailRes updateMe(String currentUserLoginId, UpdateCustomerCommand command) {
 		User user = getCustomerByLoginId(currentUserLoginId);
 		user.update(command.address());
@@ -118,6 +135,12 @@ public class CustomerServiceImpl implements CustomerService {
 		User user = getCustomerByLoginId(loginId);
 		user.softDelete();
 		reviewClient.deleteAllReviews(user.getId());
+
+		Cache cache = cacheManager.getCache("user:customer");
+		if (cache != null) {
+			cache.evict("loginId:" + user.getLoginId());
+			cache.evict("userId:" + user.getId());
+		}
 	}
 
 	@Override
@@ -136,6 +159,12 @@ public class CustomerServiceImpl implements CustomerService {
 			ACCESS_TOKEN_BLACKLIST_PREFIX + currentUserLoginId + ":" + hashKey, substringAccessToken, jwtUtil.getAccessKeyExpirationTime()
 		);
 		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + currentUserLoginId);
+
+		Cache cache = cacheManager.getCache("user:customer");
+		if (cache != null) {
+			cache.evict("loginId:" + user.getLoginId());
+			cache.evict("userId:" + user.getId());
+		}
 	}
 
 	private User getCustomerByLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -76,7 +76,7 @@ public class CustomerServiceImpl implements CustomerService {
 	}
 
 	@Override
-	@Cacheable(cacheNames = "user:customer", key = "'loginId:' + #loginId")
+	@Cacheable(cacheNames = CUSTOMER_CACHE_PREFIX, key = "'loginId:' + #loginId")
 	public ReadCustomerDetailRes getCustomerByLoginId(String currentUserLoginId, String loginId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -84,7 +84,7 @@ public class CustomerServiceImpl implements CustomerService {
 	}
 
 	@Override
-	@Cacheable(cacheNames = "user:customer", key = "'userId:' + #userId")
+	@Cacheable(cacheNames = CUSTOMER_CACHE_PREFIX, key = "'userId:' + #userId")
 	public ReadCustomerDetailRes getCustomerByUserId(String currentUserLoginId, Long userId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -92,7 +92,7 @@ public class CustomerServiceImpl implements CustomerService {
 	}
 
 	@Override
-	@Cacheable(cacheNames = "user:customer", key = "'loginId:' + #currentUserLoginId")
+	@Cacheable(cacheNames = CUSTOMER_CACHE_PREFIX, key = "'loginId:' + #currentUserLoginId")
 	public ReadCustomerDetailRes getMe(String currentUserLoginId) {
 		return ReadCustomerDetailRes.from(getCustomerByLoginId(currentUserLoginId));
 	}
@@ -100,8 +100,8 @@ public class CustomerServiceImpl implements CustomerService {
 	@Override
 	@Transactional
 	@Caching(evict = {
-		@CacheEvict(cacheNames = "user:customer", key = "'loginId:' + #result.loginId"),
-		@CacheEvict(cacheNames = "user:customer", key = "'userId:' + #result.userId")
+		@CacheEvict(cacheNames = CUSTOMER_CACHE_PREFIX, key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = CUSTOMER_CACHE_PREFIX, key = "'userId:' + #result.userId")
 	})
 	public UpdateCustomerDetailRes updateCustomerByLoginId(
 		String currentUserLoginId, String loginId, UpdateCustomerCommand command
@@ -117,8 +117,8 @@ public class CustomerServiceImpl implements CustomerService {
 	@Override
 	@Transactional
 	@Caching(evict = {
-		@CacheEvict(cacheNames = "user:customer", key = "'loginId:' + #result.loginId"),
-		@CacheEvict(cacheNames = "user:customer", key = "'userId:' + #result.userId")
+		@CacheEvict(cacheNames = CUSTOMER_CACHE_PREFIX, key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = CUSTOMER_CACHE_PREFIX, key = "'userId:' + #result.userId")
 	})
 	public UpdateCustomerDetailRes updateMe(String currentUserLoginId, UpdateCustomerCommand command) {
 		User user = getCustomerByLoginId(currentUserLoginId);
@@ -196,7 +196,7 @@ public class CustomerServiceImpl implements CustomerService {
 	}
 
 	private void removeCache(User user) {
-		Cache cache = cacheManager.getCache("user:customer");
+		Cache cache = cacheManager.getCache(CUSTOMER_CACHE_PREFIX);
 		if (cache != null) {
 			cache.evict("loginId:" + user.getLoginId());
 			cache.evict("userId:" + user.getId());

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/CustomerServiceImpl.java
@@ -136,11 +136,7 @@ public class CustomerServiceImpl implements CustomerService {
 		user.softDelete();
 		reviewClient.deleteAllReviews(user.getId());
 
-		Cache cache = cacheManager.getCache("user:customer");
-		if (cache != null) {
-			cache.evict("loginId:" + user.getLoginId());
-			cache.evict("userId:" + user.getId());
-		}
+		removeCache(user);
 	}
 
 	@Override
@@ -160,11 +156,7 @@ public class CustomerServiceImpl implements CustomerService {
 		);
 		tokenRepository.remove(REFRESH_TOKEN_WHITELIST_PREFIX + currentUserLoginId);
 
-		Cache cache = cacheManager.getCache("user:customer");
-		if (cache != null) {
-			cache.evict("loginId:" + user.getLoginId());
-			cache.evict("userId:" + user.getId());
-		}
+		removeCache(user);
 	}
 
 	private User getCustomerByLoginId(String loginId) {
@@ -200,6 +192,14 @@ public class CustomerServiceImpl implements CustomerService {
 	private void validateTokenIsNotNull(String token) {
 		if (token == null) {
 			throw new BusinessException(AuthErrorCode.NOT_FOUND_TOKEN);
+		}
+	}
+
+	private void removeCache(User user) {
+		Cache cache = cacheManager.getCache("user:customer");
+		if (cache != null) {
+			cache.evict("loginId:" + user.getLoginId());
+			cache.evict("userId:" + user.getId());
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -1,5 +1,10 @@
 package com.palja.user_service.application.service.impl;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -29,6 +34,7 @@ public class ManagerServiceImpl implements ManagerService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final CacheManager cacheManager;
 
 	@Override
 	@Transactional
@@ -60,6 +66,7 @@ public class ManagerServiceImpl implements ManagerService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "user:manager", key = "'loginId:' + #loginId")
 	public ReadManagerDetailRes getManagerByLoginId(String currentUserLoginId, String loginId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -67,6 +74,7 @@ public class ManagerServiceImpl implements ManagerService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "user:manager", key = "'userId:' + #userId")
 	public ReadManagerDetailRes getManagerByUserId(String currentUserLoginId, Long userId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -74,12 +82,17 @@ public class ManagerServiceImpl implements ManagerService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "user:manager", key = "'loginId:' + #currentUserLoginId")
 	public ReadManagerDetailRes getMe(String currentUserLoginId) {
 		return ReadManagerDetailRes.from(getUserByLoginId(currentUserLoginId));
 	}
 
 	@Override
 	@Transactional
+	@Caching(evict = {
+		@CacheEvict(cacheNames = "user:manager", key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = "user:manager", key = "'userId:' + #result.userId")
+	})
 	public UpdateManagerDetailRes updateManagerByLoginId(String loginId, UpdateManagerCommand command) {
 		User user = getManagerByLoginId(loginId);
 		user.update(command.address());
@@ -89,6 +102,10 @@ public class ManagerServiceImpl implements ManagerService {
 
 	@Override
 	@Transactional
+	@Caching(evict = {
+		@CacheEvict(cacheNames = "user:manager", key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = "user:manager", key = "'userId:' + #result.userId")
+	})
 	public UpdateManagerDetailRes updateMe(String currentUserLoginId, UpdateManagerCommand command) {
 		User user = getUserByLoginId(currentUserLoginId);
 		user.update(command.address());
@@ -101,6 +118,12 @@ public class ManagerServiceImpl implements ManagerService {
 	public void deleteManagerByLoginId(String loginId) {
 		User user = getManagerByLoginId(loginId);
 		user.softDelete();
+
+		Cache cache = cacheManager.getCache("user:manager");
+		if (cache != null) {
+			cache.evict("loginId:" + user.getLoginId());
+			cache.evict("userId:" + user.getId());
+		}
 	}
 
 	private User getUserByLoginId(String loginId) {

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -1,5 +1,7 @@
 package com.palja.user_service.application.service.impl;
 
+import static com.palja.user_service.application.util.RedisKeyConstants.*;
+
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
@@ -66,7 +68,7 @@ public class ManagerServiceImpl implements ManagerService {
 	}
 
 	@Override
-	@Cacheable(cacheNames = "user:manager", key = "'loginId:' + #loginId")
+	@Cacheable(cacheNames = MANAGER_CACHE_PREFIX, key = "'loginId:' + #loginId")
 	public ReadManagerDetailRes getManagerByLoginId(String currentUserLoginId, String loginId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -74,7 +76,7 @@ public class ManagerServiceImpl implements ManagerService {
 	}
 
 	@Override
-	@Cacheable(cacheNames = "user:manager", key = "'userId:' + #userId")
+	@Cacheable(cacheNames = MANAGER_CACHE_PREFIX, key = "'userId:' + #userId")
 	public ReadManagerDetailRes getManagerByUserId(String currentUserLoginId, Long userId) {
 		validateUserExistsByLoginId(currentUserLoginId);
 
@@ -82,7 +84,7 @@ public class ManagerServiceImpl implements ManagerService {
 	}
 
 	@Override
-	@Cacheable(cacheNames = "user:manager", key = "'loginId:' + #currentUserLoginId")
+	@Cacheable(cacheNames = MANAGER_CACHE_PREFIX, key = "'loginId:' + #currentUserLoginId")
 	public ReadManagerDetailRes getMe(String currentUserLoginId) {
 		return ReadManagerDetailRes.from(getUserByLoginId(currentUserLoginId));
 	}
@@ -90,8 +92,8 @@ public class ManagerServiceImpl implements ManagerService {
 	@Override
 	@Transactional
 	@Caching(evict = {
-		@CacheEvict(cacheNames = "user:manager", key = "'loginId:' + #result.loginId"),
-		@CacheEvict(cacheNames = "user:manager", key = "'userId:' + #result.userId")
+		@CacheEvict(cacheNames = MANAGER_CACHE_PREFIX, key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = MANAGER_CACHE_PREFIX, key = "'userId:' + #result.userId")
 	})
 	public UpdateManagerDetailRes updateManagerByLoginId(String loginId, UpdateManagerCommand command) {
 		User user = getManagerByLoginId(loginId);
@@ -103,8 +105,8 @@ public class ManagerServiceImpl implements ManagerService {
 	@Override
 	@Transactional
 	@Caching(evict = {
-		@CacheEvict(cacheNames = "user:manager", key = "'loginId:' + #result.loginId"),
-		@CacheEvict(cacheNames = "user:manager", key = "'userId:' + #result.userId")
+		@CacheEvict(cacheNames = MANAGER_CACHE_PREFIX, key = "'loginId:' + #result.loginId"),
+		@CacheEvict(cacheNames = MANAGER_CACHE_PREFIX, key = "'userId:' + #result.userId")
 	})
 	public UpdateManagerDetailRes updateMe(String currentUserLoginId, UpdateManagerCommand command) {
 		User user = getUserByLoginId(currentUserLoginId);
@@ -159,7 +161,7 @@ public class ManagerServiceImpl implements ManagerService {
 	}
 
 	private void removeCache(User user) {
-		Cache cache = cacheManager.getCache("user:manager");
+		Cache cache = cacheManager.getCache(MANAGER_CACHE_PREFIX);
 		if (cache != null) {
 			cache.evict("loginId:" + user.getLoginId());
 			cache.evict("userId:" + user.getId());

--- a/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
+++ b/user-service/src/main/java/com/palja/user_service/application/service/impl/ManagerServiceImpl.java
@@ -119,11 +119,7 @@ public class ManagerServiceImpl implements ManagerService {
 		User user = getManagerByLoginId(loginId);
 		user.softDelete();
 
-		Cache cache = cacheManager.getCache("user:manager");
-		if (cache != null) {
-			cache.evict("loginId:" + user.getLoginId());
-			cache.evict("userId:" + user.getId());
-		}
+		removeCache(user);
 	}
 
 	private User getUserByLoginId(String loginId) {
@@ -159,6 +155,14 @@ public class ManagerServiceImpl implements ManagerService {
 	private void validateDuplicateEmail(String email) {
 		if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
 			throw new BusinessException(UserErrorCode.DUPLICATED_EMAIL);
+		}
+	}
+
+	private void removeCache(User user) {
+		Cache cache = cacheManager.getCache("user:manager");
+		if (cache != null) {
+			cache.evict("loginId:" + user.getLoginId());
+			cache.evict("userId:" + user.getId());
 		}
 	}
 

--- a/user-service/src/main/java/com/palja/user_service/application/util/CacheType.java
+++ b/user-service/src/main/java/com/palja/user_service/application/util/CacheType.java
@@ -1,4 +1,6 @@
-package com.palja.user_service.infrastructure.util;
+package com.palja.user_service.application.util;
+
+import static com.palja.user_service.application.util.RedisKeyConstants.*;
 
 import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
 import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
@@ -12,9 +14,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum CacheType {
 
-	MANAGER("user:manager", ReadManagerDetailRes.class),
-	CUSTOMER("user:customer", ReadCustomerDetailRes.class),
-	COMPANY_USER("user:companyUser", ReadCompanyUserDetailRes.class),
+	MANAGER(MANAGER_CACHE_PREFIX, ReadManagerDetailRes.class),
+	CUSTOMER(CUSTOMER_CACHE_PREFIX, ReadCustomerDetailRes.class),
+	COMPANY_USER(COMPANY_USER_CACHE_PREFIX, ReadCompanyUserDetailRes.class),
 	;
 
 	private final String cacheName;

--- a/user-service/src/main/java/com/palja/user_service/application/util/RedisKeyConstants.java
+++ b/user-service/src/main/java/com/palja/user_service/application/util/RedisKeyConstants.java
@@ -6,7 +6,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RedisKeyConstants {
 
+	/// Token Key
 	public static final String ACCESS_TOKEN_BLACKLIST_PREFIX = "AUTH:BL:AT:";
 	public static final String REFRESH_TOKEN_WHITELIST_PREFIX = "AUTH:WL:RT:";
+
+	/// Cache Key
+	public static final String MANAGER_CACHE_PREFIX = "user:manager";
+	public static final String CUSTOMER_CACHE_PREFIX = "user:customer";
+	public static final String COMPANY_USER_CACHE_PREFIX = "user:companyUser";
 
 }

--- a/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
@@ -61,7 +61,7 @@ public class User extends BaseEntity {
 		this.email = email;
 		this.address = address;
 		this.role = role;
-		this.status = UserStatus.ACTIVE;
+		this.status = this.role == UserRole.COMPANY_USER ? UserStatus.PENDING : UserStatus.ACTIVE;
 	}
 
 	public static User create(String loginId, String password, String name, String email, String address, UserRole role) {

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/config/RedisConfig.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/config/RedisConfig.java
@@ -1,17 +1,33 @@
 package com.palja.user_service.infrastructure.config;
 
+import static org.springframework.data.redis.serializer.RedisSerializationContext.*;
+
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.palja.user_service.infrastructure.util.CacheType;
+
+@EnableCaching
 @Configuration
 public class RedisConfig {
 
@@ -37,6 +53,28 @@ public class RedisConfig {
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setValueSerializer(new StringRedisSerializer());
 		return redisTemplate;
+	}
+
+	@Bean
+	public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		Map<String, RedisCacheConfiguration> redisCacheConfigurationMap = new HashMap<>();
+		for (CacheType cache : CacheType.values()) {
+			redisCacheConfigurationMap.put(
+				cache.getCacheName(), RedisCacheConfiguration.defaultCacheConfig()
+					.disableCachingNullValues()
+					.entryTtl(Duration.ofMinutes(30))
+					.serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+					.serializeValuesWith(SerializationPair.fromSerializer(new Jackson2JsonRedisSerializer<>(objectMapper, cache.getValueType())))
+			);
+		}
+
+		return RedisCacheManager.builder(redisConnectionFactory)
+			.withInitialCacheConfigurations(redisCacheConfigurationMap)
+			.build();
 	}
 
 }

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/config/RedisConfig.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/config/RedisConfig.java
@@ -23,7 +23,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.palja.user_service.infrastructure.util.CacheType;
+import com.palja.user_service.application.util.CacheType;
 
 @EnableCaching
 @Configuration

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/config/RedisConfig.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/config/RedisConfig.java
@@ -17,11 +17,9 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/util/CacheType.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/util/CacheType.java
@@ -14,7 +14,7 @@ public enum CacheType {
 
 	MANAGER("user:manager", ReadManagerDetailRes.class),
 	CUSTOMER("user:customer", ReadCustomerDetailRes.class),
-	COMPANY_USER("user:company_user", ReadCompanyUserDetailRes.class),
+	COMPANY_USER("user:companyUser", ReadCompanyUserDetailRes.class),
 	;
 
 	private final String cacheName;

--- a/user-service/src/main/java/com/palja/user_service/infrastructure/util/CacheType.java
+++ b/user-service/src/main/java/com/palja/user_service/infrastructure/util/CacheType.java
@@ -1,0 +1,23 @@
+package com.palja.user_service.infrastructure.util;
+
+import com.palja.user_service.application.dto.response.ReadCompanyUserDetailRes;
+import com.palja.user_service.application.dto.response.ReadCustomerDetailRes;
+import com.palja.user_service.application.dto.response.ReadManagerDetailRes;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CacheType {
+
+	MANAGER("user:manager", ReadManagerDetailRes.class),
+	CUSTOMER("user:customer", ReadCustomerDetailRes.class),
+	COMPANY_USER("user:company_user", ReadCompanyUserDetailRes.class),
+	;
+
+	private final String cacheName;
+	private final Class<?> valueType;
+
+}

--- a/user-service/src/test/java/com/palja/user_service/service/CompanyUserServiceImplTest.java
+++ b/user-service/src/test/java/com/palja/user_service/service/CompanyUserServiceImplTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -57,6 +58,7 @@ public class CompanyUserServiceImplTest {
 	@Mock private ProductClient productClient;
 	@Mock private PasswordEncoder passwordEncoder;
 	@Mock private JwtUtil jwtUtil;
+	@Mock private CacheManager cacheManager;
 
 	private User user1;
 	private User user2;
@@ -485,14 +487,14 @@ public class CompanyUserServiceImplTest {
 		void updateCompanyUserStatus_success() {
 			// given
 			given(userRepository.existsByLoginIdAndDeletedAtIsNull(anyString())).willReturn(true);
-			given(userRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(user1));
+			given(companyUserRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(companyUser1));
 
 			// when
 			companyUserService.updateCompanyUserStatus(currentUserLoginId, companyUser1.getUser().getLoginId(), command);
 
 			// then
 			assertThat(user1.getStatus()).isEqualTo(UserStatus.ACTIVE);
-			then(userRepository).should(times(1)).findByLoginIdAndDeletedAtIsNull(anyString());
+			then(companyUserRepository).should(times(1)).findByLoginIdAndDeletedAtIsNull(anyString());
 		}
 
 		@Nested
@@ -516,7 +518,7 @@ public class CompanyUserServiceImplTest {
 			void updateCompanyUserStatus_notFoundUser_failure() {
 				// given
 				given(userRepository.existsByLoginIdAndDeletedAtIsNull(anyString())).willReturn(true);
-				given(userRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.empty());
+				given(companyUserRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.empty());
 
 				// when & then
 				assertThatThrownBy(() -> companyUserService.updateCompanyUserStatus(
@@ -528,16 +530,16 @@ public class CompanyUserServiceImplTest {
 			@DisplayName("유효하지 않은 상태 값")
 			void updateCompanyUserStatus_invalidStatus_failure() {
 				// given
-				UpdateCompanyUserStatusCommand command = UpdateCompanyUserStatusCommand.builder()
+				UpdateCompanyUserStatusCommand errorCommand = UpdateCompanyUserStatusCommand.builder()
 					.status("status")
 					.build();
 
 				given(userRepository.existsByLoginIdAndDeletedAtIsNull(anyString())).willReturn(true);
-				given(userRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(user1));
+				given(companyUserRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(companyUser1));
 
 				// when & then
 				assertThatThrownBy(() -> companyUserService.updateCompanyUserStatus(
-					currentUserLoginId, companyUser1.getUser().getLoginId(), command)
+					currentUserLoginId, companyUser1.getUser().getLoginId(), errorCommand)
 				).isInstanceOf(IllegalArgumentException.class).hasMessage("유효하지 않은 상태 값 입니다.");
 			}
 
@@ -550,7 +552,7 @@ public class CompanyUserServiceImplTest {
 					.build();
 
 				given(userRepository.existsByLoginIdAndDeletedAtIsNull(anyString())).willReturn(true);
-				given(userRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(user1));
+				given(companyUserRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(companyUser1));
 
 				// when & then
 				assertThatThrownBy(() -> companyUserService.updateCompanyUserStatus(
@@ -568,7 +570,7 @@ public class CompanyUserServiceImplTest {
 					.build();
 
 				given(userRepository.existsByLoginIdAndDeletedAtIsNull(anyString())).willReturn(true);
-				given(userRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(user1));
+				given(companyUserRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(companyUser1));
 
 				// when & then
 				assertThatThrownBy(() -> companyUserService.updateCompanyUserStatus(
@@ -586,7 +588,7 @@ public class CompanyUserServiceImplTest {
 					.build();
 
 				given(userRepository.existsByLoginIdAndDeletedAtIsNull(anyString())).willReturn(true);
-				given(userRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(user1));
+				given(companyUserRepository.findByLoginIdAndDeletedAtIsNull(anyString())).willReturn(Optional.of(companyUser1));
 
 				// when & then
 				assertThatThrownBy(() -> companyUserService.updateCompanyUserStatus(

--- a/user-service/src/test/java/com/palja/user_service/service/CustomerServiceImplTest.java
+++ b/user-service/src/test/java/com/palja/user_service/service/CustomerServiceImplTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -47,6 +48,7 @@ public class CustomerServiceImplTest {
 	@Mock private ReviewClient reviewClient;
 	@Mock private PasswordEncoder passwordEncoder;
 	@Mock private JwtUtil jwtUtil;
+	@Mock private CacheManager cacheManager;
 
 	private User customer1;
 	private User customer2;

--- a/user-service/src/test/java/com/palja/user_service/service/ManagerServiceImplTest.java
+++ b/user-service/src/test/java/com/palja/user_service/service/ManagerServiceImplTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +41,7 @@ public class ManagerServiceImplTest {
 
 	@Mock private UserRepository userRepository;
 	@Mock private PasswordEncoder passwordEncoder;
+	@Mock private CacheManager cacheManager;
 
 	private User manager1;
 	private User manager2;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #255 

<br>

## 📌 개요
- 유저 서비스 단건 조회 API에 레디스 캐싱을 적용했습니다.

<br>

## 🔁 변경 사항
- RedisConfig에 RedisCacheManager를 Bean으로 등록했습니다.
  - Jackson2JsonRedisSerializer를 사용하고 CacheType을 Enum으로 생성하여 각 객체의 타입을 등록했습니다.
- 단건 조회 API를 호출할 때 캐시를 저장하고 수정, 삭제 API가 호출될 때 저장된 캐시를 삭제했습니다.
- 역직렬화를 위해 각 ResponseDTO에 생성자 어노테이션을 추가했습니다.
- User 엔티티에서 status 부분 조건문이 삭제돼서 다시 추가했습니다. (ngrinder 테스트 때 코드 수정 후 잘못커밋돼서 삭제됨)
- CompanyUser의 상태를 변경할 때 User를 조회하던 로직을 삭제하고 CompanyUser를 조회하도록 변경했습니다.
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
