### PR TITLE
FIX/ PaymentService 결제 취소 실패 로직 수정

### DIFF
--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
@@ -189,9 +189,8 @@ public class PaymentServiceImpl implements PaymentService {
             payment.cancel(command.cancelReason());
             paymentRepository.save(payment);
 
-            log.info("[CANCEL] pgRes.success=false -> save cancelFailedLog start. paymentId={}", payment.getId());
+            log.info("결제 취소 pg 실패 cancelFailedLog 저장: paymentId={}", payment.getId());
             paymentLogRepository.save(PaymentLog.createCancelFailedLog(payment, pgRes));
-            log.info("[CANCEL] save cancelFailedLog done. paymentId={}", payment.getId());
 
             log.info("결제 취소 완료: paymentId={}, status={}", payment.getId(), payment.getStatus());
             return CancelPaymentRes.from(payment);

--- a/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/palja/payment_service/application/service/impl/PaymentServiceImpl.java
@@ -166,7 +166,6 @@ public class PaymentServiceImpl implements PaymentService {
                 .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         UserRes user = userClient.getUserByLoginId(command.loginId());
-
         paymentValidator.validateCancelPayment(payment, command, user);
 
         PGPaymentRes pgRes;
@@ -174,13 +173,9 @@ public class PaymentServiceImpl implements PaymentService {
             log.info("Toss 결제 취소 요청: paymentId={}, cancelAmount={}, reason={}",
                     payment.getId(), command.cancelAmount(), command.cancelReason());
 
-            pgRes = pgPaymentService.cancelPayment(
-                    payment,
-                    command.cancelAmount(),
-                    command.cancelReason()
-            );
+            pgRes = pgPaymentService.cancelPayment(payment, command.cancelAmount(), command.cancelReason());
 
-            log.info("Toss 결제 취소 응답: paymentId={}, reason={}, pgMessage={}",
+            log.info("Toss 결제 취소 응답: paymentId={}, success={}, pgMessage={}",
                     payment.getId(), pgRes.isSuccess(), pgRes.getPgResponseMessage());
 
         } catch (BusinessException e) {
@@ -192,25 +187,20 @@ public class PaymentServiceImpl implements PaymentService {
 
         if (pgRes.isSuccess()) {
             payment.cancel(command.cancelReason());
-            log.info("결제 취소 상태 변경 완료: paymentId={}, status={}", payment.getId(), payment.getStatus());
-        } else {
-            payment.fail(pgRes.getPgResponseMessage());
-            log.warn("결제 취소 실패 처리 완료: paymentId={}, reason={}", payment.getId(), pgRes.getPgResponseMessage());
+            paymentRepository.save(payment);
+
+            log.info("[CANCEL] pgRes.success=false -> save cancelFailedLog start. paymentId={}", payment.getId());
+            paymentLogRepository.save(PaymentLog.createCancelFailedLog(payment, pgRes));
+            log.info("[CANCEL] save cancelFailedLog done. paymentId={}", payment.getId());
+
+            log.info("결제 취소 완료: paymentId={}, status={}", payment.getId(), payment.getStatus());
+            return CancelPaymentRes.from(payment);
         }
 
-        paymentRepository.save(payment);
+        paymentLogRepository.save(PaymentLog.createCancelFailedLog(payment, pgRes));
 
-        PaymentLog resultLog = pgRes.isSuccess()
-                ? PaymentLog.createCanceledLog(payment, pgRes)
-                : PaymentLog.createFailedLog(payment, pgRes);
-        paymentLogRepository.save(resultLog);
-
-        if (!pgRes.isSuccess()) {
-            throw new BusinessException(PaymentErrorCode.PAYMENT_FAILED);
-        }
-
-        log.info("결제 취소 완료: paymentId={}", payment.getId());
-        return CancelPaymentRes.from(payment);
+        log.warn("결제 취소 실패: paymentId={}, reason={}", payment.getId(), pgRes.getPgResponseMessage());
+        throw new BusinessException(PaymentErrorCode.PAYMENT_CANCEL_FAILED);
     }
 
     @Override

--- a/payment-service/src/main/java/com/palja/payment_service/domain/entity/PaymentLog.java
+++ b/payment-service/src/main/java/com/palja/payment_service/domain/entity/PaymentLog.java
@@ -126,6 +126,20 @@ public class PaymentLog extends BaseEntity {
                 .build();
     }
 
+    public static PaymentLog createCancelFailedLog(Payment payment, PGPaymentRes pgRes) {
+        return PaymentLog.builder()
+                .payment(payment)
+                .orderId(payment.getOrderId())
+                .userId(payment.getUserId())
+                .amount(payment.getAmount())
+                .status(PaymentStatus.APPROVED)
+                .paymentKey(resolvePaymentKey(pgRes, payment))
+                .pgResponseCode(pgRes != null ? pgRes.getPgResponseCode() : null)
+                .pgResponseMessage("[CANCEL_FAILED] " + (pgRes != null ? pgRes.getPgResponseMessage() : "unknown"))
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+
     private static String resolvePaymentKey(PGPaymentRes pgRes, Payment payment) {
         return Objects.toString(
                 pgRes != null ? pgRes.getPaymentKey() : null,

--- a/payment-service/src/main/java/com/palja/payment_service/exception/PaymentErrorCode.java
+++ b/payment-service/src/main/java/com/palja/payment_service/exception/PaymentErrorCode.java
@@ -44,6 +44,7 @@ public enum PaymentErrorCode implements ErrorCode {
 
     // 결제 처리 실패 & 시스템 오류
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "결제에 실패했습니다."),
+    PAYMENT_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "결제 취소에 실패했습니다."),
     PAYMENT_SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 시스템 내부 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/adapter/OrderClientAdapter.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/adapter/OrderClientAdapter.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class OrderAdapter implements OrderClient {
+public class OrderClientAdapter implements OrderClient {
 
     private final OrderFeignClient orderFeignClient;
 

--- a/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/adapter/UserClientAdapter.java
+++ b/payment-service/src/main/java/com/palja/payment_service/infrastructure/external/adapter/UserClientAdapter.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UserAdapter implements UserClient {
+public class UserClientAdapter implements UserClient {
 
     private final UserFeignClient userFeignClient;
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #278

<br>

## 📌 개요
- 결제 취소 실패 시 결제 상태가 FAILED로 변경되던 로직을 수정했습니다.
- 결제 취소 실패는 “결제 승인 실패”와 의미가 다르므로 결제 상태는 APPROVED를 유지하고, 실패 로그를 별도로 남기며 PAYMENT_CANCEL_FAILED 에러로 응답합니다.

<br>

## 🔁 변경 사항
- PaymentServiceImpl.cancelPayment() 취소 실패 시 payment.fail() 제거 → 결제 상태 APPROVED 유지합니다.
- 결제 취소 실패 전용 로그 저장 후 PAYMENT_CANCEL_FAILED 예외 반환합니다. (PG사 문제로 인해 결제 취소 실패일 경우에만 로그가 저장됩니다. 그 외에는 예외 던짐)
- PaymentErrorCode에 PAYMENT_CANCEL_FAILED 추가했습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
- 추후 outbox+kafka 적용 시 PaymentCancelFailed 이벤트 발행할 예정입니다.

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
