### PR TITLE
BUGFIX/ProductService 회원 탈퇴에 따른 상품삭제 버그 수정, 엔티티 논리적 삭제 개선

### DIFF
--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.application.service.impl;
 
+import com.palja.common.auditor.CurrentUser;
 import com.palja.common.exception.BusinessException;
 import com.palja.common.exception.CommonErrorCode;
 import com.palja.product_service.application.command.CreateProductCommand;
@@ -233,7 +234,7 @@ public class ProductServiceImpl implements ProductService {
 
         validateIsSameUser(product.getCompanyUserId(), myInfo.getCompanyUserId());
 
-        product.delete();
+        product.softDelete();
 
         boolean result = repository.deleteStockFromRedis(productId.toString());
         validateRedisOperation(result);
@@ -243,8 +244,10 @@ public class ProductServiceImpl implements ProductService {
     @Transactional
     public void deleteProductForUser(UUID companyUserId) {
 
+        String loginId = CurrentUser.getLoginId();
+        repository.deleteProductForUser(companyUserId, loginId);
+
         List<UUID> idList = repository.findAllIdsByCompanyUserId(companyUserId);
-        repository.deleteProductForUser(companyUserId);
         boolean result = repository.deleteAllStockFromRedis(idList);
         validateRedisOperation(result);
 

--- a/product-service/src/main/java/com/palja/product_service/domain/entity/Category.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/entity/Category.java
@@ -53,4 +53,9 @@ public class Category extends BaseEntity {
     public int hashCode() {
         return Objects.hashCode(categoryNumber);
     }
+
+    @Override
+    public void softDelete() {
+        super.softDelete();
+    }
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/entity/Product.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/entity/Product.java
@@ -119,8 +119,9 @@ public class Product extends BaseEntity {
         return this.price;
     }
 
-    public void delete() {
-        this.productStock.delete();
+    @Override
+    public void softDelete() {
+        this.productStock.mySoftDelete();
         super.softDelete();
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/entity/ProductStock.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/entity/ProductStock.java
@@ -49,7 +49,11 @@ public class ProductStock extends BaseEntity {
         return this;
     }
 
-    protected void delete() {
+    @Override
+    public void softDelete() {
+    }
+
+    protected void mySoftDelete() {
         super.softDelete();
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/repository/ProductRepository.java
@@ -44,5 +44,5 @@ public interface ProductRepository {
 
     boolean deleteAllStockFromRedis(List<UUID> productIds);
 
-    void deleteProductForUser(UUID companyUserId);
+    void deleteProductForUser(UUID companyUserId, String loginId);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/JpaProductRepository.java
@@ -27,10 +27,23 @@ public interface JpaProductRepository extends JpaRepository<Product, UUID> {
     @Query("SELECT p FROM Product p JOIN FETCH p.productStock WHERE p.id = :productId AND p.deletedAt IS null")
     Optional<Product> findByIdFetchStockWithLock(@Param("productId") UUID productId);
 
-    @Query("SELECT p.id FROM Product p WHERE p.companyUserId = :companyUserId")
+    @Query("SELECT p FROM Product p WHERE p.companyUserId = :companyUserId AND p.deletedAt IS null")
     List<UUID> findAllIdsByCompanyUserId(@Param("companyUserId")UUID companyUserId);
 
     @Modifying
-    @Query("UPDATE Product p SET p.deletedAt = local datetime WHERE p.companyUserId = :companyUserId")
-    void deleteAllByCompanyUserId(@Param("companyUserId") UUID companyUserId);
+    @Query(value = """
+           WITH softdelete_product AS (
+                      UPDATE palja.palja_product.p_product p
+                      SET deleted_at = CURRENT_TIMESTAMP,
+                          deleted_by= :loginId
+                      WHERE p.company_user_id = :companyUserId
+                      RETURNING p.product_id
+           )
+           UPDATE palja.palja_product.p_product_stock ps
+                      SET deleted_at = CURRENT_TIMESTAMP,
+                          deleted_by= :loginId
+                      FROM softdelete_product sdp
+                      WHERE sdp.product_id = ps.product_id
+           """, nativeQuery = true)
+    void deleteAllByCompanyUserId(@Param("companyUserId") UUID companyUserId, @Param("loginId") String loginId);
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/impl/ProductRepositoryImpl.java
@@ -139,8 +139,8 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public void deleteProductForUser(UUID companyUserId) {
+    public void deleteProductForUser(UUID companyUserId, String loginId) {
 
-        jpaProductRepository.deleteAllByCompanyUserId(companyUserId);
+        jpaProductRepository.deleteAllByCompanyUserId(companyUserId, loginId);
     }
 }

--- a/product-service/src/main/resources/application-datasource.yml
+++ b/product-service/src/main/resources/application-datasource.yml
@@ -6,7 +6,7 @@ spring:
     password: paljagood
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     open-in-view: false
     properties:
       hibernate:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #285 

<br>

## 📌 개요
- 회원 탈퇴에 따른 상품 삭제시, 상품의 재고도 논리적 삭제하도록 합니다
- 엔티티의 논리적 삭제메서드 구조 개선

<br>

## 🔁 변경 사항

1. 회원 탈퇴에 따른 상품 삭제시 재고의 논리적 삭제를 위해 postgreSql의 CTE(Common Table Expression)기능을 사용했습니다
   - 상품 삭제를 진행하면서 상품의 id를 반환해주는 임시 테이블로 만들고 상품 재고의 삭제에 이 id를 사용합니다
  
2. 회원 탈퇴에 따른 상품 삭제시, 레디스 재고삭제를 위해 상품UUID를 얻어오는 메서드에 deleted_at is null 을 추가했습니다

3. 엔티티의 논리적 삭제 메서드에 베이스 엔티티의 메서드를 오버라이딩하게 개선했습니다.
   - 재고 엔티티는 상품 엔티티에서 관리하기 위해 오버라이드 한 메서드는 아무 일도 안하게 두고, 새로 메서드를 만들었습니다

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
