### PR TITLE
FEAT/CouponService Kafka 이벤트 역직렬화 적용

### DIFF
--- a/coupon-service/src/main/java/com/palja/coupon_service/application/event/KafkaEvent.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/event/KafkaEvent.java
@@ -1,0 +1,17 @@
+package com.palja.coupon_service.application.event;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,          // 타입 식별자를 "이름"으로
+        include = JsonTypeInfo.As.PROPERTY,  // JSON 프로퍼티로 포함
+        property = "@type"                   // Type 필드로 구분
+)
+@JsonSubTypes({
+        // 필요한 이벤트 계속 추가
+        @JsonSubTypes.Type(value = OrderEvent.class, name = "OrderEvent"),
+        @JsonSubTypes.Type(value = UserEvent.class, name = "UserEvent")
+})
+public interface KafkaEvent {
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/event/OrderEvent.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/event/OrderEvent.java
@@ -1,0 +1,17 @@
+package com.palja.coupon_service.application.event;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.palja.coupon_service.application.event.dto.request.CouponCancelEventReq;
+import com.palja.coupon_service.application.event.dto.request.CouponUseEventReq;
+import com.palja.coupon_service.application.event.dto.response.CouponCancelEventRes;
+import com.palja.coupon_service.application.event.dto.response.CouponUseEventRse;
+
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = CouponCancelEventReq.class, name = "CouponCancelEventReq"),
+        @JsonSubTypes.Type(value = CouponUseEventReq.class, name = "CouponUseEventReq"),
+
+        @JsonSubTypes.Type(value = CouponCancelEventRes.class, name = "CouponCancelEventRes"),
+        @JsonSubTypes.Type(value = CouponUseEventRse.class, name = "CouponUseEventRse"),
+})
+public interface OrderEvent extends KafkaEvent {
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/event/UserEvent.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/event/UserEvent.java
@@ -1,4 +1,10 @@
 package com.palja.coupon_service.application.event;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.palja.coupon_service.application.event.dto.request.DeleteCustomerEventReq;
+
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = DeleteCustomerEventReq.class, name = "DeleteCustomerEventReq")
+})
 public interface UserEvent extends KafkaEvent {
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/event/UserEvent.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/event/UserEvent.java
@@ -1,0 +1,4 @@
+package com.palja.coupon_service.application.event;
+
+public interface UserEvent extends KafkaEvent {
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/request/CouponCancelEventReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/request/CouponCancelEventReq.java
@@ -1,19 +1,19 @@
 package com.palja.coupon_service.application.event.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.palja.coupon_service.application.event.OrderEvent;
+import lombok.*;
 
 import java.util.UUID;
 
 @Getter
 @Builder
 @AllArgsConstructor
-public class CouponCancelEventReq {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponCancelEventReq implements OrderEvent {
 
-    private final UUID sagaId;
-    private final UUID orderId;
-    private final UUID couponUserId;
+    private UUID sagaId;
+    private UUID orderId;
+    private UUID couponUserId;
 
     public CouponCancelEventReq of(UUID sagaId, UUID orderId, UUID couponUserId) {
         return CouponCancelEventReq.builder()

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/request/CouponUseEventReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/request/CouponUseEventReq.java
@@ -1,8 +1,7 @@
 package com.palja.coupon_service.application.event.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.palja.coupon_service.application.event.OrderEvent;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -10,12 +9,13 @@ import java.util.UUID;
 @Getter
 @Builder
 @AllArgsConstructor
-public class CouponUseEventReq {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponUseEventReq implements OrderEvent {
 
-    private final UUID sagaId;
-    private final UUID orderId;
-    private final UUID couponUserId;
-    private final BigDecimal discountAmount;
+    private UUID sagaId;
+    private UUID orderId;
+    private UUID couponUserId;
+    private BigDecimal discountAmount;
 
     public static CouponUseEventReq of(UUID sagaId, UUID orderId, UUID couponUserId, BigDecimal discountAmount) {
         return CouponUseEventReq.builder()

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/request/DeleteCustomerEventReq.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/request/DeleteCustomerEventReq.java
@@ -1,0 +1,17 @@
+package com.palja.coupon_service.application.event.dto.request;
+
+import com.palja.coupon_service.application.event.UserEvent;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeleteCustomerEventReq implements UserEvent {
+
+	private Long userId;
+
+	public static DeleteCustomerEventReq of(Long userId) {
+		return DeleteCustomerEventReq.builder().userId(userId).build();
+	}
+}

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/response/CouponCancelEventRes.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/response/CouponCancelEventRes.java
@@ -1,15 +1,15 @@
 package com.palja.coupon_service.application.event.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.palja.coupon_service.application.event.OrderEvent;
+import lombok.*;
 
 import java.util.UUID;
 
 @Getter
 @Builder
 @AllArgsConstructor
-public class CouponCancelEventRes {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponCancelEventRes implements OrderEvent {
 
     private UUID sagaId;
     private UUID orderId;

--- a/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/response/CouponUseEventRse.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/application/event/dto/response/CouponUseEventRse.java
@@ -1,15 +1,15 @@
 package com.palja.coupon_service.application.event.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.palja.coupon_service.application.event.OrderEvent;
+import lombok.*;
 
 import java.util.UUID;
 
 @Getter
 @Builder
 @AllArgsConstructor
-public class CouponUseEventRse {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponUseEventRse implements OrderEvent {
 
     private UUID sagaId;
     private UUID orderId;

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/config/KafkaConsumerConfig.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/config/KafkaConsumerConfig.java
@@ -1,5 +1,6 @@
 package com.palja.coupon_service.infrastructure.config;
 
+import com.palja.coupon_service.application.event.KafkaEvent;
 import io.micrometer.tracing.Tracer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -33,7 +34,7 @@ public class KafkaConsumerConfig {
     private String groupId;
 
     @Bean
-    public ConsumerFactory<String, Object> consumerFactory() {
+    public ConsumerFactory<String, KafkaEvent> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
@@ -45,16 +46,16 @@ public class KafkaConsumerConfig {
 
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
         props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
-        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, Object.class.getName());
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, KafkaEvent.class);
         return new DefaultKafkaConsumerFactory<>(props);
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
-            KafkaRecordInterceptor<Object> consumerInterceptor,
+    public ConcurrentKafkaListenerContainerFactory<String, KafkaEvent> kafkaListenerContainerFactory(
+            KafkaRecordInterceptor<KafkaEvent> consumerInterceptor,
             CommonErrorHandler errorHandler
     ) {
-        ConcurrentKafkaListenerContainerFactory<String, Object> factory
+        ConcurrentKafkaListenerContainerFactory<String, KafkaEvent> factory
                 = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         factory.setRecordInterceptor(consumerInterceptor);  // Interceptor 적용
@@ -63,12 +64,12 @@ public class KafkaConsumerConfig {
     }
 
     @Bean
-    public KafkaRecordInterceptor<Object> consumerInterceptor(Tracer tracer) {
+    public KafkaRecordInterceptor<KafkaEvent> consumerInterceptor(Tracer tracer) {
         return new KafkaRecordInterceptor<>(tracer);
     }
 
     @Bean
-    public CommonErrorHandler kafkaErrorHandler(KafkaTemplate<String, Object> kafkaTemplate) {
+    public CommonErrorHandler kafkaErrorHandler(KafkaTemplate<String, KafkaEvent> kafkaTemplate) {
 
         // DLT(Dead Letter Topic)로 메시지 전송
         DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/config/KafkaProducerConfig.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/config/KafkaProducerConfig.java
@@ -1,6 +1,7 @@
 package com.palja.coupon_service.infrastructure.config;
 
 import com.palja.common.interceptor.KafkaProducerInterceptor;
+import com.palja.coupon_service.application.event.KafkaEvent;
 import io.micrometer.tracing.Tracer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -26,12 +27,12 @@ public class KafkaProducerConfig {
     private String bootstrapServers;
 
     @Bean
-    public KafkaProducerInterceptor<Object> kafkaEventProducerInterceptor(Tracer tracer) {
+    public KafkaProducerInterceptor<KafkaEvent> kafkaEventProducerInterceptor(Tracer tracer) {
         return new KafkaProducerInterceptor<>(tracer);
     }
 
     @Bean
-    public ProducerFactory<String, Object> producerFactory() {
+    public ProducerFactory<String, KafkaEvent> producerFactory() {
         Map<String, Object> config = new HashMap<>();
 
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -43,8 +44,8 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, Object> kafkaTemplate(KafkaProducerInterceptor<Object> kafkaProducerInterceptor) {
-        KafkaTemplate<String, Object> kafkaTemplate = new KafkaTemplate<>(producerFactory());
+    public KafkaTemplate<String, KafkaEvent> kafkaTemplate(KafkaProducerInterceptor<KafkaEvent> kafkaProducerInterceptor) {
+        KafkaTemplate<String, KafkaEvent> kafkaTemplate = new KafkaTemplate<>(producerFactory());
         kafkaTemplate.setProducerInterceptor(kafkaProducerInterceptor);
 
         return kafkaTemplate;

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/external/kafka/KafkaTopics.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/external/kafka/KafkaTopics.java
@@ -5,7 +5,7 @@ public class KafkaTopics {
     public static final String COUPON_USE_SUCCESS = "order.coupon.use.success";
     public static final String COUPON_USE_FAILURE = "order.coupon.use.failure";
 
-    public static final String COUPON_CANCEL_REQUEST = "order.coupon.cancel.request";
-    public static final String COUPON_CANCEL_SUCCESS = "order.coupon.cancel.success";
-    public static final String COUPON_CANCEL_FAILURE = "order.coupon.cancel.failure";
+    public static final String COUPON_CANCEL_REQUEST = "order.cancel.request";
+
+    public static final String CUSTOMER_DELETE_REQUEST_TOPIC = "user.customer.delete.request";
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/external/kafka/consumer/CouponKafkaConsumer.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/external/kafka/consumer/CouponKafkaConsumer.java
@@ -5,6 +5,7 @@ import com.palja.coupon_service.application.command.UseCouponCommand;
 import com.palja.coupon_service.application.event.KafkaEvent;
 import com.palja.coupon_service.application.event.dto.request.CouponCancelEventReq;
 import com.palja.coupon_service.application.event.dto.request.CouponUseEventReq;
+import com.palja.coupon_service.application.event.dto.request.DeleteCustomerEventReq;
 import com.palja.coupon_service.application.event.dto.response.CouponCancelEventRes;
 import com.palja.coupon_service.application.event.dto.response.CouponUseEventRse;
 import com.palja.coupon_service.application.service.CouponService;
@@ -64,18 +65,27 @@ public class CouponKafkaConsumer {
 
             CouponCancelEventRes response = CouponCancelEventRes.of(event.getSagaId(), event.getOrderId());
 
-            kafkaTemplate.send(KafkaTopics.COUPON_CANCEL_SUCCESS, response);
             log.info("쿠폰 취소 성공 - sagaId: {}, orderId: {}, couponUserId: {}",
                     event.getSagaId(), event.getOrderId(), event.getCouponUserId());
 
         } catch (Exception e) {
             CouponCancelEventRes response = CouponCancelEventRes.of(event.getSagaId(), event.getOrderId());
 
-            kafkaTemplate.send(KafkaTopics.COUPON_CANCEL_FAILURE, response);
-
             log.error("쿠폰 취소 실패 - sagaId: {}, orderId: {}, couponUserId: {}",
                     event.getSagaId(), event.getOrderId(), event.getCouponUserId(), e);
         }
+    }
 
+    @KafkaListener(topics = KafkaTopics.CUSTOMER_DELETE_REQUEST_TOPIC)
+    public void deleteAllCoupons(DeleteCustomerEventReq event) {
+        log.info("사용자 쿠폰 삭제 요청 이벤트 수신 - userId: {}", event.getUserId());
+
+        //try {
+        //    couponService.deleteAllCoupons("");
+        //    log.info("사용자 쿠폰 삭제 성공 - userId: {}", event.getUserId());
+        //
+        //} catch (Exception e) {
+        //    log.error("사용자 쿠폰 삭제 실패 - userId: {}", event.getUserId());
+        //}
     }
 }

--- a/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/external/kafka/consumer/CouponKafkaConsumer.java
+++ b/coupon-service/src/main/java/com/palja/coupon_service/infrastructure/external/kafka/consumer/CouponKafkaConsumer.java
@@ -1,8 +1,8 @@
 package com.palja.coupon_service.infrastructure.external.kafka.consumer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palja.common.auditor.CurrentUser;
 import com.palja.coupon_service.application.command.UseCouponCommand;
+import com.palja.coupon_service.application.event.KafkaEvent;
 import com.palja.coupon_service.application.event.dto.request.CouponCancelEventReq;
 import com.palja.coupon_service.application.event.dto.request.CouponUseEventReq;
 import com.palja.coupon_service.application.event.dto.response.CouponCancelEventRes;
@@ -11,7 +11,6 @@ import com.palja.coupon_service.application.service.CouponService;
 import com.palja.coupon_service.infrastructure.external.kafka.KafkaTopics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
@@ -22,13 +21,10 @@ import org.springframework.stereotype.Component;
 public class CouponKafkaConsumer {
 
     private final CouponService couponService;
-    private final ObjectMapper objectMapper;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaTemplate<String, KafkaEvent> kafkaTemplate;
 
     @KafkaListener(topics = KafkaTopics.COUPON_USE_REQUEST)
-    public void useCoupon(ConsumerRecord<String, Object> record) {
-        CouponUseEventReq event = objectMapper.convertValue(record.value(), CouponUseEventReq.class);
-
+    public void useCoupon(CouponUseEventReq event) {
         log.info("쿠폰 사용 요청 이벤트 수신 - sagaId: {}, orderId: {}, couponUserId: {}",
                 event.getSagaId(), event.getOrderId(), event.getCouponUserId());
 
@@ -59,9 +55,7 @@ public class CouponKafkaConsumer {
     }
 
     @KafkaListener(topics = KafkaTopics.COUPON_CANCEL_REQUEST)
-    public void cancelCoupon(ConsumerRecord<String, Object> record) {
-        CouponCancelEventReq event = objectMapper.convertValue(record.value(), CouponCancelEventReq.class);
-
+    public void cancelCoupon(CouponCancelEventReq event) {
         log.info("쿠폰 취소 요청 이벤트 수신 - sagaId: {}, orderId: {}, couponUserId: {}",
                 event.getSagaId(), event.getOrderId(), event.getCouponUserId());
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

* [ ] 기능 추가
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크

Close #344 

## 📌 개요

CouponService Kafka 이벤트 역직렬화 적용 및 사용자 삭제 시 쿠폰 삭제 이벤트 추가했습니다.

## 🔁 변경 사항

### 1. 이벤트 인터페이스 및 계층 구조 도입

* `KafkaEvent`: 최상위 마커 인터페이스로, `@JsonTypeInfo`와 `@JsonSubTypes`를 사용하여 JSON 메시지에 포함된 `@type` 필드를 기반으로 적절한 하위 클래스로 자동 변환되도록 설정했습니다.
* `OrderEvent`, `UserEvent`: 도메인 영역별로 이벤트를 분류할 수 있는 중간 인터페이스를 추가하여 관리 효율성을 높였습니다.

### 2. DTO 구조 개선 및 상속 적용

* `CouponUseEventReq`, `CouponCancelEventReq` 등 모든 이벤트 DTO가 해당 도메인 이벤트 인터페이스(`OrderEvent` 등)를 구현하도록 수정했습니다.
* 불변성 유지를 위해 필드를 정리하고, Jackson 역직렬화를 위한 `@NoArgsConstructor(access = AccessLevel.PROTECTED)`를 추가했습니다.

### 3. Kafka 설정 최적화 (`KafkaConsumerConfig`, `KafkaProducerConfig`)

* 기존 `Object` 타입을 사용하던 `KafkaTemplate` 및 `ConsumerFactory`를 `KafkaEvent` 타입으로 구체화하여 타입 안정성을 확보했습니다.
* `JsonDeserializer` 설정에서 `VALUE_DEFAULT_TYPE`을 `KafkaEvent.class`로 지정하여 메시지 소비 시 자동 형변환이 원활하게 이루어지도록 개선했습니다.

### 4. 컨슈머 로직 단순화 (`CouponKafkaConsumer`)

* 메시지 수신 시 `ConsumerRecord<String, Object>`를 받아 수동으로 `objectMapper`를 통해 변환하던 로직을 제거했습니다.
* Spring Kafka의 메시지 컨버터 기능을 활용하여 파라미터에서 즉시 `DeleteCustomerEventReq` 등의 구체적인 객체를 주입받도록 변경하여 가독성을 높였습니다.

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트

* [x] PR 템플릿에 맞추어 작성했어요.
* [x] 변경 내용에 대한 테스트를 진행했어요.
* [x] 프로그램이 정상적으로 동작해요.
* [x] PR에 적절한 라벨을 선택했어요.
* [x] 불필요한 코드는 삭제했어요.
