### PR TITLE
FEAT/ProductService 단건 조회에 캐싱 적용

### DIFF
--- a/product-service/src/main/java/com/palja/product_service/ProductServiceApplication.java
+++ b/product-service/src/main/java/com/palja/product_service/ProductServiceApplication.java
@@ -2,6 +2,7 @@ package com.palja.product_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableCaching
 @EnableJpaAuditing
 @EnableScheduling
 @EnableFeignClients

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/FindProductRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/FindProductRes.java
@@ -1,13 +1,16 @@
 package com.palja.product_service.application.dto.res;
 
 import com.palja.product_service.domain.entity.Product;
-import com.palja.product_service.domain.vo.Money;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class FindProductRes {
 
     private UUID productId;

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -21,6 +21,7 @@ import com.palja.product_service.domain.service.ProductCategoryService;
 import com.palja.product_service.exception.CategoryErrorCode;
 import com.palja.product_service.exception.ProductErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -58,6 +59,7 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
+    @Cacheable(cacheNames = "productForUser", key = "#productId")
     public FindProductRes findProduct(UUID productId) {
 
         Product product = repository.findProduct(productId);
@@ -81,6 +83,7 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
+    @Cacheable(cacheNames = "productForTimeDeal", key = "#productId")
     public ProductInfoForTimeDealRes findProductForTimeDeal(UUID productId) {
 
         ProductInfoForTimeDealDto dto = repository.findProductForTimeDeal(productId);
@@ -89,6 +92,7 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
+    @Cacheable(cacheNames = "productForOrder", key = "#productId")
     public ProductInfoForOrderRes findProductForOrder(UUID productId) {
 
         ProductInfoForOrderDto dto = repository.findProductForOrder(productId);

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/config/RedisConfig.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package com.palja.product_service.infrastructure.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.IntegerCodec;
@@ -9,12 +11,21 @@ import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
+
+import static org.springframework.data.redis.serializer.RedisSerializationContext.*;
 
 @Configuration
 public class RedisConfig {
@@ -50,5 +61,27 @@ public class RedisConfig {
         ));
 
         return Redisson.create(config);
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory factory, ObjectMapper objectMapper) {
+
+        ObjectMapper mapper = objectMapper.copy();
+        mapper.activateDefaultTyping(
+                mapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL_AND_ENUMS,
+                JsonTypeInfo.As.WRAPPER_OBJECT
+        );
+        GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(mapper);
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeKeysWith(SerializationPair.fromSerializer(RedisSerializer.string()))
+                .serializeValuesWith(SerializationPair.fromSerializer(jsonSerializer))
+                .entryTtl(Duration.ofMinutes(5));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(factory)
+                .cacheDefaults(config)
+                .build();
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
@@ -15,8 +15,11 @@ import java.util.UUID;
 
 public interface JpaProductRepository extends JpaRepository<Product, UUID> {
 
-    @Query("SELECT p FROM Product p JOIN FETCH p.productStock WHERE p.id = :productId AND p.deletedAt IS null")
-    Optional<Product> findByIdFetchStock(@Param("productId") UUID productId);
+    @Query("SELECT p FROM Product p " +
+            "JOIN FETCH p.productStock " +
+            "JOIN FETCH p.category " +
+            "WHERE p.id = :productId AND p.deletedAt IS null")
+    Optional<Product> findByIdFetchAll(@Param("productId") UUID productId);
 
     @Query("SELECT ps FROM ProductStock ps JOIN Product p ON ps.id = :productId AND p.deletedAt IS NULL")
     Optional<ProductStock> findStockByProductId(@Param("productId") UUID productId);

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -50,7 +50,7 @@ public class ProductRepositoryImpl implements ProductRepository {
     public Product findProduct(UUID productId) {
 
         return jpaProductRepository
-                .findByIdFetchStock(productId)
+                .findByIdFetchAll(productId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
     }
 

--- a/product-service/src/main/resources/application-datasource.yml
+++ b/product-service/src/main/resources/application-datasource.yml
@@ -6,7 +6,7 @@ spring:
     password: paljagood
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     open-in-view: false
     properties:
       hibernate:

--- a/product-service/src/test/java/com/palja/product_service/application/service/impl/ProductServiceImplTest.java
+++ b/product-service/src/test/java/com/palja/product_service/application/service/impl/ProductServiceImplTest.java
@@ -7,7 +7,9 @@ import com.palja.product_service.application.dto.res.CreateProductRes;
 import com.palja.product_service.application.dto.res.FindProductListByConditionRes;
 import com.palja.product_service.application.dto.res.FindProductRes;
 import com.palja.product_service.application.port.UserClient;
+import com.palja.product_service.domain.dto.req.CreateReq;
 import com.palja.product_service.domain.dto.req.FindListByConditionReq;
+import com.palja.product_service.domain.dto.req.UserInfo;
 import com.palja.product_service.domain.dto.res.FindProductListByConditionDto;
 import com.palja.product_service.domain.entity.Category;
 import com.palja.product_service.domain.entity.Product;
@@ -85,7 +87,7 @@ class ProductServiceImplTest {
         Product expected = product;
 
         given(userService.getMyInfo()).willReturn(companyUserInfo);
-        given(productCategoryService.createProductAndCategory(command.toDomainReq(), companyUserInfo)).willReturn(expected);
+        given(productCategoryService.createProductAndCategory(any(CreateReq.class), any(UserInfo.class))).willReturn(expected);
         given(productRepository.isNotUnique(anyString(), anyString(), anyString())).willReturn(Boolean.FALSE);
         given(productRepository.save(any(Product.class))).willReturn(expected);
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #265 

<br>

## 📌 개요
- 사용자가 상품을 조회했을때, 해당 정보를 레디스에 캐시합니다.
- 주문 서비스가 상품을 조회했을때, 해당 정보를 레디스에 캐시합니다.
- 타임딜 서비스가 상품을 조회했을때, 해당 정보를 레디스에 캐시합니다.

<br>

## 🔁 변경 사항

1. RedisConfig에 캐시 설정과 서비스 클래스에 캐싱 어노테이션, 메인 클래스에 캐싱 어노테이션 추가했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
