### PR TITLE
FEAT/타임딜 재고 차감 Redisson 분산 락 도입

### DIFF
--- a/timedeal-service/build.gradle
+++ b/timedeal-service/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.52.0'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'

--- a/timedeal-service/build.gradle
+++ b/timedeal-service/build.gradle
@@ -50,12 +50,15 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
-    annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     implementation 'com.palja:common-module:0.9.1'
 }

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/facade/TimeDealLockFacade.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/facade/TimeDealLockFacade.java
@@ -1,0 +1,34 @@
+package com.palja.timedeal_service.application.facade;
+
+import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
+import com.palja.timedeal_service.application.service.TimeDealService;
+import com.palja.timedeal_service.application.port.LockExecutor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TimeDealLockFacade {
+
+    private static final String LOCK_KEY_PREFIX = "lock:timedeal:decrease:";
+
+    private final LockExecutor distributedLockExecutor;
+    private final TimeDealService timeDealService;
+
+    public void decreaseRemainingQuantityWithLock(DecreaseRemainingQuantityCommand command) {
+        String lockKey = LOCK_KEY_PREFIX + command.timeDealId();
+
+        distributedLockExecutor.execute(
+                lockKey,
+                1,
+                TimeUnit.SECONDS,
+                () -> {
+                    log.info("타임딜 재고 차감 락 획득 성공. timeDealId={}", command.timeDealId());
+                    timeDealService.decreaseRemainingQuantity(command);
+                });
+    }
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/facade/TimeDealLockFacade.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/facade/TimeDealLockFacade.java
@@ -24,7 +24,7 @@ public class TimeDealLockFacade {
 
         distributedLockExecutor.execute(
                 lockKey,
-                1,
+                2,
                 TimeUnit.SECONDS,
                 () -> {
                     log.info("타임딜 재고 차감 락 획득 성공. timeDealId={}", command.timeDealId());

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/application/port/LockExecutor.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/application/port/LockExecutor.java
@@ -1,0 +1,7 @@
+package com.palja.timedeal_service.application.port;
+
+import java.util.concurrent.TimeUnit;
+
+public interface LockExecutor {
+    void execute(String key, long waitTime, TimeUnit timeUnit, Runnable task);
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/common/TimeDealErrorCode.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/common/TimeDealErrorCode.java
@@ -50,7 +50,11 @@ public enum TimeDealErrorCode implements ErrorCode {
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
     COMPANY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "업체 판매자를 찾을 수 없습니다."),
     TIME_DEAL_NOT_OPEN(HttpStatus.BAD_REQUEST, "OPEN 상태의 타임딜만 재고 차감이 가능합니다."),
-    TIME_DEAL_NOT_IN_PERIOD(HttpStatus.BAD_REQUEST, "현재 시간에 재고 차감을 수행할 수 없는 타임딜입니다.");
+    TIME_DEAL_NOT_IN_PERIOD(HttpStatus.BAD_REQUEST, "현재 시간에 재고 차감을 수행할 수 없는 타임딜입니다."),
+
+    // Redisson 관련
+    LOCK_ACQUIRE_FAILED(HttpStatus.TOO_MANY_REQUESTS, "현재 접속자가 많아 잠시 후 다시 시도해주세요."),
+    LOCK_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "요청 처리 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/config/RedissonConfig.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/config/RedissonConfig.java
@@ -1,0 +1,28 @@
+package com.palja.timedeal_service.infrastructure.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+
+        config.useSingleServer()
+                .setAddress("redis://" + host + ":" + port);
+
+        return Redisson.create(config);
+    }
+}

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/consumer/TimeDealKafkaConsumer.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/external/kafka/consumer/TimeDealKafkaConsumer.java
@@ -4,6 +4,7 @@ import com.palja.timedeal_service.application.command.ChangeTimeDealStatusFailed
 import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
 import com.palja.timedeal_service.application.command.RestoreRemainingQuantityCommand;
 import com.palja.timedeal_service.application.command.UpdateProductPriceCommand;
+import com.palja.timedeal_service.application.facade.TimeDealLockFacade;
 import com.palja.timedeal_service.application.event.dto.TimeDealEvent;
 import com.palja.timedeal_service.application.event.dto.request.in.*;
 import com.palja.timedeal_service.application.event.dto.response.TimeDealStockDecreaseEventRes;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 public class TimeDealKafkaConsumer {
 
     private final TimeDealService timeDealService;
+    private final TimeDealLockFacade timeDealLock;
     private final KafkaTemplate<String, TimeDealEvent> kafkaTemplate;
 
     @KafkaListener(topics = KafkaTopics.ORDER_STOCK_DECREASE_REQUEST)
@@ -39,7 +41,8 @@ public class TimeDealKafkaConsumer {
                     .decreaseQuantity(event.getQuantity())
                     .build();
 
-            timeDealService.decreaseRemainingQuantity(command);
+//            timeDealService.decreaseRemainingQuantity(command);
+            timeDealLock.decreaseRemainingQuantityWithLock(command);
 
             TimeDealStockDecreaseEventRes res = TimeDealStockDecreaseEventRes.success(event.getSagaId(), event.getOrderId());
             kafkaTemplate.send(KafkaTopics.ORDER_STOCK_DECREASE_SUCCESS, res);

--- a/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/lock/RedissonLockExecutor.java
+++ b/timedeal-service/src/main/java/com/palja/timedeal_service/infrastructure/lock/RedissonLockExecutor.java
@@ -1,0 +1,47 @@
+package com.palja.timedeal_service.infrastructure.lock;
+
+import com.palja.common.exception.BusinessException;
+import com.palja.timedeal_service.application.port.LockExecutor;
+import com.palja.timedeal_service.common.TimeDealErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedissonLockExecutor implements LockExecutor {
+
+    private final RedissonClient redissonClient;
+
+    @Override
+    public void execute(String key, long waitTime, TimeUnit timeUnit, Runnable task) {
+        RLock lock = redissonClient.getLock(key);
+
+        boolean locked = false;
+
+        try {
+            locked = lock.tryLock(waitTime, timeUnit);
+
+            if (!locked) {
+                log.error("분산락 획득 실패. key={}", key);
+                throw new BusinessException(TimeDealErrorCode.LOCK_ACQUIRE_FAILED);
+            }
+
+            task.run();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("분산락 대기 중 인터럽트 발생. key={}", key, e);
+            throw new BusinessException(TimeDealErrorCode.LOCK_INTERRUPTED);
+        } finally {
+            if (locked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.info("분산락 해제 완료. key={}", key);
+            }
+        }
+    }
+}

--- a/timedeal-service/src/main/resources/application-kafka.yml
+++ b/timedeal-service/src/main/resources/application-kafka.yml
@@ -1,0 +1,5 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: timedeal-service

--- a/timedeal-service/src/main/resources/application-redis.yml
+++ b/timedeal-service/src/main/resources/application-redis.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: "localhost"
+      port: 6379

--- a/timedeal-service/src/main/resources/application.yml
+++ b/timedeal-service/src/main/resources/application.yml
@@ -5,11 +5,6 @@ spring:
   application:
     name: timedeal-service
 
-  kafka:
-    bootstrap-servers: localhost:9092
-    consumer:
-      group-id: timedeal-service
-
   profiles:
     include:
       - datasource
@@ -17,3 +12,5 @@ spring:
       - eureka
       - swagger
       - monitor
+      - kafka
+      - redis

--- a/timedeal-service/src/main/resources/logback-spring.xml
+++ b/timedeal-service/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
     <springProperty name="SERVICE_NAME" source="spring.application.name"/>
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
 
-    <springProfile name="local">
+    <springProfile name="local | test">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
                 <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){magenta} %clr(%-4level) [${SERVICE_NAME}] [%thread] [%X{traceId}] %clr(%logger){cyan} %msg%n</pattern>

--- a/timedeal-service/src/test/java/com/palja/timedeal_service/application/service/TImeDealServiceTest.java
+++ b/timedeal-service/src/test/java/com/palja/timedeal_service/application/service/TImeDealServiceTest.java
@@ -1,0 +1,8 @@
+package com.palja.timedeal_service.application.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TImeDealServiceTest {
+}

--- a/timedeal-service/src/test/java/com/palja/timedeal_service/integration/concurrency/TimeDealStockDecreaseTest.java
+++ b/timedeal-service/src/test/java/com/palja/timedeal_service/integration/concurrency/TimeDealStockDecreaseTest.java
@@ -1,0 +1,126 @@
+package com.palja.timedeal_service.integration.concurrency;
+
+import com.palja.common.auditor.AuditorContext;
+import com.palja.common.vo.UserRole;
+import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
+import com.palja.timedeal_service.application.service.TimeDealService;
+import com.palja.timedeal_service.domain.entity.TimeDeal;
+import com.palja.timedeal_service.domain.repository.TimeDealRepository;
+import com.palja.timedeal_service.domain.vo.Amount;
+import com.palja.timedeal_service.domain.vo.Period;
+import com.palja.timedeal_service.domain.vo.Quantity;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class TimeDealStockDecreaseTest {
+
+    private static final String TEST_LOGIN_ID = "test-user";
+    private static final int THREAD_COUNT = 100;
+    private static final long INITIAL_QUANTITY = 100L;
+    private static final long DECREASE_QUANTITY = 1L;
+
+    @Autowired
+    private TimeDealService timeDealService;
+
+    @Autowired
+    private TimeDealRepository timeDealRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private TimeDeal timeDeal;
+
+    @BeforeEach
+    void setUp() {
+        AuditorContext.set(TEST_LOGIN_ID, UserRole.MASTER);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        timeDeal = TimeDeal.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "동시성 테스트 타임딜",
+                "동시성 테스트",
+                Period.of(now.plusMinutes(10), now.plusDays(1)),
+                Amount.of(10000L, 5000L),
+                Quantity.of(INITIAL_QUANTITY)
+        );
+
+        timeDeal.openNow("동시성 테스트 타임딜 오픈");
+        timeDealRepository.save(timeDeal);
+    }
+
+    @AfterEach
+    void tearDown() {
+        AuditorContext.clear();
+    }
+
+    /**
+     * Redisson 락 및 원자적 update 적용 전
+     * 동시성 상황에서 성공/실패 수와 잔여 재고를 관찰하기 위한 테스트
+     * 상황에 따라 flaky 할 수 있으므로 정합성 불일치를 강하게 assert 하지 않음
+     */
+    @Test
+    @DisplayName("타임딜 재고 차감 동시 요청 시 성공, 실패 수와 잔여 재고 테스트")
+    void concurrentTimeDealStockDecreaseTest() throws InterruptedException {
+        log.info("테스트 시작");
+
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < THREAD_COUNT ; i++) {
+            executorService.submit(() -> {
+                try {
+                    AuditorContext.set("test-user", UserRole.MASTER);
+
+                    timeDealService.decreaseRemainingQuantity(
+                            new DecreaseRemainingQuantityCommand(timeDeal.getTimeDealId(), DECREASE_QUANTITY)
+                    );
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    log.error("타임딜 재고 차감 실패 - message={}", e.getMessage(), e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        entityManager.clear();
+
+        TimeDeal persistedTimeDeal = timeDealRepository.findByTimeDealId(timeDeal.getTimeDealId())
+                .orElseThrow(() -> new IllegalArgumentException("타임딜 조회 실패"));
+
+        log.info("조회 완료");
+        log.info("성공 요청 수 = {}", successCount.get());
+        log.info("실패 요청 수 = {}", failCount.get());
+        log.info("잔여 타임딜 수량 = {}", persistedTimeDeal.getRemainingQuantity());
+
+        assertThat(successCount.get() + failCount.get()).isEqualTo(THREAD_COUNT);
+
+        executorService.shutdown();
+    }
+}

--- a/timedeal-service/src/test/java/com/palja/timedeal_service/integration/concurrency/TimeDealStockDecreaseWithLockTest.java
+++ b/timedeal-service/src/test/java/com/palja/timedeal_service/integration/concurrency/TimeDealStockDecreaseWithLockTest.java
@@ -3,6 +3,7 @@ package com.palja.timedeal_service.integration.concurrency;
 import com.palja.common.auditor.AuditorContext;
 import com.palja.common.vo.UserRole;
 import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
+import com.palja.timedeal_service.application.facade.TimeDealLockFacade;
 import com.palja.timedeal_service.application.service.TimeDealService;
 import com.palja.timedeal_service.domain.entity.TimeDeal;
 import com.palja.timedeal_service.domain.repository.TimeDealRepository;
@@ -30,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
-class TimeDealStockDecreaseTest {
+class TimeDealStockDecreaseWithLockTest {
 
     private static final String TEST_LOGIN_ID = "test-user";
     private static final int THREAD_COUNT = 100;
@@ -38,7 +39,7 @@ class TimeDealStockDecreaseTest {
     private static final long DECREASE_QUANTITY = 1L;
 
     @Autowired
-    private TimeDealService timeDealService;
+    private TimeDealLockFacade timeDealLock;
 
     @Autowired
     private TimeDealRepository timeDealRepository;
@@ -74,12 +75,12 @@ class TimeDealStockDecreaseTest {
     }
 
     /**
-     * Redisson 락 및 원자적 update 적용 전
+     * Redisson 락 적용 후
      * 동시성 상황에서 성공/실패 수와 잔여 재고를 관찰하기 위한 테스트
      * 상황에 따라 flaky 할 수 있으므로 정합성 불일치를 강하게 assert 하지 않음
      */
     @Test
-    @DisplayName("타임딜 재고 차감 동시 요청 시 성공, 실패 수와 잔여 재고 테스트")
+    @DisplayName("락 전용 후 타임딜 재고 차감 동시 요청 시 성공, 실패 수와 잔여 재고 테스트")
     void concurrentTimeDealStockDecreaseTest() throws InterruptedException {
         log.info("테스트 시작");
 
@@ -94,9 +95,13 @@ class TimeDealStockDecreaseTest {
                 try {
                     AuditorContext.set("test-user", UserRole.MASTER);
 
-                    timeDealService.decreaseRemainingQuantity(
-                            new DecreaseRemainingQuantityCommand(timeDeal.getTimeDealId(), DECREASE_QUANTITY)
-                    );
+                    DecreaseRemainingQuantityCommand command = DecreaseRemainingQuantityCommand.builder()
+                            .timeDealId(timeDeal.getTimeDealId())
+                            .decreaseQuantity(DECREASE_QUANTITY)
+                            .build();
+
+                    timeDealLock.decreaseRemainingQuantityWithLock(command);
+
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();

--- a/timedeal-service/src/test/java/com/palja/timedeal_service/integration/concurrency/TimeDealStockDecreaseWithoutLockTest.java
+++ b/timedeal-service/src/test/java/com/palja/timedeal_service/integration/concurrency/TimeDealStockDecreaseWithoutLockTest.java
@@ -1,0 +1,131 @@
+package com.palja.timedeal_service.integration.concurrency;
+
+import com.palja.common.auditor.AuditorContext;
+import com.palja.common.vo.UserRole;
+import com.palja.timedeal_service.application.command.DecreaseRemainingQuantityCommand;
+import com.palja.timedeal_service.application.facade.TimeDealLockFacade;
+import com.palja.timedeal_service.application.service.TimeDealService;
+import com.palja.timedeal_service.domain.entity.TimeDeal;
+import com.palja.timedeal_service.domain.repository.TimeDealRepository;
+import com.palja.timedeal_service.domain.vo.Amount;
+import com.palja.timedeal_service.domain.vo.Period;
+import com.palja.timedeal_service.domain.vo.Quantity;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class TimeDealStockDecreaseWithoutLockTest {
+
+    private static final String TEST_LOGIN_ID = "test-user";
+    private static final int THREAD_COUNT = 100;
+    private static final long INITIAL_QUANTITY = 100L;
+    private static final long DECREASE_QUANTITY = 1L;
+
+    @Autowired
+    private TimeDealService timeDealService;
+
+    @Autowired
+    private TimeDealRepository timeDealRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private TimeDeal timeDeal;
+
+    @BeforeEach
+    void setUp() {
+        AuditorContext.set(TEST_LOGIN_ID, UserRole.MASTER);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        timeDeal = TimeDeal.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "동시성 테스트 타임딜",
+                "동시성 테스트",
+                Period.of(now.plusMinutes(10), now.plusDays(1)),
+                Amount.of(10000L, 5000L),
+                Quantity.of(INITIAL_QUANTITY)
+        );
+
+        timeDeal.openNow("동시성 테스트 타임딜 오픈");
+        timeDealRepository.save(timeDeal);
+    }
+
+    @AfterEach
+    void tearDown() {
+        AuditorContext.clear();
+    }
+
+    /**
+     * Redisson 락 적용 전
+     * 동시성 상황에서 성공/실패 수와 잔여 재고를 관찰하기 위한 테스트
+     * 상황에 따라 flaky 할 수 있으므로 정합성 불일치를 강하게 assert 하지 않음
+     */
+    @Test
+    @DisplayName("락 전용 전 타임딜 재고 차감 동시 요청 시 성공, 실패 수와 잔여 재고 테스트")
+    void concurrentTimeDealStockDecreaseTest() throws InterruptedException {
+        log.info("테스트 시작");
+
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < THREAD_COUNT ; i++) {
+            executorService.submit(() -> {
+                try {
+                    AuditorContext.set("test-user", UserRole.MASTER);
+
+                    DecreaseRemainingQuantityCommand command = DecreaseRemainingQuantityCommand.builder()
+                            .timeDealId(timeDeal.getTimeDealId())
+                            .decreaseQuantity(DECREASE_QUANTITY)
+                            .build();
+
+                    timeDealService.decreaseRemainingQuantity(command);
+
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    log.error("타임딜 재고 차감 실패 - message={}", e.getMessage(), e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        entityManager.clear();
+
+        TimeDeal persistedTimeDeal = timeDealRepository.findByTimeDealId(timeDeal.getTimeDealId())
+                .orElseThrow(() -> new IllegalArgumentException("타임딜 조회 실패"));
+
+        log.info("조회 완료");
+        log.info("성공 요청 수 = {}", successCount.get());
+        log.info("실패 요청 수 = {}", failCount.get());
+        log.info("잔여 타임딜 수량 = {}", persistedTimeDeal.getRemainingQuantity());
+
+        assertThat(successCount.get() + failCount.get()).isEqualTo(THREAD_COUNT);
+
+        executorService.shutdown();
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #366 

<br>

## 📌 개요
- 타임딜 선착순 구매 시 동시 요청으로 인해 발생하는 재고 정합성 문제를 해결하기 위해 Redis 기반 Redisson 분산 락 도입

<br>

## 🔁 변경 사항

- Redisson 설정 추가 (RedissonClient 설정 파일 추가, 분산 락 사용을 위한 의존성 및 설정 구성)
- 동시성 테스트 코드 작성 (분산 락 도입/미도입)

<br>

## 📸 스크린샷

<details>
  <summary>동시성 테스트 결과</summary>

락 미적용 -> 재고 불일치 발생
<img width="1342" height="92" alt="image" src="https://github.com/user-attachments/assets/4a13087a-ed75-4e0b-8e64-ade0675eda13" />

락 적용 -> 정상 차감 및 정합성 유지
<img width="1335" height="102" alt="image" src="https://github.com/user-attachments/assets/faa097de-5e9a-4046-aa09-f617f03c3a2b" />

</details>

<br>

## 👀 기타 더 이야기해볼 점
- 테스트 결과 재고 정합성이 개선된 것을 확인했습니다!

<br>

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
