### PR TITLE
BUG/ProductService - 주문의 상품조회 에러 해결, 카프카 메세지 구독 에러 해결, 빌드시 레디스 테스트제외

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -76,6 +76,7 @@ dependencyManagement {
 	}
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
+test {
+    exclude('**/RedisRepositoryImplTest.class')
+    useJUnitPlatform()
 }

--- a/product-service/src/main/java/com/palja/product_service/application/dto/res/ProductInfoForOrderRes.java
+++ b/product-service/src/main/java/com/palja/product_service/application/dto/res/ProductInfoForOrderRes.java
@@ -14,8 +14,8 @@ public class ProductInfoForOrderRes {
     private UUID productId;
     private UUID companyUserId;
     private String productName;
-    private BigDecimal price;
-    private int stockQuantity;
+    private Long price;
+    private Long stockQuantity;
 
     public static ProductInfoForOrderRes fromDto(ProductInfoForOrderDto dto) {
 

--- a/product-service/src/main/java/com/palja/product_service/domain/dto/res/ProductInfoForOrderDto.java
+++ b/product-service/src/main/java/com/palja/product_service/domain/dto/res/ProductInfoForOrderDto.java
@@ -13,6 +13,6 @@ public class ProductInfoForOrderDto {
     private UUID productId;
     private UUID companyUserId;
     private String productName;
-    private BigDecimal price;
-    private int stockQuantity;
+    private Long price;
+    private Long stockQuantity;
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/config/KafkaConsumerConfig.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,75 @@
+package com.palja.product_service.infrastructure.config;
+
+import com.palja.common.interceptor.KafkaRecordInterceptor;
+import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseOrderEventDto;
+import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseTimeDealDto;
+import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreEventDto;
+import io.micrometer.tracing.Tracer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.DelegatingByTopicDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static com.palja.product_service.infrastructure.external.kafka.ProductKafkaTopic.*;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS;
+
+    @Bean
+    public KafkaRecordInterceptor<Object> consumerInterceptor(Tracer tracer) {
+
+        return new KafkaRecordInterceptor<>(tracer);
+    }
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+
+        return new DefaultKafkaConsumerFactory<>(
+                Map.of(
+                        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS,
+                        ConsumerConfig.GROUP_ID_CONFIG, "product-service",
+//                        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+//                        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class,
+                        JsonDeserializer.TRUSTED_PACKAGES, "*"
+                ), new StringDeserializer(),
+                new DelegatingByTopicDeserializer(Map.of(
+                        Pattern.compile(DECREASE_STOCK_TIMEDEAL),
+                        new JsonDeserializer<>(StockDecreaseTimeDealDto.class, false),
+                        Pattern.compile(SALE_STOCK_ORDER),
+                        new JsonDeserializer<>(StockDecreaseOrderEventDto.class, false),
+                        Pattern.compile(".*restore.*"),
+                        new JsonDeserializer<>(StockRestoreEventDto.class, false),
+                        Pattern.compile(ORDER_CANCEL),
+                        new JsonDeserializer<>(StockRestoreEventDto.class, false)
+                ), new JsonDeserializer<Object>())
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(Tracer tracer) {
+        //빈 이름도 동일하게..
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory
+                = new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.setConsumerFactory(consumerFactory());
+        factory.setRecordInterceptor(consumerInterceptor(tracer));
+        factory.setConcurrency(3);
+        factory.getContainerProperties().setPollTimeout(3000);
+
+        return factory;
+    }
+}

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/config/KafkaProducerConfig.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/config/KafkaProducerConfig.java
@@ -1,20 +1,16 @@
 package com.palja.product_service.infrastructure.config;
 
 import com.palja.common.interceptor.KafkaProducerInterceptor;
-import com.palja.common.interceptor.KafkaRecordInterceptor;
 import io.micrometer.tracing.Tracer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.kafka.annotation.EnableKafka;
-import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.TopicBuilder;
-import org.springframework.kafka.core.*;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.Map;
@@ -23,9 +19,8 @@ import static com.palja.product_service.infrastructure.external.kafka.ProductKaf
 import static com.palja.product_service.infrastructure.external.kafka.ProductKafkaTopic.DECREASE_STOCK_TIMEDEAL;
 import static org.springframework.kafka.core.KafkaAdmin.NewTopics;
 
-@EnableKafka
 @Configuration
-public class KafkaConfig {
+public class KafkaProducerConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String BOOTSTRAP_SERVERS;
@@ -59,39 +54,6 @@ public class KafkaConfig {
     public ProducerFactory<String, Object> producerFactory() {
 
         return new DefaultKafkaProducerFactory<>(producerConfigs());
-    }
-
-    @Bean
-    public KafkaRecordInterceptor<Object> consumerInterceptor(Tracer tracer) {
-
-        return new KafkaRecordInterceptor<>(tracer);
-    }
-
-    @Bean
-    public ConsumerFactory<String, Object> consumerFactory() {
-
-        return new DefaultKafkaConsumerFactory<>(
-                Map.of(
-                        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS,
-                        ConsumerConfig.GROUP_ID_CONFIG, "product-service",
-                        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
-                        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class
-                )
-        );
-    }
-
-    @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(Tracer tracer) {
-        //빈 이름도 동일하게..
-        ConcurrentKafkaListenerContainerFactory<String, Object> factory
-                = new ConcurrentKafkaListenerContainerFactory<>();
-
-        factory.setConsumerFactory(consumerFactory());
-        factory.setRecordInterceptor(consumerInterceptor(tracer));
-        factory.setConcurrency(3);
-        factory.getContainerProperties().setPollTimeout(3000);
-
-        return factory;
     }
 
     @Bean

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/listener/ProductKafkaListener.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/listener/ProductKafkaListener.java
@@ -22,39 +22,25 @@ public class ProductKafkaListener {
     private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = DECREASE_STOCK_TIMEDEAL)
-    public void handleDecreaseStockTimeDealEvent(ConsumerRecord<String, Object> dto) {
+    public void handleDecreaseStockTimeDealEvent(StockDecreaseTimeDealDto dto) {
 
-        String value = (String) dto.value();
-        StockDecreaseTimeDealDto event = Deserialization(value, StockDecreaseTimeDealDto.class);
-
-        productService.decreaseStockForTimeDeal(event.getProductId(), event.getQuantity());
+        productService.decreaseStockForTimeDeal(dto.getProductId(), dto.getQuantity());
     }
 
     @KafkaListener(topics = SALE_STOCK_ORDER)
-    public void handleDecreaseStockOrderEvent(ConsumerRecord<String, Object> dto) {
+    public void handleDecreaseStockOrderEvent(StockDecreaseOrderEventDto dto) {
 
-        String value = (String) dto.value();
-        StockDecreaseOrderEventDto event = Deserialization(value, StockDecreaseOrderEventDto.class);
-
-        if (event.getIsTimeDeal().equals(Boolean.FALSE)) {
+        if (dto.getIsTimeDeal().equals(Boolean.FALSE)) {
             productService.saleProduct(
-                    event.getSagaId(), event.getProductId(), event.getOrderId(), event.getQuantity());
+                    dto.getSagaId(), dto.getProductId(), dto.getOrderId(), dto.getQuantity());
         }
     }
 
     @KafkaListener(topics = {INCREASE_STOCK_TIMEDEAL, RESTORE_STOCK_ORDER, ORDER_CANCEL})
-    public void handleIncreaseStockEvent(ConsumerRecord<String, Object> dto) {
+    public void handleIncreaseStockEvent(StockRestoreEventDto dto) {
 
-        String value = (String) dto.value();
-        StockRestoreEventDto event = Deserialization(value, StockRestoreEventDto.class);
-
-        if(event.getIsTimeDeal() == null || event.getIsTimeDeal().equals(Boolean.FALSE)) {
-            productService.stockRestore(event.getProductId(), event.getQuantity());
+        if(dto.getIsTimeDeal() == null || dto.getIsTimeDeal().equals(Boolean.FALSE)) {
+            productService.stockRestore(dto.getProductId(), dto.getQuantity());
         }
-    }
-
-    private <T> T Deserialization(Object value, Class<T> type) {
-
-        return objectMapper.convertValue(value, type);
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/repository/DslProductRepository.java
@@ -29,7 +29,7 @@ public class DslProductRepository {
                         product.id,
                         product.companyUserId,
                         product.price.amount.longValue(),
-                        product.productStock.quantity.longValue()))
+                        product.productStock.quantity))
                 .from(product)
                 .where(product.id.eq(productId).and(product.deletedAt.isNull()))
                 .fetchOne();


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #314 

<br>

## 📌 개요
- 주문 생성시 상품조회 요청에 실패하는 버그 해결
- 카프카 메세지를 수신하는데 발생하는 버그 해결
- 그레이들 빌드시, 도커를 필요로하는 레디스 테스트만을 제외하고 빌드

<br>

## 🔁 변경 사항

1. 주문 생성시 반환하는 상품 정보 클래스의 타입을 수정했습니다
2. 타임딜에서 상품쪽으로 보내는 카프카 메세지 수신시 발생하는 에러를 해결했습니다.
3. CICD에 테스트를 포함시키기 위해 도커를 필요로하는 테스트를 제외하고 빌드하도록 했습니다.
4. 카프카 설정을 리스너, 컨슈머 2개로 나눴습니다

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

주문생성시 발행되는 카프카 메세지 수신 테스트는 주문 생성시 SAGA ID가 없다는 DB제약조건이 발생해 어떻게 수정해야 할 지 몰라 못했습니다.

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
