### PR TITLE
FEAT/상품 -> 타임딜 재고 차감 실패 이벤트 구독, 보상 트랜잭션 적용 및 상품 -> 타임딜 가격 업데이트 이벤트 구독

### DIFF
--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/TimeDealEvent.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/TimeDealEvent.java
@@ -5,8 +5,8 @@ import com.palja.product_service.infrastructure.external.kafka.dto.StockDecrease
 import com.palja.product_service.infrastructure.external.kafka.dto.StockRestoreTimeDealEventDto;
 
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = StockDecreaseTimeDealDto.class, name = "StockDecreaseTimeDealDto"),
-        @JsonSubTypes.Type(value = StockRestoreTimeDealEventDto.class, name = "StockRestoreEventDto"),
+        @JsonSubTypes.Type(value = StockDecreaseTimeDealDto.class, name = "ProductStockDecreaseEventReq"),
+        @JsonSubTypes.Type(value = StockRestoreTimeDealEventDto.class, name = "ProductStockRestoreEventReq"),
 })
 public interface TimeDealEvent extends KafkaEvent {
 }

--- a/product-service/src/main/java/com/palja/product_service/application/event/dto/request/DecreaseStockTimeDealErrorEventReq.java
+++ b/product-service/src/main/java/com/palja/product_service/application/event/dto/request/DecreaseStockTimeDealErrorEventReq.java
@@ -13,10 +13,11 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DecreaseStockTimeDealErrorEventReq implements ProductEvent {
 
+    private UUID timeDealId;
     private UUID productId;
     private String message;
 
-    public static DecreaseStockTimeDealErrorEventReq create(UUID productId, String message) {
-        return new DecreaseStockTimeDealErrorEventReq(productId, message);
+    public static DecreaseStockTimeDealErrorEventReq create(UUID timeDealId, UUID productId, String message) {
+        return new DecreaseStockTimeDealErrorEventReq(timeDealId, productId, message);
     }
 }

--- a/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/ProductService.java
@@ -7,7 +7,6 @@ import com.palja.product_service.application.dto.res.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Optional;
 import java.util.UUID;
 
 public interface ProductService {
@@ -28,7 +27,7 @@ public interface ProductService {
 
     void saleProduct(UUID sagaId, UUID productId, UUID orderId, Long quantity);
 
-    void decreaseStockForTimeDeal(UUID productId, Long quantity);
+    void decreaseStockForTimeDeal(UUID timeDealId, UUID productId, Long quantity);
 
     void stockRestore(UUID productId, Long quantity);
 

--- a/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
+++ b/product-service/src/main/java/com/palja/product_service/application/service/impl/ProductServiceImpl.java
@@ -189,7 +189,7 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     @Transactional
-    public void decreaseStockForTimeDeal(UUID productId, Long quantity) {
+    public void decreaseStockForTimeDeal(UUID timeDealId, UUID productId, Long quantity) {
 
         ProductStock restoredStock = repository.findProduct(productId).decreaseStock(quantity);
 
@@ -199,7 +199,7 @@ public class ProductServiceImpl implements ProductService {
 
         productEventPublisher.publishCreateTimeDealEvent(
                 DecreaseStockTimeDealErrorEventReq.create(
-                        productId, ProductErrorCode.INVALID_STOCK.getMessage()
+                        timeDealId, productId, ProductErrorCode.INVALID_STOCK.getMessage()
         ));
     }
 

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/consumer/ProductKafkaConsumer.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/consumer/ProductKafkaConsumer.java
@@ -19,7 +19,7 @@ public class ProductKafkaConsumer {
     @KafkaListener(topics = DECREASE_STOCK_TIMEDEAL)
     public void handleDecreaseStockTimeDealEvent(StockDecreaseTimeDealDto dto) {
 
-        productService.decreaseStockForTimeDeal(dto.getProductId(), dto.getQuantity());
+        productService.decreaseStockForTimeDeal(dto.getTimeDealId(), dto.getProductId(), dto.getQuantity());
     }
 
     @KafkaListener(topics = SALE_STOCK_ORDER)

--- a/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/producer/ProductKafkaProducer.java
+++ b/product-service/src/main/java/com/palja/product_service/infrastructure/external/kafka/producer/ProductKafkaProducer.java
@@ -1,5 +1,6 @@
 package com.palja.product_service.infrastructure.external.kafka.producer;
 
+import com.palja.product_service.application.event.dto.ProductEvent;
 import com.palja.product_service.application.event.dto.request.ChangePriceEventReq;
 import com.palja.product_service.application.event.dto.request.DecreaseStockTimeDealErrorEventReq;
 import com.palja.product_service.application.event.dto.request.SaleProductErrorEventReq;
@@ -19,11 +20,11 @@ import static com.palja.product_service.infrastructure.external.kafka.ProductKaf
 @RequiredArgsConstructor
 public class ProductKafkaProducer implements ProductEventPublisher {
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaTemplate<String, ProductEvent> kafkaTemplate;
 
-    private void publish(String topic, Object productEvent) {
+    private void publish(String topic, ProductEvent productEvent) {
 
-        CompletableFuture<SendResult<String, Object>> send = kafkaTemplate.send(topic, productEvent);
+        CompletableFuture<SendResult<String, ProductEvent>> send = kafkaTemplate.send(topic, productEvent);
         send.whenComplete((result, exception) -> {
 
             if(result != null) {

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/ChangeTimeDealStatusFailedCommand.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/ChangeTimeDealStatusFailedCommand.java
@@ -1,0 +1,13 @@
+package com.palja.timedeal_service.application.command;
+
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record ChangeTimeDealStatusFailedCommand(
+        UUID timeDealId,
+        UUID productId,
+        String reason
+) {
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/ChangeTimeDealStatusFailedCommand.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/ChangeTimeDealStatusFailedCommand.java
@@ -9,5 +9,4 @@ public record ChangeTimeDealStatusFailedCommand(
         UUID timeDealId,
         UUID productId,
         String reason
-) {
-}
+) {}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/UpdateProductPriceCommand.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/command/UpdateProductPriceCommand.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import java.util.UUID;
 
 @Builder
-public record DecreaseRemainingQuantityCommand(
-        UUID timeDealId,
-        long decreaseQuantity
+public record UpdateProductPriceCommand(
+        UUID productId,
+        Long newPrice
 ) {}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/KafkaEvent.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/KafkaEvent.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = OrderEvent.class, name = "OrderEvent"),
         @JsonSubTypes.Type(value = UserEvent.class, name = "UserEvent"),
+        @JsonSubTypes.Type(value = ProductEvent.class, name = "ProductEvent"),
 })
 public interface KafkaEvent {
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/ProductEvent.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/ProductEvent.java
@@ -1,0 +1,10 @@
+package com.palja.timedeal_service.application.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.palja.timedeal_service.application.event.dto.request.in.ProductStockDecreaseFailureEventReq;
+
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ProductStockDecreaseFailureEventReq.class, name = "DecreaseStockTimeDealErrorEventReq"),
+})
+public interface ProductEvent extends KafkaEvent{
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/ProductEvent.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/ProductEvent.java
@@ -1,10 +1,12 @@
 package com.palja.timedeal_service.application.event.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.palja.timedeal_service.application.event.dto.request.in.ProductPriceUpdateEventReq;
 import com.palja.timedeal_service.application.event.dto.request.in.ProductStockDecreaseFailureEventReq;
 
 @JsonSubTypes({
         @JsonSubTypes.Type(value = ProductStockDecreaseFailureEventReq.class, name = "DecreaseStockTimeDealErrorEventReq"),
+        @JsonSubTypes.Type(value = ProductPriceUpdateEventReq.class, name = "ChangePriceEventReq"),
 })
 public interface ProductEvent extends KafkaEvent{
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/request/in/ProductPriceUpdateEventReq.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/request/in/ProductPriceUpdateEventReq.java
@@ -1,0 +1,18 @@
+package com.palja.timedeal_service.application.event.dto.request.in;
+
+import com.palja.timedeal_service.application.event.dto.ProductEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ProductPriceUpdateEventReq implements ProductEvent {
+
+    private UUID productId;
+    private Long price;
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/request/in/ProductStockDecreaseFailureEventReq.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/event/dto/request/in/ProductStockDecreaseFailureEventReq.java
@@ -1,0 +1,19 @@
+package com.palja.timedeal_service.application.event.dto.request.in;
+
+import com.palja.timedeal_service.application.event.dto.ProductEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ProductStockDecreaseFailureEventReq implements ProductEvent {
+
+    private UUID timeDealId;
+    private UUID productId;
+    private String message;
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
@@ -21,4 +21,5 @@ public interface TimeDealService {
     void restoreRemainingQuantity(RestoreRemainingQuantityCommand command);
     void deleteByCompanyUser(UUID companyUserId);
     void changeTimeDealStatusFailed(ChangeTimeDealStatusFailedCommand command);
+    void updateProductPrice(UpdateProductPriceCommand command);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/TimeDealService.java
@@ -20,4 +20,5 @@ public interface TimeDealService {
     void decreaseRemainingQuantity(DecreaseRemainingQuantityCommand command);
     void restoreRemainingQuantity(RestoreRemainingQuantityCommand command);
     void deleteByCompanyUser(UUID companyUserId);
+    void changeTimeDealStatusFailed(ChangeTimeDealStatusFailedCommand command);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -253,6 +253,20 @@ public class TimeDealServiceImpl implements TimeDealService {
         log.info("타임딜 실패 처리 완료");
     }
 
+    @Override
+    @Transactional
+    public void updateProductPrice(UpdateProductPriceCommand command) {
+        log.info("상품 가격 동기화 시작");
+
+        List<TimeDeal> timeDeals = timeDealRepository.findAllPendingByProductId(command.productId(), TimeDealStatus.PENDING);
+
+        for (TimeDeal timeDeal : timeDeals) {
+            timeDeal.changeProductPrice(command.newPrice());
+        }
+
+        log.info("상품 가격 동기화 완료");
+    }
+
     // TODO. 로직 수정 필요
     private void updateTimeDealFields(TimeDeal timeDeal, UpdateTimeDealCommand command) {
         TimeDealStatus status = timeDeal.getTimeDealStatus();

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/service/impl/TimeDealServiceImpl.java
@@ -17,6 +17,7 @@ import com.palja.timedeal_service.application.validator.TimeDealValidator;
 import com.palja.timedeal_service.common.TimeDealEditableField;
 import com.palja.timedeal_service.domain.entity.TimeDeal;
 import com.palja.timedeal_service.domain.entity.TimeDealStatusHistory;
+import com.palja.timedeal_service.domain.reason.TimeDealStatusReason;
 import com.palja.timedeal_service.domain.repository.TimeDealRepository;
 import com.palja.timedeal_service.domain.vo.Amount;
 import com.palja.timedeal_service.domain.vo.Period;
@@ -237,6 +238,19 @@ public class TimeDealServiceImpl implements TimeDealService {
         }
 
         log.info("업체 판매자 관련 타임딜 삭제 완료");
+    }
+
+    @Override
+    @Transactional
+    public void changeTimeDealStatusFailed(ChangeTimeDealStatusFailedCommand command) {
+        log.info("타임딜 실패 처리 시작");
+
+        TimeDeal timeDeal = getActiveTimeDeal(command.timeDealId());
+        log.info("타임딜 실패 처리 아이디 timeDealId = {}", timeDeal.getTimeDealId());
+
+        timeDeal.changeStatusFailed(command.reason() != null ? command.reason() : TimeDealStatusReason.PRODUCT_STOCK_DECREASE_FAILED);
+
+        log.info("타임딜 실패 처리 완료");
     }
 
     // TODO. 로직 수정 필요

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
@@ -156,6 +156,11 @@ public class TimeDeal extends BaseEntity {
         return changeStatus(TimeDealStatus.CLOSED, reason);
     }
 
+    public boolean changeStatusFailed(String reason) {
+        changeStatus(TimeDealStatus.FAILED, reason);
+        return true;
+    }
+
     // ========== 재고 ==========
     public void decreaseRemainingQuantity(long decreaseQuantity) {
         ensureDecreasableStock();

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/entity/TimeDeal.java
@@ -116,6 +116,10 @@ public class TimeDeal extends BaseEntity {
         this.amount = this.amount.updateTimeDealPrice(newTimeDealPrice);
     }
 
+    public void changeProductPrice(long newOriginalPrice) {
+        this.amount = this.amount.updateOriginalPrice(newOriginalPrice);
+    }
+
     public void changeTotalQuantity(long newTotalQuantity) {
         this.timeDealStock.changeTotalQuantity(newTotalQuantity);
     }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/reason/TimeDealStatusReason.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/reason/TimeDealStatusReason.java
@@ -1,0 +1,7 @@
+package com.palja.timedeal_service.domain.reason;
+
+public class TimeDealStatusReason {
+    public static final String PRODUCT_STOCK_DECREASE_FAILED = "상품 재고 차감 실패";
+
+    private TimeDealStatusReason() {}
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/repository/TimeDealRepository.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/repository/TimeDealRepository.java
@@ -15,4 +15,5 @@ public interface TimeDealRepository {
     Optional<TimeDeal> findByTimeDealId(UUID timeDealId);
     Page<TimeDeal> searchTimeDeals(Pageable pageable);
     List<TimeDeal> findAllByCompanyUserId(UUID companyUserId, TimeDealStatus status, LocalDateTime now);
+    List<TimeDeal> findAllPendingByProductId(UUID productId, TimeDealStatus status);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/Amount.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/Amount.java
@@ -40,6 +40,10 @@ public class Amount {
         return new Amount(this.originalPrice, newTimeDealPrice);
     }
 
+    public Amount updateOriginalPrice(long newOriginalPrice) {
+        return new Amount(newOriginalPrice, this.timeDealPrice);
+    }
+
     // ========== 계산 ==========
     private int calculateDiscount(long originalPrice, long timeDealPrice) {
         return (int) (((double) (originalPrice - timeDealPrice) / originalPrice) * 100);

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/TimeDealStatus.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/domain/vo/TimeDealStatus.java
@@ -13,7 +13,7 @@ public enum TimeDealStatus {
 
         @Override
         public boolean canTransitTo(TimeDealStatus newStatus) {
-            return newStatus == OPEN || newStatus == CLOSED;
+            return newStatus == OPEN || newStatus == CLOSED || newStatus == FAILED;
         }
     },
 
@@ -42,6 +42,18 @@ public enum TimeDealStatus {
     },
 
     CLOSED("종료") {
+        @Override
+        public boolean canEditField(TimeDealEditableField field) {
+            return false;
+        }
+
+        @Override
+        public boolean canTransitTo(TimeDealStatus newStatus) {
+            return false;
+        }
+    },
+
+    FAILED("실패") {
         @Override
         public boolean canEditField(TimeDealEditableField field) {
             return false;

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/consumer/TimeDealKafkaConsumer.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/consumer/TimeDealKafkaConsumer.java
@@ -3,11 +3,9 @@ package com.palja.timedeal_service.infrastructure.external.kafka.consumer;
 import com.palja.timedeal_service.application.command.ChangeTimeDealStatusFailedCommand;
 import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
 import com.palja.timedeal_service.application.command.RestoreRemainingQuantityCommand;
+import com.palja.timedeal_service.application.command.UpdateProductPriceCommand;
 import com.palja.timedeal_service.application.event.dto.TimeDealEvent;
-import com.palja.timedeal_service.application.event.dto.request.in.ProductStockDecreaseFailureEventReq;
-import com.palja.timedeal_service.application.event.dto.request.in.TimeDealDeleteByCompanyUserEventReq;
-import com.palja.timedeal_service.application.event.dto.request.in.TimeDealStockDecreaseEventReq;
-import com.palja.timedeal_service.application.event.dto.request.in.TimeDealStockRestoreEventReq;
+import com.palja.timedeal_service.application.event.dto.request.in.*;
 import com.palja.timedeal_service.application.event.dto.response.TimeDealStockDecreaseEventRes;
 import com.palja.timedeal_service.application.service.TimeDealService;
 import com.palja.timedeal_service.infrastructure.external.kafka.topic.KafkaTopics;
@@ -102,5 +100,19 @@ public class TimeDealKafkaConsumer {
         timeDealService.changeTimeDealStatusFailed(command);
 
         log.info("[Kafka] 타임딜 실패 보상 처리 완료 timeDealId={}", event.getTimeDealId());
+    }
+
+    @KafkaListener(topics = KafkaTopics.PRODUCT_PRICE_UPDATE_REQUEST)
+    public void updateProductPrice(ProductPriceUpdateEventReq event) {
+        log.info("[Kafka] 상품 가격 업데이트 요청 수신 productId={}, newPrice={}", event.getProductId(), event.getPrice());
+
+        UpdateProductPriceCommand command = UpdateProductPriceCommand.builder()
+                .productId(event.getProductId())
+                .newPrice(event.getPrice())
+                .build();
+
+        timeDealService.updateProductPrice(command);
+
+        log.info("[Kafka] 상품 가격 업데이트 처리 완료 productId={}, newPrice={}", event.getProductId(), event.getPrice());
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/consumer/TimeDealKafkaConsumer.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/consumer/TimeDealKafkaConsumer.java
@@ -1,8 +1,10 @@
 package com.palja.timedeal_service.infrastructure.external.kafka.consumer;
 
+import com.palja.timedeal_service.application.command.ChangeTimeDealStatusFailedCommand;
 import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
 import com.palja.timedeal_service.application.command.RestoreRemainingQuantityCommand;
 import com.palja.timedeal_service.application.event.dto.TimeDealEvent;
+import com.palja.timedeal_service.application.event.dto.request.in.ProductStockDecreaseFailureEventReq;
 import com.palja.timedeal_service.application.event.dto.request.in.TimeDealDeleteByCompanyUserEventReq;
 import com.palja.timedeal_service.application.event.dto.request.in.TimeDealStockDecreaseEventReq;
 import com.palja.timedeal_service.application.event.dto.request.in.TimeDealStockRestoreEventReq;
@@ -85,5 +87,20 @@ public class TimeDealKafkaConsumer {
     private boolean isValidTimeDealEvent(boolean isTimeDeal) {
 
         return isTimeDeal;
+    }
+
+    @KafkaListener(topics = KafkaTopics.PRODUCT_STOCK_DECREASE_FAILURE)
+    public void timeDealStatusFailed(ProductStockDecreaseFailureEventReq event) {
+        log.info("[Kafka] 상품 재고 차감 실패 이벤트 수신 timeDealId = {}, productId={}, message={}", event.getTimeDealId(), event.getProductId(), event.getMessage());
+
+        ChangeTimeDealStatusFailedCommand command = ChangeTimeDealStatusFailedCommand.builder()
+                .timeDealId(event.getTimeDealId())
+                .productId(event.getProductId())
+                .reason(event.getMessage())
+                .build();
+
+        timeDealService.changeTimeDealStatusFailed(command);
+
+        log.info("[Kafka] 타임딜 실패 보상 처리 완료 timeDealId={}", event.getTimeDealId());
     }
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/topic/KafkaTopics.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/topic/KafkaTopics.java
@@ -13,4 +13,5 @@ public class KafkaTopics {
     public static final String ORDER_STOCK_DECREASE_REQUEST = "order.stock.decrease.request";
     public static final String ORDER_STOCK_RESTORE_REQUEST = "order.stock.restore.request";
     public static final String USER_COMPANY_USER_DELETE_REQUEST = "user.company-user.delete.request";
+    public static final String PRODUCT_STOCK_DECREASE_FAILURE = "product.stock.timedeal.decrease.failure";
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/topic/KafkaTopics.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/topic/KafkaTopics.java
@@ -14,4 +14,5 @@ public class KafkaTopics {
     public static final String ORDER_STOCK_RESTORE_REQUEST = "order.stock.restore.request";
     public static final String USER_COMPANY_USER_DELETE_REQUEST = "user.company-user.delete.request";
     public static final String PRODUCT_STOCK_DECREASE_FAILURE = "product.stock.timedeal.decrease.failure";
+    public static final String PRODUCT_PRICE_UPDATE_REQUEST = "product.timedeal.price-update.request";
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/JpaTimeDealRepository.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/JpaTimeDealRepository.java
@@ -38,8 +38,17 @@ public interface JpaTimeDealRepository extends JpaRepository<TimeDeal, UUID> {
     join fetch td.timeDealStock
     where td.companyUserId = :companyUserId
       and td.timeDealStatus = :status
-      and td.period.startAt > :now
       and td.deletedAt is null
 """)
     List<TimeDeal> findAllByCompanyUserId(UUID companyUserId, TimeDealStatus status, LocalDateTime now);
+
+    @Query("""
+    select td
+    from TimeDeal td
+    join fetch td.timeDealStock ts
+    where td.productId = :productId
+      and td.timeDealStatus = :status
+      and td.deletedAt is null
+""")
+    List<TimeDeal> findAllPendingByProductId(UUID productId, TimeDealStatus status);
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/adapter/TimeDealRepositoryImpl.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/repository/adapter/TimeDealRepositoryImpl.java
@@ -37,4 +37,9 @@ public class TimeDealRepositoryImpl implements TimeDealRepository {
     public List<TimeDeal> findAllByCompanyUserId(UUID companyUserId, TimeDealStatus status, LocalDateTime now) {
         return jpaTimeDealRepository.findAllByCompanyUserId(companyUserId, status, now);
     }
+
+    @Override
+    public List<TimeDeal> findAllPendingByProductId(UUID productId, TimeDealStatus status) {
+        return jpaTimeDealRepository.findAllPendingByProductId(productId, status);
+    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #317 

<br>

## 📌 개요
- 상품 → 타임딜 재고 차감 실패 이벤트 구독 기능 추가
- 보상 트랜잭션으로 타임딜 상태를 FAILED로 전환하도록 구현
- 상품 → 타임딜 가격 변경 이벤트 구독 및 가격 동기화 로직 추가
- 전체 흐름에 대한 테스트 완료!

<br>

## 🔁 변경 사항
- 상품 → 타임딜 재고 차감 실패 이벤트에 timeDealId를 포함하도록 수정하여 타임딜 서비스에서 정확한 보상 대상 식별이 가능하도록 개선하였습니다
- ProductService 마지막 테스트 때 수정한 부분을 반영했습니다!

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
