### PR TITLE
FEAT/배송 송장 등록 API 구현

### DIFF
--- a/order-service/src/main/java/com/palja/order_service/application/command/RegisterDeliveryCommand.java
+++ b/order-service/src/main/java/com/palja/order_service/application/command/RegisterDeliveryCommand.java
@@ -1,0 +1,17 @@
+package com.palja.order_service.application.command;
+
+import com.palja.common.vo.UserRole;
+import lombok.Builder;
+
+import java.util.UUID;
+
+// 배송 정보 등록 Command
+@Builder
+public record RegisterDeliveryCommand (
+        UUID orderId,
+        String loginId,
+        UserRole userRole,
+        String trackingNumber,
+        String courierCompany
+) {
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/DeliveryRegisterRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/DeliveryRegisterRes.java
@@ -1,0 +1,52 @@
+package com.palja.order_service.application.dto.response;
+
+import com.palja.order_service.domain.entity.Order;
+import com.palja.order_service.domain.vo.DeliveryStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 배송 정보 등록 응답 DTO
+ */
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "배송 정보 등록 응답")
+public class DeliveryRegisterRes {
+
+    @Schema(description = "주문 ID", example = "550e8400-e29b-41d4-a716-446655440100")
+    private UUID orderId;
+
+    @Schema(description = "배송 상태", example = "IN_TRANSIT")
+    private DeliveryStatus status;
+
+    @Schema(description = "수령인 정보")
+    private RecipientRes recipient;
+
+    @Schema(description = "송장 정보")
+    private TrackingRes tracking;
+
+    @Schema(description = "생성 시간", example = "2025-12-01T10:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시간", example = "2025-12-01T12:00:00")
+    private LocalDateTime updatedAt;
+
+    // Order 엔티티 → 배송 정보 응답 DTO 변환
+    public static DeliveryRegisterRes from(Order order) {
+        return DeliveryRegisterRes.builder()
+                .orderId(order.getOrderId())
+                .status(order.getDelivery().getStatus())
+                .recipient(RecipientRes.from(order.getDelivery().getRecipient()))
+                .tracking(TrackingRes.from(order.getDelivery()))
+                .createdAt(order.getCreatedAt())
+                .updatedAt(order.getUpdatedAt())
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/DeliveryRegisterRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/DeliveryRegisterRes.java
@@ -2,6 +2,7 @@ package com.palja.order_service.application.dto.response;
 
 import com.palja.order_service.domain.entity.Order;
 import com.palja.order_service.domain.vo.DeliveryStatus;
+import com.palja.order_service.domain.vo.OrderStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -23,8 +24,11 @@ public class DeliveryRegisterRes {
     @Schema(description = "주문 ID", example = "550e8400-e29b-41d4-a716-446655440100")
     private UUID orderId;
 
+    @Schema(description = "주문 상태", example = "PREPARING")
+    private OrderStatus orderStatus;
+
     @Schema(description = "배송 상태", example = "IN_TRANSIT")
-    private DeliveryStatus status;
+    private DeliveryStatus deliveryStatus;
 
     @Schema(description = "수령인 정보")
     private RecipientRes recipient;
@@ -42,7 +46,8 @@ public class DeliveryRegisterRes {
     public static DeliveryRegisterRes from(Order order) {
         return DeliveryRegisterRes.builder()
                 .orderId(order.getOrderId())
-                .status(order.getDelivery().getStatus())
+                .orderStatus(order.getStatus())
+                .deliveryStatus(order.getDelivery().getStatus())
                 .recipient(RecipientRes.from(order.getDelivery().getRecipient()))
                 .tracking(TrackingRes.from(order.getDelivery()))
                 .createdAt(order.getCreatedAt())

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/RecipientRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/RecipientRes.java
@@ -1,0 +1,39 @@
+package com.palja.order_service.application.dto.response;
+
+import com.palja.order_service.domain.vo.Recipient;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 수령인 정보 응답
+ */
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "수령인 정보")
+public class RecipientRes {
+
+    @Schema(description = "수령인 이름", example = "김차돌")
+    private String name;
+
+    @Schema(description = "수령인 이메일", example = "kim@example.com")
+    private String email;
+
+    @Schema(description = "수령인 주소", example = "서울시 강남구 테헤란로 123")
+    private String address;
+
+    @Schema(description = "배송 요청사항", example = "부재 시 문 앞에 놓아주세요")
+    private String deliveryMessage;
+
+    public static RecipientRes from(Recipient recipient) {
+        return RecipientRes.builder()
+                .name(recipient.getName())
+                .email(recipient.getEmail())
+                .address(recipient.getAddress())
+                .deliveryMessage(recipient.getDeliveryMessage())
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/dto/response/TrackingRes.java
+++ b/order-service/src/main/java/com/palja/order_service/application/dto/response/TrackingRes.java
@@ -1,0 +1,41 @@
+package com.palja.order_service.application.dto.response;
+
+import com.palja.order_service.domain.entity.OrderDelivery;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 송장 정보 응답
+ */
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "송장 정보")
+public class TrackingRes {
+
+    @Schema(description = "송장 번호", example = "123456789012")
+    private String trackingNumber;
+
+    @Schema(description = "택배사", example = "CJ대한통운")
+    private String courierCompany;
+
+    @Schema(description = "배송 시작 시간", example = "2025-12-01T12:00:00")
+    private LocalDateTime shippedAt;
+
+    @Schema(description = "배송 완료 시간", example = "2025-12-03T15:30:00")
+    private LocalDateTime deliveredAt;
+
+    public static TrackingRes from(OrderDelivery delivery) {
+        return TrackingRes.builder()
+                .trackingNumber(delivery.getTrackingNumber())
+                .courierCompany(delivery.getCourierCompany())
+                .shippedAt(delivery.getShippedAt())
+                .deliveredAt(delivery.getDeliveredAt())
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -73,6 +73,8 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_RECIPIENT_INFO(HttpStatus.BAD_REQUEST, "수령인 정보가 유효하지 않습니다."),
     INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "배송 주소가 유효하지 않습니다."),
     INVALID_TRACKING_NUMBER(HttpStatus.BAD_REQUEST, "운송장 번호가 유효하지 않습니다."),
+    TRACKING_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 송장 번호가 등록된 주문입니다."),
+    DELIVERY_STATUS_CANNOT_REGISTER_TRACKING(HttpStatus.BAD_REQUEST, "현재 배송 상태에서는 송장을 등록할 수 없습니다."),
 
     // ===== 결제 관련 =====
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "결제 시간이 초과되었습니다."),

--- a/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/palja/order_service/application/exception/OrderErrorCode.java
@@ -26,6 +26,7 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "주문 금액이 올바르지 않습니다."),
     ORDER_CANNOT_BE_CANCELED(HttpStatus.BAD_REQUEST, "현재 상태에서는 주문을 취소할 수 없습니다."),
     NO_CANCEL_PERMISSION(HttpStatus.FORBIDDEN, "해당 주문을 취소할 권한이 없습니다."),
+    SELLER_NOT_OWNER(HttpStatus.FORBIDDEN, "해당 상품에 대한 판매자 권한이 없습니다."),
 
     INVENTORY_DEDUCTION_FAILED(HttpStatus.BAD_REQUEST, "재고 차감에 실패했습니다."),
     INVENTORY_RESTORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "재고 복구에 실패했습니다."),
@@ -75,6 +76,7 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_TRACKING_NUMBER(HttpStatus.BAD_REQUEST, "운송장 번호가 유효하지 않습니다."),
     TRACKING_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 송장 번호가 등록된 주문입니다."),
     DELIVERY_STATUS_CANNOT_REGISTER_TRACKING(HttpStatus.BAD_REQUEST, "현재 배송 상태에서는 송장을 등록할 수 없습니다."),
+    DELIVERY_REGISTRATION_DENIED(HttpStatus.FORBIDDEN, "배송 정보 등록 권한이 없습니다."),
 
     // ===== 결제 관련 =====
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "결제 시간이 초과되었습니다."),

--- a/order-service/src/main/java/com/palja/order_service/application/service/OrderDeliveryService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/OrderDeliveryService.java
@@ -1,4 +1,9 @@
 package com.palja.order_service.application.service;
 
+import com.palja.order_service.application.command.RegisterDeliveryCommand;
+import com.palja.order_service.application.dto.response.DeliveryRegisterRes;
+
 public interface OrderDeliveryService {
+
+    DeliveryRegisterRes registerDeliveryTracking(RegisterDeliveryCommand command);
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/OrderService.java
@@ -13,8 +13,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.UUID;
 
 public interface OrderService {
-    void save(Order order);
-
     OrderCreateRes createOrder(CreateOrderCommand command);
 
     void registerPayment(UUID orderId, UUID paymentId);

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderDeliveryServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderDeliveryServiceImpl.java
@@ -35,11 +35,6 @@ public class OrderDeliveryServiceImpl implements OrderDeliveryService {
         // 권한 검증
         orderDeliveryValidator.validateDeliveryRegistrationAuthority(order, command.userRole(), command.loginId());
 
-        // 주문 상태 검증 (PAID 상태만 가능)
-        if (!order.getStatus().isPaid()) {
-            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS_FOR_PAYMENT);
-        }
-
         // 배송 정보 존재 확인
         OrderDelivery delivery = order.requireDelivery();
 

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderDeliveryServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderDeliveryServiceImpl.java
@@ -1,15 +1,57 @@
 package com.palja.order_service.application.service.impl;
 
+import com.palja.common.exception.BusinessException;
+import com.palja.order_service.application.command.RegisterDeliveryCommand;
+import com.palja.order_service.application.dto.response.DeliveryRegisterRes;
+import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.OrderDeliveryService;
-import com.palja.order_service.domain.repository.OrderRepository;
-import com.palja.order_service.domain.service.OrderDomainService;
+import com.palja.order_service.application.service.OrderService;
+import com.palja.order_service.application.service.validator.OrderDeliveryValidator;
+import com.palja.order_service.domain.entity.Order;
+import com.palja.order_service.domain.entity.OrderDelivery;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderDeliveryServiceImpl implements OrderDeliveryService {
 
-    private final OrderRepository orderRepository;
-    private final OrderDomainService orderDomainService;
+    private final OrderDeliveryValidator orderDeliveryValidator;
+    private final OrderService orderService;
+
+    /**
+     * 배송 정보 등록 (송장 번호 등록)
+     */
+    @Override
+    @Transactional
+    public DeliveryRegisterRes registerDeliveryTracking(RegisterDeliveryCommand command) {
+        // 주문 조회
+        Order order = orderService.findOrderWithDetails(command.orderId());
+
+        // 권한 검증
+        orderDeliveryValidator.validateDeliveryRegistrationAuthority(order, command.userRole(), command.loginId());
+
+        // 주문 상태 검증 (PAID 상태만 가능)
+        if (!order.getStatus().isPaid()) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS_FOR_PAYMENT);
+        }
+
+        // 배송 정보 존재 확인
+        OrderDelivery delivery = order.requireDelivery();
+
+        // 송장 번호 등록 (READY → REQUESTED)
+        delivery.registerTracking(command.trackingNumber(), command.courierCompany());
+
+        // 주문 상태 업데이트 (PAID → PREPARING)
+        order.markAsPreparing();
+
+        // 저장
+        orderService.save(order);
+
+        return DeliveryRegisterRes.from(order);
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderDeliveryServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderDeliveryServiceImpl.java
@@ -1,14 +1,12 @@
 package com.palja.order_service.application.service.impl;
 
-import com.palja.common.exception.BusinessException;
 import com.palja.order_service.application.command.RegisterDeliveryCommand;
 import com.palja.order_service.application.dto.response.DeliveryRegisterRes;
-import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.service.OrderDeliveryService;
 import com.palja.order_service.application.service.OrderService;
 import com.palja.order_service.application.service.validator.OrderDeliveryValidator;
 import com.palja.order_service.domain.entity.Order;
-import com.palja.order_service.domain.entity.OrderDelivery;
+import com.palja.order_service.domain.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +20,7 @@ public class OrderDeliveryServiceImpl implements OrderDeliveryService {
 
     private final OrderDeliveryValidator orderDeliveryValidator;
     private final OrderService orderService;
+    private final OrderRepository orderRepository;
 
     /**
      * 배송 정보 등록 (송장 번호 등록)
@@ -29,24 +28,10 @@ public class OrderDeliveryServiceImpl implements OrderDeliveryService {
     @Override
     @Transactional
     public DeliveryRegisterRes registerDeliveryTracking(RegisterDeliveryCommand command) {
-        // 주문 조회
         Order order = orderService.findOrderWithDetails(command.orderId());
-
-        // 권한 검증
         orderDeliveryValidator.validateDeliveryRegistrationAuthority(order, command.userRole(), command.loginId());
-
-        // 배송 정보 존재 확인
-        OrderDelivery delivery = order.requireDelivery();
-
-        // 송장 번호 등록 (READY → REQUESTED)
-        delivery.registerTracking(command.trackingNumber(), command.courierCompany());
-
-        // 주문 상태 업데이트 (PAID → PREPARING)
-        order.markAsPreparing();
-
-        // 저장
-        orderService.save(order);
-
+        // 송장 등록 + 주문상태 PREPARING 전환
+        order.onTrackingRegistered(command.trackingNumber(), command.courierCompany());
         return DeliveryRegisterRes.from(order);
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/impl/OrderServiceImpl.java
@@ -8,6 +8,7 @@ import com.palja.order_service.application.command.CompleteOrderPaymentCommand;
 import com.palja.order_service.application.command.CreateOrderCommand;
 import com.palja.order_service.application.dto.external.*;
 import com.palja.order_service.application.dto.response.*;
+import com.palja.order_service.application.event.publisher.OrderInternalEventPublisher;
 import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.port.CouponClient;
 import com.palja.order_service.application.port.ProductClient;
@@ -17,8 +18,8 @@ import com.palja.order_service.application.saga.model.OrderSaga;
 import com.palja.order_service.application.service.OrderSagaService;
 import com.palja.order_service.application.service.OrderService;
 import com.palja.order_service.application.service.calculator.OrderPriceCalculator;
-import com.palja.order_service.application.event.publisher.OrderInternalEventPublisher;
 import com.palja.order_service.application.service.validator.OrderValidator;
+import com.palja.order_service.application.support.ExternalIdentityResolver;
 import com.palja.order_service.domain.entity.Order;
 import com.palja.order_service.domain.repository.OrderRepository;
 import com.palja.order_service.domain.service.OrderDomainService;
@@ -56,6 +57,8 @@ public class OrderServiceImpl implements OrderService {
     private final OrderValidator orderValidator;
     private final OrderPriceCalculator orderPriceCalculator;
     private final OrderSagaService orderSagaService;
+
+    private final ExternalIdentityResolver identityResolver;
 
     // Spring Event
     private final OrderInternalEventPublisher internalEventPublisher;
@@ -237,12 +240,6 @@ public class OrderServiceImpl implements OrderService {
         log.info("주문 결제 ID 등록 완료: orderId={}, paymentId={}", orderId, paymentId);
     }
 
-    // 주문 저장
-    @Transactional
-    public void save(Order order) {
-        orderRepository.save(order);
-    }
-
     // ====== Order Cancellation Workflow ======
     /**
      * 주문 취소
@@ -353,7 +350,7 @@ public class OrderServiceImpl implements OrderService {
     ) {
         log.info("고객 주문 목록 조회 시작: loginId={}", loginId);
 
-        Long userId = resolveCustomerId(loginId);
+        Long userId = identityResolver.resolveCustomerId(loginId);
 
         OrderStatus orderStatus = OrderStatus.from(request.getStatus());
         LocalDateTime startDateTime = toStartDateTimeOrMin(request.getStartDate());
@@ -440,11 +437,11 @@ public class OrderServiceImpl implements OrderService {
 
         switch (userRole) {
             case CUSTOMER -> {
-                customerId = resolveCustomerId(loginId);
+                customerId = identityResolver.resolveCustomerId(loginId);
             }
             case COMPANY_USER -> {
-                companyUserId = resolveCompanyUserId(loginId);
-                productSellerId = resolveProductSellerId(order.getOrderItem().getProductId());
+                companyUserId = identityResolver.resolveCompanyUserId(loginId);
+                productSellerId = identityResolver.resolveProductSellerId(order.getOrderItem().getProductId());
             }
         }
 
@@ -458,18 +455,6 @@ public class OrderServiceImpl implements OrderService {
     }
 
     // ===== Private: Utility =====
-    private Long resolveCustomerId(String loginId) {
-        return userClient.getMyCustomer(loginId).getUserId();
-    }
-
-    private UUID resolveCompanyUserId(String loginId) {
-        return userClient.getMyCompanyUser(loginId).getCompanyUserId();
-    }
-
-    private UUID resolveProductSellerId(UUID productId) {
-        return productClient.getProduct(productId).getCompanyUserId();
-    }
-
     // 배송 정보 생성
     private Recipient createRecipient(CreateOrderCommand command) {
         return Recipient.create(

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderDeliveryValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderDeliveryValidator.java
@@ -3,14 +3,10 @@ package com.palja.order_service.application.service.validator;
 import com.palja.common.exception.BusinessException;
 import com.palja.common.vo.UserRole;
 import com.palja.order_service.application.exception.OrderErrorCode;
-import com.palja.order_service.application.port.ProductClient;
-import com.palja.order_service.application.port.UserClient;
 import com.palja.order_service.domain.entity.Order;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-
-import java.util.UUID;
 
 // 주문 배송 관련 검증을 담당 컴포넌트
 @Slf4j
@@ -18,8 +14,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class OrderDeliveryValidator {
 
-    private final UserClient userClient;
-    private final ProductClient productClient;
     private final OrderValidator orderValidator;
 
     /**
@@ -35,25 +29,12 @@ public class OrderDeliveryValidator {
                 return;
 
             case COMPANY_USER:
-                // 현재 로그인한 판매자 ID
-                UUID currentCompanyUserId = resolveCompanyUserId(loginId);
-                // 해당 상품의 실제 판매자 ID
-                UUID sellerCompanyUserId = resolveProductSellerId(order.getOrderItem().getProductId());
                 // 판매자 소유권 검증
-                orderValidator.verifySellerOwnership(currentCompanyUserId, sellerCompanyUserId);
+                orderValidator.validateSellerOwnsProduct(loginId, order.getOrderItem().getProductId());
                 return;
 
             default:
-                throw new BusinessException(OrderErrorCode.ORDER_MODIFICATION_DENIED);
+                throw new BusinessException(OrderErrorCode.DELIVERY_REGISTRATION_DENIED);
         }
-    }
-
-    // ===== Private: Utility =====
-    private UUID resolveCompanyUserId(String loginId) {
-        return userClient.getMyCompanyUser(loginId).getCompanyUserId();
-    }
-
-    private UUID resolveProductSellerId(UUID productId) {
-        return productClient.getProduct(productId).getCompanyUserId();
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderDeliveryValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderDeliveryValidator.java
@@ -1,0 +1,59 @@
+package com.palja.order_service.application.service.validator;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.exception.OrderErrorCode;
+import com.palja.order_service.application.port.ProductClient;
+import com.palja.order_service.application.port.UserClient;
+import com.palja.order_service.domain.entity.Order;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+// 주문 배송 관련 검증을 담당 컴포넌트
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderDeliveryValidator {
+
+    private final UserClient userClient;
+    private final ProductClient productClient;
+    private final OrderValidator orderValidator;
+
+    /**
+     * 배송 정보 등록 권한 검증
+     * - MANAGER: 항상 허용
+     * - COMPANY_USER: 본인이 판매한 상품의 주문일 때만 허용
+     */
+    public void validateDeliveryRegistrationAuthority(Order order, UserRole userRole, String loginId) {
+
+        switch (userRole) {
+            case MANAGER:
+                // 매니저 허용
+                return;
+
+            case COMPANY_USER:
+                // 현재 로그인한 판매자 ID
+                UUID currentCompanyUserId = resolveCompanyUserId(loginId);
+                // 해당 상품의 실제 판매자 ID
+                UUID sellerCompanyUserId = resolveProductSellerId(order.getOrderItem().getProductId());
+                // 판매자 소유권 검증
+                orderValidator.verifySellerOwnership(currentCompanyUserId, sellerCompanyUserId);
+                return;
+
+            default:
+                throw new BusinessException(OrderErrorCode.ORDER_MODIFICATION_DENIED);
+        }
+    }
+
+    // ===== Private: Utility =====
+    private UUID resolveCompanyUserId(String loginId) {
+        return userClient.getMyCompanyUser(loginId).getCompanyUserId();
+    }
+
+    private UUID resolveProductSellerId(UUID productId) {
+        return productClient.getProduct(productId).getCompanyUserId();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
+++ b/order-service/src/main/java/com/palja/order_service/application/service/validator/OrderValidator.java
@@ -10,6 +10,7 @@ import com.palja.order_service.application.dto.CouponUserStatus;
 import com.palja.order_service.application.dto.external.*;
 import com.palja.order_service.application.exception.OrderErrorCode;
 import com.palja.order_service.application.port.UserClient;
+import com.palja.order_service.application.support.ExternalIdentityResolver;
 import com.palja.order_service.domain.entity.Order;
 import com.palja.order_service.domain.vo.OrderStatus;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ import java.util.regex.Pattern;
 public class OrderValidator {
 
     private final UserClient userClient;
+    private final ExternalIdentityResolver identityResolver;
 
     // 검증 상수
     private static final Pattern EMAIL_PATTERN = Pattern.compile(
@@ -422,7 +424,7 @@ public class OrderValidator {
         if (!companyUserId.equals(sellerId)) {
             log.warn("판매자 소유권 검증 실패: companyUserId={}, sellerId={}",
                     companyUserId, sellerId);
-            throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+            throw new BusinessException(OrderErrorCode.SELLER_NOT_OWNER);
         }
     }
 
@@ -490,5 +492,19 @@ public class OrderValidator {
 
         log.debug("결제 완료 검증 성공: orderId={}, paymentId={}, amount={}",
                 order.getOrderId(), command.paymentId(), command.paidAmount());
+    }
+
+    // 판매자가 특정 상품의 소유자인지 검증
+    public void validateSellerOwnsProduct(String loginId, UUID productId) {
+        // 현재 로그인한 판매자 ID
+        UUID sellerId = identityResolver.resolveCompanyUserId(loginId);
+        // 해당 상품의 실제 판매자 ID
+        UUID productOwnerId = identityResolver.resolveProductSellerId(productId);
+
+        if (!sellerId.equals(productOwnerId)) {
+            log.warn("판매자 소유권 검증 실패: sellerId={}, productOwnerId={}",
+                    sellerId, productOwnerId);
+            throw new BusinessException(OrderErrorCode.SELLER_NOT_OWNER);
+        }
     }
 }

--- a/order-service/src/main/java/com/palja/order_service/application/support/ExternalIdentityResolver.java
+++ b/order-service/src/main/java/com/palja/order_service/application/support/ExternalIdentityResolver.java
@@ -1,0 +1,38 @@
+package com.palja.order_service.application.support;
+
+import com.palja.order_service.application.port.ProductClient;
+import com.palja.order_service.application.port.UserClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * 외부 User / Product 서비스를 조회하여
+ * Order 유스케이스 수행에 필요한 식별자를 해결(resolve)하는 컴포넌트
+ * - 조회 전용
+ * - 도메인 로직 없음
+ * - 외부 의존성 캡슐화 목적
+ */
+@Component
+@RequiredArgsConstructor
+public class ExternalIdentityResolver {
+
+    private final UserClient userClient;
+    private final ProductClient productClient;
+
+    // 로그인한 고객 userId
+    public Long resolveCustomerId(String loginId) {
+        return userClient.getMyCustomer(loginId).getUserId();
+    }
+
+    // 로그인한 판매자 userId
+    public UUID resolveCompanyUserId(String loginId) {
+        return userClient.getMyCompanyUser(loginId).getCompanyUserId();
+    }
+
+    // 상품의 판매자 userId
+    public UUID resolveProductSellerId(UUID productId) {
+        return productClient.getProduct(productId).getCompanyUserId();
+    }
+}

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/Order.java
@@ -310,4 +310,18 @@ public class Order extends BaseEntity {
                             this.orderAmount.getFinalAmount(), paidAmount));
         }
     }
+
+    // 송장 등록 -> 배송 준비 시작
+    public void onTrackingRegistered(String trackingNumber, String courierCompany) {
+        // 주문 상태 기준으로 송장 등록 가능한지 검증
+        if (!this.status.canRegisterTracking()) {
+            throw new IllegalStateException("송장 등록이 불가능한 주문 상태입니다: " + this.status);
+        }
+
+        // 배송에 위임 (중복 등록/값 검증/배송 상태 전이)
+        delivery.registerTracking(trackingNumber, courierCompany);
+
+        // 주문 상태 전환 규칙 적용
+        transitionTo(OrderStatus.PREPARING);
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/domain/entity/OrderDelivery.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/entity/OrderDelivery.java
@@ -55,11 +55,15 @@ public class OrderDelivery {
                 .recipient(recipient)
                 .build();
     }
-
     // 송장 등록
     public void registerTracking(String trackingNumber, String courierCompany) {
+        // 이미 등록됐는지 검증 (중복 등록 방지)
+        if (isTrackingRegistered()) {
+            throw new IllegalStateException("이미 송장이 등록된 배송입니다.");
+        }
+
         if (!this.status.canRegisterTracking()) {
-            throw new IllegalStateException("배송 준비 상태에서만 송장을 등록할 수 있습니다.");
+            throw new IllegalStateException("송장 등록이 불가능한 배송 상태입니다: " + this.status);
         }
 
         validateTrackingNumber(trackingNumber);
@@ -71,6 +75,11 @@ public class OrderDelivery {
         // 송장 발행/배송요청 상태로 변경
         transitionTo(DeliveryStatus.REQUESTED);
     }
+
+    public boolean isTrackingRegistered() {
+        return this.trackingNumber != null && !this.trackingNumber.isBlank();
+    }
+
 
     // 배송 정보 수정 (READY 상태에서만)
     public void updateRecipient(Recipient newRecipient) {

--- a/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
+++ b/order-service/src/main/java/com/palja/order_service/domain/vo/OrderStatus.java
@@ -201,6 +201,14 @@ public enum OrderStatus {
         return this == DELIVERED;
     }
 
+    /**
+     * 송장 등록 가능 여부
+     * - 결제 완료(PAID) 이후 물류 처리가 시작될 때 송장 등록
+     */
+    public boolean canRegisterTracking() {
+        return this == PAID;
+    }
+
     // ======= 관리자 권한 검증 =======
     /**
      * 관리자 권한으로 변경 가능한 상태인지 검증

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderDeliveryController.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/OrderDeliveryController.java
@@ -1,4 +1,37 @@
 package com.palja.order_service.presentation.controller;
 
+import com.palja.common.response.ApiResponse;
+import com.palja.order_service.application.dto.response.DeliveryRegisterRes;
+import com.palja.order_service.presentation.dto.request.RegisterDeliveryReq;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.UUID;
+
+
+@Tag(name = "Delivery", description = "배송 관리 API")
+@RequestMapping("/api/v1/orders/{orderId}/delivery")
 public interface OrderDeliveryController {
+
+    @Operation(
+            summary = "배송 정보 등록 (송장 번호 등록)",
+            description = """
+                    판매자가 송장 번호를 등록하고 배송을 시작합니다.
+                    - 권한: COMPANY_USER, MANAGER
+                    - 주문 상태가 PAID여야 합니다.
+                    - 배송 상태: READY → REQUESTED
+                    - 주문 상태: PAID → PREPARING
+                    """
+    )
+    ResponseEntity<ApiResponse<DeliveryRegisterRes>> registerDelivery(
+            @Parameter(description = "주문 ID", required = true)
+            @PathVariable UUID orderId,
+            @Valid @RequestBody RegisterDeliveryReq request
+    );
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderDeliveryControllerImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderDeliveryControllerImpl.java
@@ -1,16 +1,38 @@
 package com.palja.order_service.presentation.controller.impl;
 
+import com.palja.common.annotation.RequiredRole;
+import com.palja.common.auditor.CurrentUser;
+import com.palja.common.response.ApiResponse;
+import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.dto.response.DeliveryRegisterRes;
 import com.palja.order_service.application.service.OrderDeliveryService;
 import com.palja.order_service.presentation.controller.OrderDeliveryController;
+import com.palja.order_service.presentation.dto.request.RegisterDeliveryReq;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/v1/orders")
+@RequestMapping("/api/v1/orders/{orderId}/delivery")
 @RequiredArgsConstructor
 public class OrderDeliveryControllerImpl implements OrderDeliveryController {
 
-    private final OrderDeliveryService orderDeliveryService;
+    private final OrderDeliveryService orderService;
 
+    @Override
+    @PostMapping
+    @RequiredRole(value = {UserRole.COMPANY_USER, UserRole.MANAGER})
+    public ResponseEntity<ApiResponse<DeliveryRegisterRes>> registerDelivery(
+            @PathVariable UUID orderId,
+            @Valid @RequestBody RegisterDeliveryReq request
+    ) {
+        DeliveryRegisterRes response = orderService.registerDeliveryTracking(
+                request.toCommand(orderId, CurrentUser.getLoginId(), CurrentUser.getRole())
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response, "배송 정보가 등록되었습니다."));
+    }
 }

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderDeliveryControllerImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderDeliveryControllerImpl.java
@@ -23,7 +23,7 @@ public class OrderDeliveryControllerImpl implements OrderDeliveryController {
     private final OrderDeliveryService orderDeliveryService;
 
     @Override
-    @PostMapping
+    @PutMapping
     @RequiredRole(value = {UserRole.COMPANY_USER, UserRole.MANAGER})
     public ResponseEntity<ApiResponse<DeliveryRegisterRes>> registerDelivery(
             @PathVariable UUID orderId,

--- a/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderDeliveryControllerImpl.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/controller/impl/OrderDeliveryControllerImpl.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class OrderDeliveryControllerImpl implements OrderDeliveryController {
 
-    private final OrderDeliveryService orderService;
+    private final OrderDeliveryService orderDeliveryService;
 
     @Override
     @PostMapping
@@ -29,7 +29,7 @@ public class OrderDeliveryControllerImpl implements OrderDeliveryController {
             @PathVariable UUID orderId,
             @Valid @RequestBody RegisterDeliveryReq request
     ) {
-        DeliveryRegisterRes response = orderService.registerDeliveryTracking(
+        DeliveryRegisterRes response = orderDeliveryService.registerDeliveryTracking(
                 request.toCommand(orderId, CurrentUser.getLoginId(), CurrentUser.getRole())
         );
 

--- a/order-service/src/main/java/com/palja/order_service/presentation/dto/request/RegisterDeliveryReq.java
+++ b/order-service/src/main/java/com/palja/order_service/presentation/dto/request/RegisterDeliveryReq.java
@@ -1,0 +1,42 @@
+package com.palja.order_service.presentation.dto.request;
+
+import com.palja.common.vo.UserRole;
+import com.palja.order_service.application.command.RegisterDeliveryCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * 배송 정보 등록 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "배송 정보 등록 요청")
+public class RegisterDeliveryReq {
+
+    @NotBlank(message = "송장 번호는 필수입니다.")
+    @Size(max = 100, message = "송장 번호는 100자를 초과할 수 없습니다.")
+    @Schema(description = "송장 번호", example = "123456789012")
+    private String trackingNumber;
+
+    @NotBlank(message = "택배사는 필수입니다.")
+    @Size(max = 50, message = "택배사명은 50자를 초과할 수 없습니다.")
+    @Schema(description = "택배사", example = "CJ대한통운")
+    private String courierCompany;
+
+    public RegisterDeliveryCommand toCommand(UUID orderId, String loginId, UserRole userRole) {
+        return RegisterDeliveryCommand.builder()
+                .orderId(orderId)
+                .loginId(loginId)
+                .userRole(userRole)
+                .trackingNumber(trackingNumber)
+                .courierCompany(courierCompany)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #328 

<br>

## 📌 개요
- 판매자/관리자가 주문에 송장 번호를 등록하고 배송을 시작할 수 있는 배송 정보 등록 API를 구현했습니다.

<br>

## 🔁 변경 사항
- 배송 정보 등록 API 추가
  - PUT /api/v1/orders/{orderId}/delivery
- 권한 검증 적용
  - COMPANY: 본인 판매 상품 주문만 가능
  - MANAGER: 전체 주문 접근 가능
- 배송 정보 업데이트
  - 배송 상태: READY → REQUESTED
  - trackingNumber, courierCompany 저장
- 주문 상태 업데이트
  - PAID → PREPARING

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
