### PR TITLE
FEAT/OrderService Swagger 설정 및 설명 추가

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -38,6 +38,8 @@ ext {
 
 dependencies {
 	implementation 'com.palja:common-module:0.9.1'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 	implementation 'io.github.openfeign:feign-micrometer'
 	// QueryDSL (jakarta 버전)
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderController.java
@@ -1,91 +1,89 @@
 package com.palja.order_service.presentation.controller;
 
-import com.palja.common.annotation.RequiredInternal;
-import com.palja.common.annotation.RequiredRole;
-import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
 import com.palja.common.response.PageResponse;
-import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.dto.response.*;
-import com.palja.order_service.application.service.OrderService;
 import com.palja.order_service.presentation.dto.request.CancelOrderReq;
 import com.palja.order_service.presentation.dto.request.CompleteOrderPaymentReq;
 import com.palja.order_service.presentation.dto.request.CreateOrderReq;
 import com.palja.order_service.presentation.dto.request.CustomerOrderSearchReq;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.UUID;
 
-@RestController
+@Tag(name = "Orders", description = "주문 API")
 @RequestMapping("/api/v1/orders")
-@RequiredArgsConstructor
-public class OrderController {
+public interface OrderController {
 
-    private final OrderService orderService;
-
-    // 주문 생성
-    @PostMapping
-    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER})
-    public ResponseEntity<ApiResponse<OrderCreateRes>> createOrder(
+    @Operation(
+            summary = "주문 생성",
+            description = """
+                주문을 생성합니다.
+                - 권한: CUSTOMER, MANAGER
+                """
+    )
+    ResponseEntity<ApiResponse<OrderCreateRes>> createOrder(
             @Valid @RequestBody CreateOrderReq request
-        ) {
-        OrderCreateRes response = orderService.createOrder(request.toCommand(CurrentUser.getLoginId(), CurrentUser.getRole()));
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(ApiResponse.success(response, "주문이 생성되었습니다."));
-    }
+    );
 
-    // 주문 상세 조회
-    @GetMapping("/{orderId}")
-    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER, UserRole.COMPANY_USER})
-    public ResponseEntity<ApiResponse<OrderDetailRes>> getOrderDetail(
+    @Operation(
+            summary = "주문 상세 조회",
+            description = """
+                    주문 단건을 상세 조회합니다.
+                    - 권한: CUSTOMER, MANAGER, COMPANY_USER
+                    """
+    )
+    ResponseEntity<ApiResponse<OrderDetailRes>> getOrderDetail(
+            @Parameter(description = "주문 ID", required = true)
             @PathVariable UUID orderId
-    ) {
-        OrderDetailRes response = orderService.getOrderDetail(orderId, CurrentUser.getLoginId(), CurrentUser.getRole());
-        return ResponseEntity.ok(ApiResponse.success(response, "주문이 조회되었습니다."));
-    }
+    );
 
-    // 주문 취소
-    @PostMapping("/{orderId}/cancel")
-    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER, UserRole.COMPANY_USER})
-    public ResponseEntity<ApiResponse<OrderCancelRes>> cancelOrder(
+    @Operation(
+            summary = "주문 취소",
+            description = """
+                    주문을 취소합니다.
+                    - 권한: CUSTOMER, MANAGER, COMPANY_USER
+                    """
+    )
+    ResponseEntity<ApiResponse<OrderCancelRes>> cancelOrder(
+            @Parameter(description = "주문 ID", required = true)
             @PathVariable UUID orderId,
             @Valid @RequestBody CancelOrderReq request
-    ) {
-        OrderCancelRes response = orderService.cancelOrder(request.toCommand(orderId, CurrentUser.getLoginId(), CurrentUser.getRole()));
-        return ResponseEntity.ok(ApiResponse.success(response,"주문이 취소되었습니다."));
-    }
+    );
 
-    // 내 주문 목록 조회
-    @GetMapping("/customer/me")
-    @RequiredRole({UserRole.CUSTOMER})
-    public ResponseEntity<ApiResponse<PageResponse<CustomerOrderSummaryRes>>> getMyOrdersByCustomer(
-            @ModelAttribute CustomerOrderSearchReq request,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable
-    ) {
-        PageResponse<CustomerOrderSummaryRes> response = orderService.getMyOrdersByCustomer(
-                CurrentUser.getLoginId(), request, pageable
-        );
-        return ResponseEntity.ok(ApiResponse.success(response, "고객용 주문 목록이 조회되었습니다.")
-        );
-    }
+    @Operation(
+            summary = "내 주문 목록 조회(고객)",
+            description = """
+                    고객 본인의 주문 목록을 조회합니다.
+                    - 권한: CUSTOMER
+                    - 정렬 기본값: createdAt DESC
+                    """
+    )
+    ResponseEntity<ApiResponse<PageResponse<CustomerOrderSummaryRes>>> getMyOrdersByCustomer(
+            @ParameterObject @ModelAttribute CustomerOrderSearchReq request,
+            @ParameterObject Pageable pageable
+    );
 
-    // 주문 결제 완료
-    @RequiredInternal
-    @PutMapping("/{orderId}/payment/complete")
-    public ResponseEntity<ApiResponse<OrderPaymentCompleteRes>> completeOrderPayment(
+    @Operation(
+            summary = "주문 결제 완료 처리(내부 호출)",
+            description = """
+                    결제 서비스 등 내부 시스템에서 주문 결제 완료 상태로 변경할 때 사용합니다.
+                    - 권한: 내부 호출(RequiredInternal)
+                    """
+    )
+    ResponseEntity<ApiResponse<OrderPaymentCompleteRes>> completeOrderPayment(
+            @Parameter(description = "주문 ID", required = true)
             @PathVariable UUID orderId,
-            @RequestBody @Valid CompleteOrderPaymentReq request
-    ) {
-        OrderPaymentCompleteRes response = orderService.completeOrderPayment(request.toCommand(orderId));
-        return ResponseEntity.ok(ApiResponse.success(response, "주문이 결제 완료되었습니다."));
-    }
+            @Valid @RequestBody CompleteOrderPaymentReq request
+    );
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderDeliveryController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderDeliveryController.java
@@ -1,15 +1,4 @@
 package com.palja.order_service.presentation.controller;
 
-import com.palja.order_service.application.service.OrderDeliveryService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-@RequestMapping("/api/v1/orders")
-@RequiredArgsConstructor
-public class OrderDeliveryController {
-
-    private final OrderDeliveryService orderDeliveryService;
-
+public interface OrderDeliveryController {
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderManagerController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderManagerController.java
@@ -1,34 +1,33 @@
 package com.palja.order_service.presentation.controller;
 
-import com.palja.common.annotation.RequiredRole;
-import com.palja.common.auditor.CurrentUser;
 import com.palja.common.response.ApiResponse;
-import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.dto.response.OrderStatusChangeRes;
-import com.palja.order_service.application.service.OrderManagerService;
 import com.palja.order_service.presentation.dto.request.OrderStatusChangeReq;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.UUID;
 
-@RestController
+@Tag(name = "Orders (Manager)", description = "주문 관리자 API")
 @RequestMapping("/api/v1/orders/manager")
-@RequiredArgsConstructor
-public class OrderManagerController {
+public interface OrderManagerController {
 
-    private final OrderManagerService orderManagerService;
-
-    // 주문 상태 변경 (관리자)
-    @PutMapping("/{orderId}/status")
-    @RequiredRole(value = {UserRole.MANAGER})
-    public ResponseEntity<ApiResponse<OrderStatusChangeRes>> changeOrderStatus(
+    @Operation(
+            summary = "주문 상태 변경(관리자)",
+            description = """
+                    관리자가 주문 상태를 변경합니다.
+                    - 권한: MANAGER
+                    """
+    )
+    ResponseEntity<ApiResponse<OrderStatusChangeRes>> changeOrderStatus(
+            @Parameter(description = "주문 ID", required = true)
             @PathVariable UUID orderId,
             @Valid @RequestBody OrderStatusChangeReq request
-    ) {
-        OrderStatusChangeRes response = orderManagerService.changeOrderStatus(request.toCommand(orderId, CurrentUser.getLoginId()));
-        return ResponseEntity.ok(ApiResponse.success(response, "주문 상태가 변경되었습니다."));
-    }
+    );
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderControllerImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderControllerImpl.java
@@ -1,0 +1,97 @@
+package com.palja.order_service.presentation.controller.impl;
+
+import com.palja.common.annotation.RequiredInternal;
+import com.palja.common.annotation.RequiredRole;
+import com.palja.common.auditor.CurrentUser;
+import com.palja.common.response.ApiResponse;
+import com.palja.common.response.PageResponse;
+import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.dto.response.*;
+import com.palja.order_service.application.service.OrderService;
+import com.palja.order_service.presentation.controller.OrderController;
+import com.palja.order_service.presentation.dto.request.CancelOrderReq;
+import com.palja.order_service.presentation.dto.request.CompleteOrderPaymentReq;
+import com.palja.order_service.presentation.dto.request.CreateOrderReq;
+import com.palja.order_service.presentation.dto.request.CustomerOrderSearchReq;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderControllerImpl implements OrderController {
+
+    private final OrderService orderService;
+
+    // 주문 생성
+    @Override
+    @PostMapping
+    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER})
+    public ResponseEntity<ApiResponse<OrderCreateRes>> createOrder(
+            @Valid @RequestBody CreateOrderReq request
+        ) {
+        OrderCreateRes response = orderService.createOrder(request.toCommand(CurrentUser.getLoginId(), CurrentUser.getRole()));
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "주문이 생성되었습니다."));
+    }
+
+    // 주문 상세 조회
+    @Override
+    @GetMapping("/{orderId}")
+    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER, UserRole.COMPANY_USER})
+    public ResponseEntity<ApiResponse<OrderDetailRes>> getOrderDetail(
+            @PathVariable UUID orderId
+    ) {
+        OrderDetailRes response = orderService.getOrderDetail(orderId, CurrentUser.getLoginId(), CurrentUser.getRole());
+        return ResponseEntity.ok(ApiResponse.success(response, "주문이 조회되었습니다."));
+    }
+
+    // 주문 취소
+    @Override
+    @PostMapping("/{orderId}/cancel")
+    @RequiredRole(value = {UserRole.MANAGER, UserRole.CUSTOMER, UserRole.COMPANY_USER})
+    public ResponseEntity<ApiResponse<OrderCancelRes>> cancelOrder(
+            @PathVariable UUID orderId,
+            @Valid @RequestBody CancelOrderReq request
+    ) {
+        OrderCancelRes response = orderService.cancelOrder(request.toCommand(orderId, CurrentUser.getLoginId(), CurrentUser.getRole()));
+        return ResponseEntity.ok(ApiResponse.success(response,"주문이 취소되었습니다."));
+    }
+
+    // 내 주문 목록 조회
+    @Override
+    @GetMapping("/customer/me")
+    @RequiredRole({UserRole.CUSTOMER})
+    public ResponseEntity<ApiResponse<PageResponse<CustomerOrderSummaryRes>>> getMyOrdersByCustomer(
+            @ModelAttribute CustomerOrderSearchReq request,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        PageResponse<CustomerOrderSummaryRes> response = orderService.getMyOrdersByCustomer(
+                CurrentUser.getLoginId(), request, pageable
+        );
+        return ResponseEntity.ok(ApiResponse.success(response, "고객용 주문 목록이 조회되었습니다.")
+        );
+    }
+
+    // 주문 결제 완료
+    @Override
+    @RequiredInternal
+    @PutMapping("/{orderId}/payment/complete")
+    public ResponseEntity<ApiResponse<OrderPaymentCompleteRes>> completeOrderPayment(
+            @PathVariable UUID orderId,
+            @RequestBody @Valid CompleteOrderPaymentReq request
+    ) {
+        OrderPaymentCompleteRes response = orderService.completeOrderPayment(request.toCommand(orderId));
+        return ResponseEntity.ok(ApiResponse.success(response, "주문이 결제 완료되었습니다."));
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderDeliveryControllerImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderDeliveryControllerImpl.java
@@ -1,0 +1,16 @@
+package com.palja.order_service.presentation.controller.impl;
+
+import com.palja.order_service.application.service.OrderDeliveryService;
+import com.palja.order_service.presentation.controller.OrderDeliveryController;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderDeliveryControllerImpl implements OrderDeliveryController {
+
+    private final OrderDeliveryService orderDeliveryService;
+
+}

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderManagerControllerImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderManagerControllerImpl.java
@@ -1,0 +1,35 @@
+package com.palja.order_service.presentation.controller.impl;
+
+import com.palja.common.annotation.RequiredRole;
+import com.palja.common.auditor.CurrentUser;
+import com.palja.common.response.ApiResponse;
+import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.dto.response.OrderStatusChangeRes;
+import com.palja.order_service.application.service.OrderManagerService;
+import com.palja.order_service.presentation.controller.OrderManagerController;
+import com.palja.order_service.presentation.dto.request.OrderStatusChangeReq;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/orders/manager")
+@RequiredArgsConstructor
+public class OrderManagerControllerImpl implements OrderManagerController {
+
+    private final OrderManagerService orderManagerService;
+
+    // 주문 상태 변경 (관리자)
+    @PutMapping("/{orderId}/status")
+    @RequiredRole(value = {UserRole.MANAGER})
+    public ResponseEntity<ApiResponse<OrderStatusChangeRes>> changeOrderStatus(
+            @PathVariable UUID orderId,
+            @Valid @RequestBody OrderStatusChangeReq request
+    ) {
+        OrderStatusChangeRes response = orderManagerService.changeOrderStatus(request.toCommand(orderId, CurrentUser.getLoginId()));
+        return ResponseEntity.ok(ApiResponse.success(response, "주문 상태가 변경되었습니다."));
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CancelOrderReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CancelOrderReq.java
@@ -2,6 +2,7 @@ package com.palja.order_service.presentation.dto.request;
 
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CancelOrderCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -14,10 +15,12 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "주문 취소 요청")
 public class CancelOrderReq {
 
     @NotBlank(message = "취소 사유는 필수입니다.")
     @Size(max = 500, message = "취소 사유는 500자를 초과할 수 없습니다.")
+    @Schema(description = "취소 사유", example = "고객 변심으로 인한 취소")
     private String cancelReason;
 
     public CancelOrderCommand toCommand(UUID orderId, String loginId, UserRole userRole) {

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CompleteOrderPaymentReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CompleteOrderPaymentReq.java
@@ -1,6 +1,7 @@
 package com.palja.order_service.presentation.dto.request;
 
 import com.palja.order_service.application.command.CompleteOrderPaymentCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -14,12 +15,16 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "주문 결제 완료 요청")
 public class CompleteOrderPaymentReq {
+
     @NotNull(message = "결제 ID는 필수입니다.")
+    @Schema(description = "결제 ID", example = "00000000-0000-0000-1000-000000000000")
     private UUID paymentId;
 
     @NotNull(message = "결제 금액은 필수입니다.")
     @DecimalMin(value = "0.01", message = "결제 금액은 0보다 커야 합니다.")
+    @Schema(description = "결제 금액", example = "12900.00")
     private BigDecimal paidAmount;
 
     public CompleteOrderPaymentCommand toCommand(UUID orderId) {

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CreateOrderReq.java
@@ -2,6 +2,7 @@ package com.palja.order_service.presentation.dto.request;
 
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.command.CreateOrderCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -15,21 +16,27 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "주문 생성 요청")
 public class CreateOrderReq {
 
     @NotNull(message = "상품 ID는 필수입니다.")
+    @Schema(description = "상품 ID", example = "00000000-0000-0000-2000-000000000000")
     private UUID productId;
 
     @NotNull(message = "주문 수량은 필수입니다.")
     @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
+    @Schema(description = "주문 수량", example = "10")
     private Long quantity;
 
+    @Schema(description = "타임딜 ID", example = "00000000-0000-0000-3000-000000000000")
     private UUID timeDealId;
 
+    @Schema(description = "사용 쿠폰 ID", example = "00000000-0000-0000-4000-000000000000")
     private UUID couponUserId;
 
     @NotNull(message = "배송 정보는 필수입니다.")
     @Valid
+    @Schema(description = "배송 정보")
     private DeliveryReq delivery;
 
     // Request → Command 변환

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CustomerOrderSearchReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/CustomerOrderSearchReq.java
@@ -1,5 +1,6 @@
 package com.palja.order_service.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -8,19 +9,24 @@ import java.time.LocalDate;
 
 @Getter
 @Setter
+@Schema(description = "고객 주문 목록 검색 조건")
 public class CustomerOrderSearchReq {
 
     // 주문 상태
+    @Schema(description = "주문 상태", example = "PAID")
     private String status;
 
     // 시작 날짜 (YYYY-MM-DD)
+    @Schema(description = "조회 시작일(yyyy-MM-dd)", example = "2025-12-01")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
 
     // 종료 날짜 (YYYY-MM-DD)
+    @Schema(description = "조회 종료일(yyyy-MM-dd)", example = "2025-12-20")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
 
     // 타임딜 주문 여부
+    @Schema(description = "타임딜 주문 여부", example = "true")
     private Boolean timeDealOrder;
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/DeliveryReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/DeliveryReq.java
@@ -1,6 +1,7 @@
 package com.palja.order_service.presentation.dto.request;
 
 import com.palja.order_service.application.command.DeliveryCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -12,21 +13,26 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "배송 정보 요청")
 public class DeliveryReq {
 
     @NotBlank(message = "수령인 이름은 필수입니다.")
     @Size(max = 50, message = "수령인 이름은 50자를 초과할 수 없습니다.")
+    @Schema(description = "수령인 이름", example = "김차돌")
     private String recipientName;
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     @Size(max = 255, message = "이메일은 255자를 초과할 수 없습니다.")
+    @Schema(description = "수령인 이메일", example = "chadoll@example.com")
     private String recipientEmail;
 
     @NotBlank(message = "수령인 주소는 필수입니다.")
     @Size(max = 200, message = "주소는 200자를 초과할 수 없습니다.")
+    @Schema(description = "배송 주소", example = "서울특별시 강남구 테헤란로 123")
     private String recipientAddress;
 
     @Size(max = 255, message = "배송 메시지는 255자를 초과할 수 없습니다.")
+    @Schema(description = "배송 메시지", example = "문 앞에 놓아주세요")
     private String deliveryMessage;
 
     // DeliveryRequest → DeliveryCommand 변환

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/OrderStatusChangeReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/OrderStatusChangeReq.java
@@ -1,6 +1,7 @@
 package com.palja.order_service.presentation.dto.request;
 
 import com.palja.order_service.application.command.OrderStatusChangeCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -13,13 +14,16 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "주문 상태 변경 요청")
 public class OrderStatusChangeReq {
 
     @NotBlank(message = "변경할 상태는 필수입니다.")
+    @Schema(description = "변경할 주문 상태", example = "DELIVERING")
     private String status;
 
     @NotBlank(message = "변경 사유는 필수입니다.")
     @Size(max = 500, message = "변경 사유는 500자 이하로 입력해주세요.")
+    @Schema(description = "변경 사유", example = "상품 출고 완료")
     private String reason;
 
     public OrderStatusChangeCommand toCommand(UUID orderId, String loginId) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #306 

<br>

## 📌 개요
- OrderService에 Swagger 설정을 추가하고 주문 API에 대한 설명을 보완했습니다.
- Controller 인터페이스를 분리하여 Swagger 명세를 정리하고 구현체를 단순화했습니다.
- 기존 환경에서 Swagger 어노테이션이 정상적으로 인식되지 않아, 의존성을 추가했습니다.

<br>

## 🔁 변경 사항
- OrderService Swagger(OpenAPI) 기본 설정 추가
- 주문 관련 API 설명(summary, description) 보완
- Controller 인터페이스 분리
- Swagger 명세를 인터페이스에 정의

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점
- Swagger 작업과는 별개로, 상품 서비스 주문 조회 시 오류가 확인되어 Product-Service 확인이 필요합니다. @newbee9507 

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
