### PR TITLE
REFACTOR/ProductService - 카프카 메세지 역직렬화 수정

### DIFF
--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/KafkaEvent.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/KafkaEvent.java
@@ -1,0 +1,18 @@
+package com.palja.product_service.application.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,          // 타입 식별자를 "이름"으로
+        include = JsonTypeInfo.As.PROPERTY,  // JSON 프로퍼티로 포함
+        property = "@type"                   // Type 필드로 구분
+)
+@JsonSubTypes({
+        // 필요한 이벤트 계속 추가
+        @JsonSubTypes.Type(value = TimeDealEvent.class, name = "TimeDealEvent"),
+        @JsonSubTypes.Type(value = OrderEvent.class, name = "OrderEvent"),
+        @JsonSubTypes.Type(value = ProductEvent.class, name = "ProductEvent"),
+})
+public interface KafkaEvent {
+}

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/OrderEvent.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/OrderEvent.java
@@ -1,0 +1,12 @@
+package com.palja.product_service.application.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseOrderDto;
+import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreOrderEventDto;
+
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = StockDecreaseOrderDto.class, name = "StockDecreaseOrderDto"),
+        @JsonSubTypes.Type(value = StockRestoreOrderEventDto.class, name = "StockRestoreOrderEventDto")
+})
+public interface OrderEvent extends KafkaEvent{
+}

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/OrderEvent.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/OrderEvent.java
@@ -5,8 +5,8 @@ import com.palja.product_service.infrastructure.external.kafka.dto.StockDecrease
 import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreOrderEventDto;
 
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = StockDecreaseOrderDto.class, name = "StockDecreaseOrderDto"),
-        @JsonSubTypes.Type(value = StockRestoreOrderEventDto.class, name = "StockRestoreOrderEventDto")
+        @JsonSubTypes.Type(value = StockDecreaseOrderDto.class, name = "StockDecreaseEventReq"),
+        @JsonSubTypes.Type(value = StockRestoreOrderEventDto.class, name = "StockRestoreEventReq")
 })
 public interface OrderEvent extends KafkaEvent{
 }

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/ProductEvent.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/ProductEvent.java
@@ -1,0 +1,21 @@
+package com.palja.product_service.application.event.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.palja.product_service.application.event.dto.request.ChangePriceEventReq;
+import com.palja.product_service.application.event.dto.request.DecreaseStockTimeDealErrorEventReq;
+import com.palja.product_service.application.event.dto.request.SaleProductErrorEventReq;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,          // 타입 식별자를 "이름"으로
+        include = JsonTypeInfo.As.PROPERTY,  // JSON 프로퍼티로 포함
+        property = "@type"                   // Type 필드로 구분
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ChangePriceEventReq.class, name = "ChangePriceEventReq"),
+        @JsonSubTypes.Type(value = DecreaseStockTimeDealErrorEventReq.class, name = "DecreaseStockTimeDealErrorEventReq"),
+        @JsonSubTypes.Type(value = SaleProductErrorEventReq.class, name = "SaleProductErrorEventReq"),
+})
+public interface ProductEvent{
+}

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/TimeDealEvent.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/TimeDealEvent.java
@@ -1,0 +1,12 @@
+package com.palja.product_service.application.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseTimeDealDto;
+import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreTimeDealEventDto;
+
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = StockDecreaseTimeDealDto.class, name = "StockDecreaseTimeDealDto"),
+        @JsonSubTypes.Type(value = StockRestoreTimeDealEventDto.class, name = "StockRestoreEventDto"),
+})
+public interface TimeDealEvent extends KafkaEvent {
+}

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/UserEvent.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/UserEvent.java
@@ -1,0 +1,10 @@
+package com.palja.product_service.application.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.palja.product_service.infrastructure.external.kafka.dto.DeleteAllByUserDto;
+
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = DeleteAllByUserDto.class, name = "DeleteCompanyUserEventReq")
+})
+public interface UserEvent extends KafkaEvent{
+}

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/request/ChangePriceEventReq.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/request/ChangePriceEventReq.java
@@ -1,6 +1,6 @@
 package com.palja.product_service.application.event.dto.request;
 
-import com.palja.product_service.application.event.dto.TimeDealEvent;
+import com.palja.product_service.application.event.dto.ProductEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChangePriceEventReq implements TimeDealEvent {
+public class ChangePriceEventReq implements ProductEvent {
 
     private UUID productId;
     private Long price;

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/request/ChangePriceEventReq.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/request/ChangePriceEventReq.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.application.event.dto.request;
 
+import com.palja.product_service.application.event.dto.TimeDealEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChangePriceEventReq {
+public class ChangePriceEventReq implements TimeDealEvent {
 
     private UUID productId;
     private Long price;

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/request/DecreaseStockTimeDealErrorEventReq.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/request/DecreaseStockTimeDealErrorEventReq.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.application.event.dto.request;
 
+import com.palja.product_service.application.event.dto.TimeDealEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DecreaseStockTimeDealErrorEventReq {
+public class DecreaseStockTimeDealErrorEventReq implements TimeDealEvent {
 
     private UUID productId;
     private String message;

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/request/DecreaseStockTimeDealErrorEventReq.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/request/DecreaseStockTimeDealErrorEventReq.java
@@ -1,6 +1,6 @@
 package com.palja.product_service.application.event.dto.request;
 
-import com.palja.product_service.application.event.dto.TimeDealEvent;
+import com.palja.product_service.application.event.dto.ProductEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DecreaseStockTimeDealErrorEventReq implements TimeDealEvent {
+public class DecreaseStockTimeDealErrorEventReq implements ProductEvent {
 
     private UUID productId;
     private String message;

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/request/SaleProductErrorEventReq.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/request/SaleProductErrorEventReq.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.application.event.dto.request;
 
+import com.palja.product_service.application.event.dto.OrderEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SaleProductErrorEventReq {
+public class SaleProductErrorEventReq implements OrderEvent {
 
     private UUID sagaId;
     private UUID orderId;

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/request/SaleProductErrorEventReq.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/request/SaleProductErrorEventReq.java
@@ -1,6 +1,6 @@
 package com.palja.product_service.application.event.dto.request;
 
-import com.palja.product_service.application.event.dto.OrderEvent;
+import com.palja.product_service.application.event.dto.ProductEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SaleProductErrorEventReq implements OrderEvent {
+public class SaleProductErrorEventReq implements ProductEvent {
 
     private UUID sagaId;
     private UUID orderId;

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/config/KafkaConsumerConfig.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/config/KafkaConsumerConfig.java
@@ -1,9 +1,7 @@
 package com.palja.product_service.infrastructure.config;
 
 import com.palja.common.interceptor.KafkaRecordInterceptor;
-import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseOrderDto;
-import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseTimeDealDto;
-import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreEventDto;
+import com.palja.product_service.application.event.dto.KafkaEvent;
 import io.micrometer.tracing.Tracer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -14,13 +12,9 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.support.serializer.DelegatingByTopicDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import java.util.Map;
-import java.util.regex.Pattern;
-
-import static com.palja.product_service.infrastructure.external.kafka.ProductKafkaTopic.*;
 
 @EnableKafka
 @Configuration
@@ -30,39 +24,31 @@ public class KafkaConsumerConfig {
     private String BOOTSTRAP_SERVERS;
 
     @Bean
-    public KafkaRecordInterceptor<Object> consumerInterceptor(Tracer tracer) {
+    public KafkaRecordInterceptor<KafkaEvent> consumerInterceptor(Tracer tracer) {
 
         return new KafkaRecordInterceptor<>(tracer);
     }
 
     @Bean
-    public ConsumerFactory<String, Object> consumerFactory() {
+    public ConsumerFactory<String, KafkaEvent> consumerFactory() {
 
         return new DefaultKafkaConsumerFactory<>(
                 Map.of(
                         ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS,
                         ConsumerConfig.GROUP_ID_CONFIG, "product-service",
-//                        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
-//                        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class,
-                        JsonDeserializer.TRUSTED_PACKAGES, "*"
-                ), new StringDeserializer(),
-                new DelegatingByTopicDeserializer(Map.of(
-                        Pattern.compile(DECREASE_STOCK_TIMEDEAL),
-                        new JsonDeserializer<>(StockDecreaseTimeDealDto.class, false),
-                        Pattern.compile(SALE_STOCK_ORDER),
-                        new JsonDeserializer<>(StockDecreaseOrderDto.class, false),
-                        Pattern.compile(".*restore.*"),
-                        new JsonDeserializer<>(StockRestoreEventDto.class, false),
-                        Pattern.compile(ORDER_CANCEL),
-                        new JsonDeserializer<>(StockRestoreEventDto.class, false)
-                ), new JsonDeserializer<Object>())
+                        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class,
+                        JsonDeserializer.TRUSTED_PACKAGES, "*",
+                        JsonDeserializer.USE_TYPE_INFO_HEADERS, false,
+                        JsonDeserializer.VALUE_DEFAULT_TYPE, KafkaEvent.class
+                )
         );
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(Tracer tracer) {
+    public ConcurrentKafkaListenerContainerFactory<String, KafkaEvent> kafkaListenerContainerFactory(Tracer tracer) {
         //빈 이름도 동일하게..
-        ConcurrentKafkaListenerContainerFactory<String, Object> factory
+        ConcurrentKafkaListenerContainerFactory<String, KafkaEvent> factory
                 = new ConcurrentKafkaListenerContainerFactory<>();
 
         factory.setConsumerFactory(consumerFactory());

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/config/KafkaProducerConfig.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/config/KafkaProducerConfig.java
@@ -1,6 +1,7 @@
 package com.palja.product_service.infrastructure.config;
 
 import com.palja.common.interceptor.KafkaProducerInterceptor;
+import com.palja.product_service.application.event.dto.ProductEvent;
 import io.micrometer.tracing.Tracer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -21,7 +22,7 @@ public class KafkaProducerConfig {
     private String BOOTSTRAP_SERVERS;
 
     @Bean
-    public KafkaProducerInterceptor<Object> interceptor(Tracer tracer) {
+    public KafkaProducerInterceptor<ProductEvent> interceptor(Tracer tracer) {
         return new KafkaProducerInterceptor<>(tracer);
     }
 
@@ -32,20 +33,21 @@ public class KafkaProducerConfig {
                 //Producer가 처음으로 연결할 Kafka 브로커의 위치
                 ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS,
                 ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
-                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class,
+                JsonSerializer.ADD_TYPE_INFO_HEADERS, false
         );
     }
 
     @Bean
-    public ProducerFactory<String, Object> producerFactory() {
+    public ProducerFactory<String, ProductEvent> producerFactory() {
 
         return new DefaultKafkaProducerFactory<>(producerConfigs());
     }
 
     @Bean
-    public KafkaTemplate<String, Object> kafkaTemplate(KafkaProducerInterceptor<Object> interceptor) {
+    public KafkaTemplate<String, ProductEvent> kafkaTemplate(KafkaProducerInterceptor<ProductEvent> interceptor) {
 
-        KafkaTemplate<String, Object> template = new KafkaTemplate<>(producerFactory());
+        KafkaTemplate<String, ProductEvent> template = new KafkaTemplate<>(producerFactory());
         template.setProducerInterceptor(interceptor);
 
         return template;

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/consumer/ProductKafkaConsumer.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/consumer/ProductKafkaConsumer.java
@@ -1,10 +1,10 @@
 package com.palja.product_service.infrastructure.external.kafka.consumer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palja.product_service.application.service.ProductService;
 import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseOrderDto;
 import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseTimeDealDto;
-import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreEventDto;
+import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreOrderEventDto;
+import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreTimeDealEventDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -18,7 +18,6 @@ import static com.palja.product_service.infrastructure.external.kafka.ProductKaf
 public class ProductKafkaConsumer {
 
     private final ProductService productService;
-    private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = DECREASE_STOCK_TIMEDEAL)
     public void handleDecreaseStockTimeDealEvent(StockDecreaseTimeDealDto dto) {
@@ -35,11 +34,15 @@ public class ProductKafkaConsumer {
         }
     }
 
-    @KafkaListener(topics = {INCREASE_STOCK_TIMEDEAL, RESTORE_STOCK_ORDER, ORDER_CANCEL})
-    public void handleIncreaseStockEvent(StockRestoreEventDto dto) {
+    @KafkaListener(topics = INCREASE_STOCK_TIMEDEAL)
+    public void handleIncreaseStockTimeDealEvent(StockRestoreTimeDealEventDto dto) {
 
-        if(dto.getIsTimeDeal() == null || dto.getIsTimeDeal().equals(Boolean.FALSE)) {
-            productService.stockRestore(dto.getProductId(), dto.getQuantity());
-        }
+        productService.stockRestore(dto.getProductId(), dto.getQuantity());
+    }
+
+    @KafkaListener(topics = {RESTORE_STOCK_ORDER, ORDER_CANCEL})
+    public void handleIncreaseStockEvent(StockRestoreOrderEventDto dto) {
+
+        productService.stockRestore(dto.getProductId(), dto.getQuantity());
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/consumer/ProductKafkaConsumer.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/consumer/ProductKafkaConsumer.java
@@ -1,10 +1,7 @@
 package com.palja.product_service.infrastructure.external.kafka.consumer;
 
 import com.palja.product_service.application.service.ProductService;
-import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseOrderDto;
-import com.palja.product_service.infrastructure.external.kafka.dto.StockDecreaseTimeDealDto;
-import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreOrderEventDto;
-import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreTimeDealEventDto;
+import com.palja.product_service.infrastructure.external.kafka.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -44,5 +41,11 @@ public class ProductKafkaConsumer {
     public void handleIncreaseStockEvent(StockRestoreOrderEventDto dto) {
 
         productService.stockRestore(dto.getProductId(), dto.getQuantity());
+    }
+
+    @KafkaListener(topics = {RESTORE_STOCK_ORDER, ORDER_CANCEL})
+    public void handleIncreaseStockEvent(DeleteAllByUserDto dto) {
+
+        productService.deleteProductForUser(dto.getCompanyUserId());
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/DeleteAllByUserDto.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/DeleteAllByUserDto.java
@@ -1,0 +1,17 @@
+package com.palja.product_service.infrastructure.external.kafka.dto;
+
+import com.palja.product_service.application.event.dto.UserEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeleteAllByUserDto implements UserEvent {
+
+    private UUID companyUserId;
+}

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockDecreaseOrderDto.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockDecreaseOrderDto.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.infrastructure.external.kafka.dto;
 
+import com.palja.product_service.application.event.dto.OrderEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StockDecreaseOrderDto {
+public class StockDecreaseOrderDto implements OrderEvent {
 
     private UUID sagaId;
     private UUID orderId;

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockDecreaseTimeDealDto.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockDecreaseTimeDealDto.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.infrastructure.external.kafka.dto;
 
+import com.palja.product_service.application.event.dto.TimeDealEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StockDecreaseTimeDealDto {
+public class StockDecreaseTimeDealDto implements TimeDealEvent {
 
     private UUID timeDealId;
     private UUID productId;

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockRestoreOrderEventDto.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockRestoreOrderEventDto.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StockRestoreEventDto {
+public class StockRestoreOrderEventDto {
 
     private UUID sagaId;
     private UUID orderId;

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockRestoreOrderEventDto.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockRestoreOrderEventDto.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.infrastructure.external.kafka.dto;
 
+import com.palja.product_service.application.event.dto.OrderEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StockRestoreOrderEventDto {
+public class StockRestoreOrderEventDto implements OrderEvent {
 
     private UUID sagaId;
     private UUID orderId;

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockRestoreTimeDealEventDto.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockRestoreTimeDealEventDto.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.infrastructure.external.kafka.dto;
 
+import com.palja.product_service.application.event.dto.TimeDealEvent;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StockRestoreTimeDealEventDto {
+public class StockRestoreTimeDealEventDto implements TimeDealEvent {
 
     private UUID sagaId;
     private UUID orderId;

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockRestoreTimeDealEventDto.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/dto/StockRestoreTimeDealEventDto.java
@@ -1,0 +1,21 @@
+package com.palja.product_service.infrastructure.external.kafka.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockRestoreTimeDealEventDto {
+
+    private UUID sagaId;
+    private UUID orderId;
+    private UUID productId;
+    private UUID timeDealId;
+    private Long quantity;
+    private Boolean isTimeDeal;
+}

--- a/product-service/src/main/java/com/palja/product_service/presentation/controller/Impl/ProductControllerImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/presentation/controller/Impl/ProductControllerImpl.java
@@ -104,12 +104,4 @@ public class ProductControllerImpl implements ProductController {
         service.deleteProduct(productId);
         return new ResponseEntity<>(ApiResponse.success("상품 삭제 성공"), HttpStatus.OK);
     }
-
-    @RequiredInternal
-    @DeleteMapping("/user/{companyUserId}")
-    public ResponseEntity<ApiResponse<String>> deleteProductForUser(@PathVariable UUID companyUserId) {
-
-        service.deleteProductForUser(companyUserId);
-        return new ResponseEntity<>(ApiResponse.success("상품 삭제 성공"), HttpStatus.OK);
-    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #338 

<br>

## 📌 개요
- 카프카 메세지 역직렬화 기능 수정
- 주문과의 카프카 메세지 타입 이름 맞춤 작업
- 유저와의 카프카 메세지 타입 이름 맞춤 작업

<br>

## 🔁 변경 사항

1. 메세지를 받을 때 사용할 인터페이스인 KafkaEvent 생성했습니다.
  - 상품으로 메세지를 발행하는 주문, 타임딜의 인터페이스를 생성해 KafkaEvnet를 상속해 메세지 역직렬화를 합니다.

2. 메세지를 보낼때 사용할 인터페이스인 ProductEvent 생성했습니다.
  - 상품이 발행하는 메세지를 표현하는 클래스가 해당 인터페이스를 구현합니다.

3. 주문에서 보내는 카프카 메세지의 타입 이름을 맞췄습니다.

4. 유저에서 보내는 탈퇴시 상품 전체삭제 메세지를 수신하고, 타입 이름을 맞췄습니다.

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
