### PR TITLE
FIX/선착순 쿠폰 발급 동시성 및 데이터 정합성 문제 수정

### DIFF
--- a/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/service/impl/CouponServiceImpl.java
@@ -68,13 +68,14 @@ public class CouponServiceImpl implements CouponService {
         RLock lock = redisRepository.getLock(lockKey);
 
         try {
-            boolean locked = lock.tryLock(1, 3, TimeUnit.SECONDS);
+            boolean locked = lock.tryLock(3, 3, TimeUnit.SECONDS);
             if (!locked)
                 throw new BusinessException(CouponErrorCode.COUPON_ISSUE_LOCK_FAILED);
 
-            // Redis 쿠폰 발급 카운트 초기화
-            redisRepository.initIssuedCount(coupon.getId(), coupon.getIssuedQuantity());
+            // Redis 쿠폰 키 검증
+            redisRepository.initIssuedCount(coupon.getId(), coupon.getIssuedQuantity(), coupon.getIssuePeriod());
 
+            // 중복 발급 검증
             if (redisRepository.isDuplicated(coupon.getId(), command.userId()))
                 throw new BusinessException(CouponErrorCode.DUPLICATE_COUPON_ISSUE);
 
@@ -88,28 +89,38 @@ public class CouponServiceImpl implements CouponService {
 
             redisRepository.issued(coupon.getId(), command.userId());
 
-            coupon.increaseIssuedQuantity();
+            try {
+                couponRepository.increaseIssuedQuantity(coupon.getId());
+                CouponUser couponUser = CouponUser.issue(coupon, command.userId());
+                CouponUser issuedCoupon = couponUserRepository.save(couponUser);
 
-            CouponUser couponUser = CouponUser.issue(coupon, command.userId());
+                log.info("선착순 쿠폰 발급 성공 issuedCouponID={}", issuedCoupon.getCoupon().getId());
+                return CreateCouponUserRes.from(issuedCoupon);
 
-            CouponUser issuedCoupon = couponUserRepository.save(couponUser);
+            } catch (Exception e) {
+                log.error("DB 저장 실패 Redis 롤백 userId={} couponId={}", command.userId(), command.couponId());
+                redisRepository.rollbackQuantity(coupon.getId(), command.userId());
+                throw e;
+            }
 
-            log.info("선착순 쿠폰 발급 성공 issuedCouponID={}", issuedCoupon.getCoupon().getId());
-            return CreateCouponUserRes.from(issuedCoupon);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            log.error("락 획득 중 인터럽트 발생. userId={}, couponId={}", command.userId(), command.couponId());
             throw new BusinessException(CouponErrorCode.COUPON_ISSUE_LOCK_FAILED);
         } catch (BusinessException e) {
-            log.error("선착순 쿠폰 발급 실패 userId={} couponId={}", command.userId(), command.couponId());
-            redisRepository.rollbackQuantity(coupon.getId(), command.userId());
             throw e;
         } catch (Exception e) {
             log.error("선착순 쿠폰 발급 중 예상치 못한 오류 userId={} couponId={}", command.userId(), command.couponId());
-            redisRepository.rollbackQuantity(coupon.getId(), command.userId());
             throw new BusinessException(CouponErrorCode.COUPON_ISSUE_LOCK_FAILED);
+
         } finally {
-            if (lock.isHeldByCurrentThread())
+            try {
                 lock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.error("락 선점 해제 실패 lockKey={}", lockKey);
+            } catch (Exception e) {
+                log.error("예상치 못한 락 선점 해제 실패 lockKey={}", lockKey, e);
+            }
         }
     }
 

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/CouponRepository.java
@@ -18,4 +18,6 @@ public interface CouponRepository {
     void delete(Coupon coupon);
 
     boolean existsByNameAndDeletedAtIsNull(String couponName);
+
+    void increaseIssuedQuantity(UUID id);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/RedisRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/domain/repository/RedisRepository.java
@@ -1,12 +1,13 @@
 package com.palja.coupon_service.domain.repository;
 
+import com.palja.coupon_service.domain.vo.IssuePeriod;
 import org.redisson.api.RLock;
 
 import java.util.UUID;
 
 public interface RedisRepository {
 
-    void initIssuedCount(UUID couponId, Integer issuedQuantity);
+    void initIssuedCount(UUID couponId, Integer issuedQuantity, IssuePeriod issuePeriod);
 
     void issued(UUID couponId, String userId);
 

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponRepositoryAdaptor.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/CouponRepositoryAdaptor.java
@@ -40,4 +40,9 @@ public class CouponRepositoryAdaptor implements CouponRepository {
     public boolean existsByNameAndDeletedAtIsNull(String couponName) {
         return jpaCouponRepository.existsByNameAndDeletedAtIsNull(couponName);
     }
+
+    @Override
+    public void increaseIssuedQuantity(UUID id) {
+        jpaCouponRepository.increaseIssuedQuantity(id);
+    }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponRepository.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/JpaCouponRepository.java
@@ -1,9 +1,12 @@
 package com.palja.coupon_service.infrastructure.repository;
 
 import com.palja.coupon_service.domain.entity.Coupon;
+import feign.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -16,4 +19,9 @@ public interface JpaCouponRepository extends JpaRepository<Coupon, UUID> {
     Optional<Coupon> findByIdAndDeletedAtIsNull(UUID id);
 
     boolean existsByNameAndDeletedAtIsNull(String couponName);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Coupon c SET c.issuedQuantity = c.issuedQuantity + 1 " +
+            "WHERE c.id = :couponId AND c.deletedAt IS NULL")
+    void increaseIssuedQuantity(@Param("couponId") UUID couponId);
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/RedisRepositoryImpl.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/repository/RedisRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.palja.coupon_service.infrastructure.repository;
 
 import com.palja.coupon_service.domain.repository.RedisRepository;
+import com.palja.coupon_service.domain.vo.IssuePeriod;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -9,6 +10,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 @Slf4j
@@ -23,12 +26,13 @@ public class RedisRepositoryImpl implements RedisRepository {
     private static final String COUPON_LOCK_KEY_PREFIX = "lock:coupon:issue:";
     private static final String COUPON_ISSUED_USERS_KEY = "coupon:issued:users:";
 
-    private static final int DurationDays = 7;
+    private static final int Default_DurationDays = 90;
 
     @Override
-    public void initIssuedCount(UUID couponId, Integer issuedQuantity) {
+    public void initIssuedCount(UUID couponId, Integer issuedQuantity, IssuePeriod issuePeriod) {
         String quantityKey = COUPON_ISSUED_COUNT_KEY + couponId;
         String usersKey = COUPON_ISSUED_USERS_KEY + couponId;
+        Duration ttl = calculateDuration(issuePeriod);
 
         if (redisTemplate.hasKey(quantityKey))
             return;
@@ -36,13 +40,29 @@ public class RedisRepositoryImpl implements RedisRepository {
         redisTemplate.opsForValue().setIfAbsent(
                 quantityKey,
                 String.valueOf(issuedQuantity),
-                Duration.ofDays(DurationDays)
+                ttl
         );
 
         if (!redisTemplate.hasKey(usersKey))
-            redisTemplate.expire(usersKey, Duration.ofDays(DurationDays));
+            redisTemplate.expire(usersKey, ttl);
 
-        log.info("Redis 쿠폰 발급 카운트 초기화 - couponId: {}, quantity: {}", couponId, issuedQuantity);
+        log.info("Redis 쿠폰 발급 카운트 초기화 - couponId: {}, quantity: {}, ttl: {}", couponId, issuedQuantity, ttl);
+    }
+
+    private Duration calculateDuration(IssuePeriod issuePeriod) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime endAt = issuePeriod.getIssueEndAt();
+
+        if (endAt == null)
+            return Duration.ofDays(Default_DurationDays);
+
+        long duration = ChronoUnit.DAYS.between(now, endAt);
+
+        // 최소 유효 시간 1시간 보장
+        if (duration <= 0)
+            return Duration.ofHours(1);
+
+        return Duration.ofDays(duration).plusDays(1);
     }
 
     @Override

--- a/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponServiceImplTest.java
+++ b/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponServiceImplTest.java
@@ -13,6 +13,7 @@ import com.palja.coupon_service.domain.repository.RedisRepository;
 import com.palja.coupon_service.domain.vo.AmountPolicy;
 import com.palja.coupon_service.domain.vo.CouponUserStatus;
 import com.palja.coupon_service.domain.vo.DiscountPolicy;
+import com.palja.coupon_service.domain.vo.IssuePeriod;
 import com.palja.coupon_service.exception.CouponErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -153,6 +154,7 @@ public class CouponServiceImplTest {
             Coupon coupon = mock(Coupon.class);
             given(coupon.getId()).willReturn(couponId);
             given(coupon.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
+            given(coupon.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
             given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(coupon));
 
             String lockKey = "lock:coupon:issue:" + couponId;
@@ -176,7 +178,7 @@ public class CouponServiceImplTest {
             verify(couponRepository).findByIdAndDeletedAtIsNull(couponId);
             verify(coupon).validateIssuable();
             verify(coupon).validateIssuePeriod();
-            verify(redisRepository).initIssuedCount(couponId, 0);
+            verify(redisRepository).initIssuedCount(couponId, 0, coupon.getIssuePeriod());
             verify(redisRepository).issued(couponId, userId);
             verify(coupon).increaseIssuedQuantity();
             verify(couponUserRepository).save(any(CouponUser.class));

--- a/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponServiceImplTest.java
+++ b/coupon-service/src/test/java/com/palja/coupon_service/application/service/impl/CouponServiceImplTest.java
@@ -153,6 +153,8 @@ public class CouponServiceImplTest {
 
             Coupon coupon = mock(Coupon.class);
             given(coupon.getId()).willReturn(couponId);
+            given(coupon.getIssuedQuantity()).willReturn(5);
+            given(coupon.getTotalQuantity()).willReturn(10);
             given(coupon.getDiscountPolicy()).willReturn(mock(DiscountPolicy.class));
             given(coupon.getIssuePeriod()).willReturn(mock(IssuePeriod.class));
             given(couponRepository.findByIdAndDeletedAtIsNull(couponId)).willReturn(Optional.of(coupon));
@@ -162,9 +164,9 @@ public class CouponServiceImplTest {
 
             given(redisRepository.getLockKey(couponId)).willReturn(lockKey);
             given(redisRepository.getLock(lockKey)).willReturn(lock);
-            given(lock.tryLock(1, 3, TimeUnit.SECONDS)).willReturn(true);
+            given(lock.tryLock(3, 3, TimeUnit.SECONDS)).willReturn(true);
             given(redisRepository.isDuplicated(couponId, userId)).willReturn(false);
-            given(lock.isHeldByCurrentThread()).willReturn(true);
+            given(redisRepository.increaseIssuedQuantity(couponId)).willReturn(6L);
 
             CouponUser couponUser = mock(CouponUser.class);
             given(couponUser.getCoupon()).willReturn(coupon);
@@ -178,9 +180,9 @@ public class CouponServiceImplTest {
             verify(couponRepository).findByIdAndDeletedAtIsNull(couponId);
             verify(coupon).validateIssuable();
             verify(coupon).validateIssuePeriod();
-            verify(redisRepository).initIssuedCount(couponId, 0, coupon.getIssuePeriod());
+            verify(redisRepository).initIssuedCount(couponId, 5, coupon.getIssuePeriod());
             verify(redisRepository).issued(couponId, userId);
-            verify(coupon).increaseIssuedQuantity();
+            verify(redisRepository).increaseIssuedQuantity(couponId);
             verify(couponUserRepository).save(any(CouponUser.class));
             verify(lock).unlock();
         }
@@ -226,7 +228,7 @@ public class CouponServiceImplTest {
 
             given(redisRepository.getLockKey(couponId)).willReturn(lockKey);
             given(redisRepository.getLock(lockKey)).willReturn(lock);
-            given(lock.tryLock(1, 3, TimeUnit.SECONDS)).willReturn(true);
+            given(lock.tryLock(3, 3, TimeUnit.SECONDS)).willReturn(true);
             given(redisRepository.isDuplicated(couponId, userId)).willReturn(true);
 
             assertThatThrownBy(() -> couponService.issueFirstComeCoupon(command))


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #295 

<br>

## 📌 개요
선착순 쿠폰 발급 시 발생하는 동시성 문제와 Redis DB 간 데이터 정합성 이슈를 수정했습니다.

<br>

## 🔁 변경 사항

1. 분산 락 획득 타임아웃 증가
- 락 대기 시간: `1초 → 3초`로 증가
- 동시 요청 급증 시 락 획득 실패율 감소

2. Redis 초기화 로직 개선
- 쿠폰 발급 기간에 따른 동적 TTL 계산 로직 추가
  - 발급 종료일까지의 기간 + 1일을 TTL로 설정
  - 종료일이 없는 경우 기본 90일 적용
  - 이미 종료된 쿠폰은 최소 1시간 보장

3. Redis 롤백 메커니즘 추가
- DB 저장 실패 시 Redis 발급 카운트 및 사용자 Set 자동 롤백

4. DB 업데이트 최적화
- `coupon.increaseIssuedQuantity()` 엔티티 변경 → `@Modifying` 쿼리로 변경
- `clearAutomatically = true` 옵션으로 영속성 컨텍스트 자동 동기화

5. 락 해제 안정성 강화

<br>

## 📸 스크린샷
<details>
  <summary>선착순 쿠폰 발급 성능 테스트 결과</summary>

<img width="1831" height="552" alt="image" src="https://github.com/user-attachments/assets/dfc353af-444b-4ae8-9a34-201b2aa99805" />

- 커넥션풀 미설정으로 초기 500 에러 발생
- 100개의 쿠폰 발행, DB Redis 정합성 일치

</details>
<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.