### PR TITLE
FIX/ UserService CompanyUser 생성 시 status 기본값 PENDING으로 설정

### DIFF
--- a/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
+++ b/user-service/src/main/java/com/palja/user_service/domain/entity/User.java
@@ -61,7 +61,7 @@ public class User extends BaseEntity {
 		this.email = email;
 		this.address = address;
 		this.role = role;
-		this.status = UserStatus.ACTIVE;
+		this.status = this.role == UserRole.COMPANY_USER ? UserStatus.PENDING : UserStatus.ACTIVE;
 	}
 
 	public static User create(String loginId, String password, String name, String email, String address, UserRole role) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #279 

<br>

## 📌 개요
- CompanyUser 생성 시 status 기본값 PENDING으로 설정

<br>

## 🔁 변경 사항
- 저번 테스트 때 Active로 설정하고 잘못 커밋돼서 기본값이 설정 코드가 빠져서 추가했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
